### PR TITLE
More warnings on inexhaustive patterns

### DIFF
--- a/hs/package.yaml
+++ b/hs/package.yaml
@@ -44,6 +44,10 @@ dependencies:
 ghc-options:
 - -Wall
 - -Werror
+- -Wcompat
+- -Wincomplete-record-updates
+- -Wincomplete-uni-patterns
+- -Wredundant-constraints
 - -O2
 - -fwrite-ide-info
 - -hiedir=.hie

--- a/hs/src/Reach/EmitGo.hs
+++ b/hs/src/Reach/EmitGo.hs
@@ -50,7 +50,7 @@ goVarType_short_strp v = goString $ goVarType_short_str v
 
 goVarType_longp :: BLVar -> Doc a
 goVarType_longp (_, (_, bt)) = goType bt
-  
+
 goVarAndType :: BLVar -> Doc a
 goVarAndType v = goVar v <+> goVarType_longp v
 
@@ -151,9 +151,9 @@ goEPExpr _ (EP_Interact _ m _ al) = (True, (ip, (Set.unions $ map snd alp)))
         ip = pretty "<-" <+> goApply ("interact." ++ m) (map fst alp)
 goEPExpr _ (EP_Digest _ al) = (False, ((goApply "stdlib.Keccak256" $ map fst alp), (Set.unions $ map snd alp)))
   where alp = map goArg al
-goEPExpr _ (EP_ArrayRef _ ae ee) = (False, ((ae' <> pretty "[" <> ee' <> pretty "]"), (Set.unions $ map snd alp)))
-  where alp = map goArg [ae, ee]
-        [ae', ee'] = map fst alp
+goEPExpr _ (EP_ArrayRef _ ae ee) = (False, ((ae_doc <> pretty "[" <> ee_doc <> pretty "]"), (Set.unions [ae_set, ee_set])))
+  where (ae_doc, ae_set) = goArg ae
+        (ee_doc, ee_set) = goArg ee
 
 goAssert :: Doc a -> Doc a
 goAssert a = goApply "stdlib.Assert" [ a ] <> semi
@@ -168,7 +168,7 @@ goEPStmt (EP_Claim _ _ a) kp = (vsep [ goAssert ap, kp ], afvs)
   where (ap, afvs) = goArg a
 goEPStmt (EP_Transfer _ to a) kp = (vsep [ goTransfer to ap, kp ], fvs)
   where (ap, afvs) = goArg a
-        fvs = Set.insert to afvs 
+        fvs = Set.insert to afvs
 
 add_from :: Int -> FromSpec -> (Doc a, Set.Set BLVar) -> (Doc a, Set.Set BLVar)
 add_from tn (FS_Join p) (x, s) =

--- a/hs/src/Reach/EmitJS.hs
+++ b/hs/src/Reach/EmitJS.hs
@@ -118,9 +118,9 @@ jsEPExpr _ (EP_Interact _ m bt al) = (True, (ip, (Set.unions $ map snd alp)))
         ip = jsApply "stdlib.isType" [(jsString (solType bt)), pretty "await" <+> jsApply ("interact." ++ m) (map fst alp)]
 jsEPExpr _ (EP_Digest _ al) = (False, ((jsApply "stdlib.keccak256" $ map fst alp), (Set.unions $ map snd alp)))
   where alp = map jsArg al
-jsEPExpr _ (EP_ArrayRef _ ae ee) = (False, ((ae' <> pretty "[" <> ee' <> pretty "]"), (Set.unions $ map snd alp)))
-  where alp = map jsArg [ae, ee]
-        [ae', ee'] = map fst alp
+jsEPExpr _ (EP_ArrayRef _ ae ee) = (False, ((ae_doc <> pretty "[" <> ee_doc <> pretty "]"), (Set.unions [ae_set, ee_set])))
+  where (ae_doc, ae_set) = jsArg ae
+        (ee_doc, ee_set) = jsArg ee
 
 jsAssert :: Doc a -> Doc a
 jsAssert a = jsApply "stdlib.assert" [ a ] <> semi
@@ -140,7 +140,7 @@ jsEPStmt stop_at_consensus s kp =
         (vsep [ jsTransfer to ap, kp ], fvs)
       else (kp, mempty)
       where (ap, afvs) = jsArg a
-            fvs = Set.insert to afvs 
+            fvs = Set.insert to afvs
 
 add_from :: Int -> FromSpec -> (Doc a, Set.Set BLVar) -> (Doc a, Set.Set BLVar)
 add_from tn (FS_Join p) (x, s) =

--- a/hs/src/Reach/ParserInternal.hs
+++ b/hs/src/Reach/ParserInternal.hs
@@ -80,7 +80,7 @@ instance ExtractTP JSBinOp where
     etp (JSBinOpStrictNeq a) = etp a
     etp (JSBinOpTimes a) = etp a
     etp (JSBinOpUrsh a) = etp a
-  
+
 instance ExtractTP JSIdent where
   etp (JSIdentName a _) = etp a
   etp JSIdentNone = Nothing
@@ -98,12 +98,12 @@ instance ExtractTP JSPropertyName where
 instance ExtractTP JSAccessor where
   etp (JSAccessorGet a) = etp a
   etp (JSAccessorSet a) = etp a
-  
+
 instance ExtractTP JSObjectProperty where
   etp (JSPropertyNameandValue a _ _) = etp a
   etp (JSPropertyIdentRef a _) = etp a
   etp (JSPropertyAccessor a _ _ _ _ _) = etp a
-  
+
 instance ExtractTP JSExpression where
   etp (JSIdentifier a _) = etp a
   etp (JSDecimal a _) = etp a
@@ -543,14 +543,15 @@ decodeStmts dss js =
                 conk = decodeStmts (sub_dss dss) ek
                 mto = case metargs of
                         Nothing -> Nothing
-                        Just etargs -> Just (de, te)
-                          where [ ede, ete ] = flattenJSCL etargs
-                                de = decodeExpr (sub_dss dss) ede
-                                te = XL_FunApp h (decodeExpr (sub_dss dss) ete) []
+                        Just etargs -> case flattenJSCL etargs of
+                          [ ede, ete ] -> Just (de, te) where
+                            de = decodeExpr (sub_dss dss) ede
+                            te = XL_FunApp h (decodeExpr (sub_dss dss) ete) []
+                          _ -> error "Pattern match fail" -- XXX Nothing?
 
 decodeBlock :: FilePath -> JSBlock -> XLExpr TP
 decodeBlock fp (JSBlock _ ss _) = decodeStmts (make_dss fp) ss
-             
+
 decodeDef :: FilePath -> JSStatement -> [XLDef TP]
 decodeDef fp j =
   case j of


### PR DESCRIPTION
Code is untested. I did the dumb thing and inserted a bunch of `error` with `-- XXX`, so now the code is more explicit about when it can fail, at least. Future work is to use actual error monads or something of the sort.

I do want to highlight `CompiledSolRec` as these change highlight typical JSON parsing in Haskell.

I went with non-invasive changes for now, but future work also likely includes things like preferring Text over String, records over tuples, etc.