### PR TITLE
Update readme on installing solc 0.5.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ If you want to work on the Reach compiler, you'll need:
 Installation on macOS:
 ```
 $ brew tap ethereum/ethereum
-$ brew install haskell-stack z3 solidity
+$ brew install haskell-stack z3
+$ brew install https://raw.githubusercontent.com/ethereum/homebrew-ethereum/7fa7027f20cca27f76c679d0c5b35ee3c565f284/solidity.rb
 ```
 
 Installation on Ubuntu:


### PR DESCRIPTION
Worked for me.

```
$ solc --version
solc, the solidity compiler commandline interface
Version: 0.5.11+commit.22be8592.Darwin.appleclang
```

See: https://github.com/ethereum/homebrew-ethereum/commit/7fa7027f20cca27f76c679d0c5b35ee3c565f284