### PR TITLE
hs code formatted w/ ormolu

### DIFF
--- a/hs/Makefile
+++ b/hs/Makefile
@@ -63,6 +63,11 @@ hs-deps:
 hs-doc:
 	stack haddock
 
+.PHONY: hs-format
+hs-format:
+	stack build ormolu
+	stack exec -- ormolu --mode inplace $$(find . -name '*.hs')
+
 .PHONY: build-circle-docker
 build-circle-docker:
 	docker build -f Dockerfile_circleci --tag $(CIRCLE_TAG) .

--- a/hs/Setup.hs
+++ b/hs/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/hs/app/Main.hs
+++ b/hs/app/Main.hs
@@ -1,57 +1,59 @@
 module Main where
 
 import Data.Char
+import Options.Applicative
+import Reach.Compiler (Verifier (Z3))
+import Reach.CompilerTool
 import System.Directory
 import System.Environment
-import Options.Applicative
 import Text.Read (readMaybe)
 
-import Reach.Compiler (Verifier(Z3))
-import Reach.CompilerTool
-
 data CompilerToolArgs = CompilerToolArgs
-  { cta_outputDir :: FilePath
-  , cta_source :: FilePath
+  { cta_outputDir :: FilePath,
+    cta_source :: FilePath
   }
 
 data CompilerToolEnv = CompilerToolEnv
-  { cte_expCon :: Bool
-  , cte_expComp :: Bool
-  , cte_verifier :: Verifier
+  { cte_expCon :: Bool,
+    cte_expComp :: Bool,
+    cte_verifier :: Verifier
   }
 
 makeCompilerToolOpts :: CompilerToolArgs -> CompilerToolEnv -> CompilerToolOpts
-makeCompilerToolOpts CompilerToolArgs{..} CompilerToolEnv{..} = CompilerToolOpts
-  { cto_outputDir = cta_outputDir
-  , cto_source = cta_source
-  , cto_expCon = cte_expCon
-  , cto_expComp = cte_expComp
-  , cto_verifier = cte_verifier
-  }
+makeCompilerToolOpts CompilerToolArgs {..} CompilerToolEnv {..} =
+  CompilerToolOpts
+    { cto_outputDir = cta_outputDir,
+      cto_source = cta_source,
+      cto_expCon = cte_expCon,
+      cto_expComp = cte_expComp,
+      cto_verifier = cte_verifier
+    }
 
 compiler :: FilePath -> Parser CompilerToolArgs
-compiler cwd = CompilerToolArgs
-  <$> strOption
-  ( long "output"
-    <> short 'o'
-    <> metavar "DIR"
-    <> help "Directory for output files"
-    <> showDefault
-    <> value cwd )
-  <*> strArgument (metavar "SOURCE")
-
+compiler cwd =
+  CompilerToolArgs
+    <$> strOption
+      ( long "output"
+          <> short 'o'
+          <> metavar "DIR"
+          <> help "Directory for output files"
+          <> showDefault
+          <> value cwd
+      )
+    <*> strArgument (metavar "SOURCE")
 
 checkTruthyEnv :: String -> IO Bool
 checkTruthyEnv varName = do
   varValMay <- lookupEnv varName
   case varValMay of
-    Just varVal -> return $ not isFalsy where
-      isFalsy = isNo || isFalse || isEmpty || isZero
-      varValLower = map toLower varVal
-      isNo = varValLower == "no"
-      isFalse = varValLower == "false"
-      isEmpty = varValLower == ""
-      isZero = varValLower == "0"
+    Just varVal -> return $ not isFalsy
+      where
+        isFalsy = isNo || isFalse || isEmpty || isZero
+        varValLower = map toLower varVal
+        isNo = varValLower == "no"
+        isFalse = varValLower == "false"
+        isEmpty = varValLower == ""
+        isZero = varValLower == "0"
     Nothing -> return False
 
 readEnvOrDefault :: Read a => String -> a -> IO a
@@ -67,10 +69,13 @@ readEnvOrDefault varName defaultVal = do
 getCompilerArgs :: IO CompilerToolArgs
 getCompilerArgs = do
   cwd <- getCurrentDirectory
-  let opts = info ( compiler cwd <**> helper )
-               ( fullDesc
-               <> progDesc "verify and compile an Reach program"
-               <> header "reachc - Reach compiler" )
+  let opts =
+        info
+          (compiler cwd <**> helper)
+          ( fullDesc
+              <> progDesc "verify and compile an Reach program"
+              <> header "reachc - Reach compiler"
+          )
   execParser opts
 
 getCompilerEnv :: IO CompilerToolEnv
@@ -78,11 +83,12 @@ getCompilerEnv = do
   expCon <- checkTruthyEnv "REACHC_ENABLE_EXPERIMENTAL_CONNECTORS"
   expComp <- checkTruthyEnv "REACHC_ENABLE_EXPERIMENTAL_COMPILER"
   vf <- readEnvOrDefault "REACHC_VERIFIER" Z3
-  return CompilerToolEnv
-    { cte_expCon = expCon
-    , cte_expComp = expComp
-    , cte_verifier = vf
-    }
+  return
+    CompilerToolEnv
+      { cte_expCon = expCon,
+        cte_expComp = expComp,
+        cte_verifier = vf
+      }
 
 main :: IO ()
 main = do

--- a/hs/src/Reach/AST.hs
+++ b/hs/src/Reach/AST.hs
@@ -1,12 +1,12 @@
 module Reach.AST where
 
-import Data.Data
-import GHC.Generics
 import Control.DeepSeq
 import qualified Data.ByteString.Char8 as B
+import Data.Data
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
+import GHC.Generics
 
 -- Shared types
 
@@ -15,21 +15,22 @@ data BaseType
   | BT_Bool
   | BT_Bytes
   | BT_Address
-  deriving (Show,Eq,Ord,Generic,NFData,Data)
+  deriving (Show, Eq, Ord, Generic, NFData, Data)
 
 data LType
   = LT_BT BaseType
   | LT_FixedArray BaseType Integer
-  deriving (Show,Eq,Ord,Generic,NFData,Data)
+  deriving (Show, Eq, Ord, Generic, NFData, Data)
 
 data ExprType
   = TY_Var String
   | TY_Con LType
-  deriving (Show,Eq)
+  deriving (Show, Eq)
+
 data FunctionType
   = TY_Arrow [ExprType] ExprType
   | TY_Forall [String] FunctionType
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 tBool :: ExprType
 tBool = TY_Con $ LT_BT BT_Bool
@@ -41,6 +42,7 @@ tBytes :: ExprType
 tBytes = TY_Con $ LT_BT BT_Bytes
 
 infix 9 -->
+
 (-->) :: [ExprType] -> ExprType -> FunctionType
 ins --> out = TY_Arrow ins out
 
@@ -48,7 +50,7 @@ data Constant
   = Con_I Integer
   | Con_B Bool
   | Con_BS B.ByteString
-  deriving (Show,Eq,Ord,Generic,NFData,Data)
+  deriving (Show, Eq, Ord, Generic, NFData, Data)
 
 conType :: Constant -> BaseType
 conType (Con_I _) = BT_UInt256
@@ -78,12 +80,12 @@ data C_Prim
   | BAND
   | BIOR
   | BXOR
-  deriving (Show,Eq,Ord,Generic,NFData,Data)
+  deriving (Show, Eq, Ord, Generic, NFData, Data)
 
 data EP_Prim
   = CP C_Prim
   | RANDOM
-  deriving (Show,Eq,Ord,Generic,NFData,Data)
+  deriving (Show, Eq, Ord, Generic, NFData, Data)
 
 primType :: EP_Prim -> FunctionType
 primType (CP ADD) = [tUInt256, tUInt256] --> tUInt256
@@ -108,21 +110,21 @@ primType (CP BXOR) = [tUInt256, tUInt256] --> tUInt256
 primType RANDOM = ([] --> tUInt256)
 
 data ClaimType
-  = CT_Assert   --- Verified on all paths
-  | CT_Assume   --- Always assumed true
-  | CT_Require  --- Verified in honest, assumed in dishonest. (This may
-                --- sound backwards, but by verifying it in honest
-                --- mode, then we are checking that the other
-                --- participants fulfill the promise when acting
-                --- honestly.)
+  = CT_Assert --- Verified on all paths
+  | CT_Assume --- Always assumed true
+  | CT_Require --- Verified in honest, assumed in dishonest. (This may
+  --- sound backwards, but by verifying it in honest
+  --- mode, then we are checking that the other
+  --- participants fulfill the promise when acting
+  --- honestly.)
   | CT_Possible --- Check if an assignment of variables exists to make
-                --- this true.
-  deriving (Show,Eq,Ord,Generic,NFData,Data)
+  --- this true.
+  deriving (Show, Eq, Ord, Generic, NFData, Data)
 
 data Role a
   = RolePart a
   | RoleContract
-  deriving (Show,Eq,Ord,Generic,NFData,Data)
+  deriving (Show, Eq, Ord, Generic, NFData, Data)
 
 role_me :: Eq a => Role a -> Role a -> Bool
 role_me _ RoleContract = True
@@ -132,7 +134,7 @@ role_me (RolePart x) (RolePart y) = x == y
 data Effect
   = Eff_Comm
   | Eff_Claim
-  deriving (Show,Eq,Ord,Generic,NFData,Data)
+  deriving (Show, Eq, Ord, Generic, NFData, Data)
 
 type Effects = S.Set Effect
 
@@ -143,7 +145,7 @@ type XLVar = String
 data XLType a
   = XLT_BT a BaseType
   | XLT_Array a (XLType a) (XLExpr a)
-  deriving (Show,Eq,Generic,NFData,Data)
+  deriving (Show, Eq, Generic, NFData, Data)
 
 data XLExpr a
   = XL_Con a Constant
@@ -164,18 +166,18 @@ data XLExpr a
   | XL_Lambda a [XLVar] (XLExpr a)
   | XL_Digest a [XLExpr a]
   | XL_ArrayRef a (XLExpr a) (XLExpr a)
-  deriving (Show,Eq,Generic,NFData,Data)
+  deriving (Show, Eq, Generic, NFData, Data)
 
 data XLDef a
   = XL_DefineValues a [XLVar] (XLExpr a)
   | XL_DefineFun a XLVar [XLVar] (XLExpr a)
-  deriving (Show,Eq,Generic,NFData)
+  deriving (Show, Eq, Generic, NFData)
 
 type XLPartInfo a = (M.Map XLVar a)
 
-data XLProgram  a=
-  XL_Prog a [XLDef a] (XLPartInfo a) (XLExpr a)
-  deriving (Show,Eq,Generic,NFData)
+data XLProgram a
+  = XL_Prog a [XLDef a] (XLPartInfo a) (XLExpr a)
+  deriving (Show, Eq, Generic, NFData)
 
 --- Inlined Language (the language after expansion)
 
@@ -198,13 +200,13 @@ data XILExpr a
   | XIL_Interact a String LType [XILExpr a]
   | XIL_Digest a [XILExpr a]
   | XIL_ArrayRef a LType (XILExpr a) (XILExpr a)
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 type XILPartInfo a = (M.Map XILVar a)
 
-data XILProgram a =
-  XIL_Prog a [LType] (XILPartInfo a) (XILExpr a)
-  deriving (Show,Eq)
+data XILProgram a
+  = XIL_Prog a [LType] (XILPartInfo a) (XILExpr a)
+  deriving (Show, Eq)
 
 {- Intermediate Language
 
@@ -230,7 +232,7 @@ type ILVar = (Int, XILVar)
 data ILArg a
   = IL_Con a Constant
   | IL_Var a ILVar
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 ilarg_type :: ILArg a -> LType
 ilarg_type (IL_Con _ c) = LT_BT $ conType c
@@ -242,12 +244,12 @@ data ILExpr a
   | IL_Interact a String LType [ILArg a]
   | IL_Digest a [ILArg a]
   | IL_ArrayRef a (ILArg a) (ILArg a)
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 data ILStmt a
   = IL_Transfer a ILVar (ILArg a)
   | IL_Claim a ClaimType (ILArg a)
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 data ILTail a
   = IL_Ret a [ILArg a]
@@ -258,14 +260,15 @@ data ILTail a
   | IL_FromConsensus a (ILTail a)
   | IL_While a [ILVar] [ILArg a] (ILTail a) (ILTail a) (ILTail a) (ILTail a)
   | IL_Continue a [ILArg a]
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 type ILPartArgs a = [ILVar]
+
 type ILPartInfo a = (S.Set ILVar)
 
-data ILProgram a =
-  IL_Prog a [LType] (ILPartInfo a) (ILTail a)
-  deriving (Show,Eq)
+data ILProgram a
+  = IL_Prog a [LType] (ILPartInfo a) (ILTail a)
+  deriving (Show, Eq)
 
 {- Backend Language
 
@@ -295,12 +298,12 @@ blvar_name (_, (n, _)) = n
 data FromSpec
   = FS_From BLVar
   | FS_Join BLVar
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 data BLArg a
   = BL_Con a Constant
   | BL_Var a BLVar
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 blarg_type :: BLArg a -> LType
 blarg_type (BL_Con _ c) = LT_BT $ conType c
@@ -313,12 +316,12 @@ data EPExpr a
   | EP_Interact a String LType [BLArg a]
   | EP_Digest a [BLArg a]
   | EP_ArrayRef a (BLArg a) (BLArg a)
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 data EPStmt a
   = EP_Claim a ClaimType (BLArg a)
   | EP_Transfer a BLVar (BLArg a)
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 data EPTail a
   = EP_Ret a [BLArg a]
@@ -329,11 +332,11 @@ data EPTail a
   | EP_FromConsensus a (EPTail a)
   | EP_Loop a Int [BLVar] [BLArg a] (EPTail a)
   | EP_Continue a Int [BLVar] [(BLArg a)]
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 data EProgram a
   = EP_Prog a (EPTail a)
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 --- --- Gather interactions
 
@@ -343,14 +346,15 @@ epe_interacts e =
     EP_Arg _ _ -> mempty
     EP_PrimApp _ _ _ -> mempty
     EP_Interact _ n rt args -> M.singleton n (arg_tys, rt)
-      where arg_tys = map blarg_type args
+      where
+        arg_tys = map blarg_type args
     EP_Digest _ _ -> mempty
     EP_ArrayRef _ _ _ -> mempty
 
 emto_interacts :: (Maybe (BLArg a, EPTail a)) -> M.Map String ([LType], LType)
 emto_interacts Nothing = mempty
 emto_interacts (Just (_, tt)) = ept_interacts tt
-  
+
 ept_interacts :: EPTail a -> M.Map String ([LType], LType)
 ept_interacts t =
   case t of
@@ -372,12 +376,12 @@ data CExpr a
   = C_PrimApp a C_Prim [BLArg a]
   | C_Digest a [BLArg a]
   | C_ArrayRef a (BLArg a) (BLArg a)
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 data CStmt a
   = C_Claim a ClaimType (BLArg a)
   | C_Transfer a BLVar (BLArg a)
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 data CTail a
   = C_Halt a
@@ -386,48 +390,48 @@ data CTail a
   | C_Let a BLVar (CExpr a) (CTail a)
   | C_Do a (CStmt a) (CTail a)
   | C_Jump a Int [BLVar] [BLVar] [BLArg a]
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 data CInterval a
   = C_Between [BLArg a] [BLArg a]
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 default_interval :: CInterval a
 default_interval = C_Between [] []
 
 interval_add_from :: (CInterval a) -> (BLArg a) -> (CInterval a)
 interval_add_from (C_Between froml tol) x =
-  C_Between (x:froml) tol
+  C_Between (x : froml) tol
 
 interval_add_to :: (CInterval a) -> (BLArg a) -> (CInterval a)
 interval_add_to (C_Between froml tol) x =
-  C_Between froml (x:tol)
+  C_Between froml (x : tol)
 
 data CHandler a
-  --- Each handler has a message that it expects to receive
-  = C_Handler a FromSpec (CInterval a) (Int, [BLVar]) [BLVar] (CTail a) Int
+  = --- Each handler has a message that it expects to receive
+    C_Handler a FromSpec (CInterval a) (Int, [BLVar]) [BLVar] (CTail a) Int
   | C_Loop a [BLVar] [BLVar] (CTail a) (CTail a) Int
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 --- A contract program is just a sequence of handlers.
 data CProgram a
   = C_Prog a [CHandler a]
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 -- -- Backend
 type BLParts a = M.Map BLVar (EProgram a)
 
 data BLProgram a
   = BL_Prog a [LType] (BLParts a) (CProgram a)
-  deriving (Show,Eq)
-
+  deriving (Show, Eq)
 -- ^ Compilation targets for consensus network
+
 data ConsensusNetwork = ETH | ETH_EVM | ALGO
   deriving (Show, Eq, Ord)
-
 -- ^ Compilation targets for backend
+
 data Backend = JS | GO
   deriving (Show, Eq, Ord)
-
 -- ^ Consensus Network Program Text map. ConsensusNetwork => FieldName => FieldValue
+
 type CNP_TMap = M.Map T.Text (M.Map T.Text T.Text)

--- a/hs/src/Reach/Backend/Go.hs
+++ b/hs/src/Reach/Backend/Go.hs
@@ -1,21 +1,20 @@
 {-# LANGUAGE NoOverloadedStrings #-}
+
 module Reach.Backend.Go where
 
 import qualified Data.ByteString.Char8 as B
+import Data.List (inits, intersperse)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as Set
 import qualified Data.Text as T
-import Data.List (intersperse, inits)
 import Data.Text.Prettyprint.Doc
-import Paths_reach (version)
 import Data.Version (showVersion)
-
+import Paths_reach (version)
 import Reach.AST
 import Reach.Connector.ETH_Solidity
-  ( solMsg_evt
-  , solMsg_fun
+  ( solMsg_evt,
+    solMsg_fun,
   )
-
 import Reach.Util
 
 goBType :: BaseType -> String
@@ -98,7 +97,8 @@ goReturn a = pretty "return" <+> a <> semi
 
 goObject :: [(String, Doc a)] -> Doc a
 goObject kvs = goBraces $ vsep $ (intersperse comma) $ map goObjField kvs
-  where goObjField (k, v) = pretty (k ++ ":") <> hardline <> v
+  where
+    goObjField (k, v) = pretty (k ++ ":") <> hardline <> v
 
 goBinOp :: String -> Doc a -> Doc a -> Doc a
 goBinOp o l r = l <+> pretty o <+> r
@@ -114,13 +114,17 @@ goTimeoutFlag n = goTxn n <> pretty ".DidTimeout"
 
 goMsgEncode :: [BLVar] -> Doc a
 goMsgEncode [] = pretty "stdlib.Msg0"
-goMsgEncode (v:vs) = goApply ("stdlib.MsgEncode_" ++ goVarType_short_str v)
-                     [ goMsgEncode vs
-                     , goVar v ]
+goMsgEncode (v : vs) =
+  goApply
+    ("stdlib.MsgEncode_" ++ goVarType_short_str v)
+    [ goMsgEncode vs,
+      goVar v
+    ]
 
 goMsgDecodePaths :: [BLVar] -> [Doc a]
 goMsgDecodePaths vs = map h $ inits vs
-  where h prevs = pretty "[]string{" <> hcat (intersperse (comma <> space) (map goVarType_short_strp prevs)) <> pretty "}"
+  where
+    h prevs = pretty "[]string{" <> hcat (intersperse (comma <> space) (map goVarType_short_strp prevs)) <> pretty "}"
 
 goPrimApply :: Int -> EP_Prim -> [BLArg b] -> [Doc a] -> Doc a
 goPrimApply tn pr al =
@@ -141,9 +145,9 @@ goPrimApply tn pr al =
     CP BIOR -> goApply "stdlib.Bior"
     CP BXOR -> goApply "stdlib.Bxor"
     CP IF_THEN_ELSE -> case al of
-                         [ _, t, _ ] ->
-                           goApply ("stdlib.Ite_" ++ goType' (blarg_type t))
-                         _ -> impossible "ite not called with three args"
+      [_, t, _] ->
+        goApply ("stdlib.Ite_" ++ goType' (blarg_type t))
+      _ -> impossible "ite not called with three args"
     CP BYTES_EQ -> goApply "stdlib.Bytes_eq"
     CP BALANCE -> \_ -> goTxn tn <> pretty ".Balance"
     CP TXN_VALUE -> \_ -> goTxn tn <> pretty ".Value"
@@ -152,149 +156,186 @@ goPrimApply tn pr al =
 goEPExpr :: Int -> EPExpr b -> (Bool, (Doc a, Set.Set BLVar))
 goEPExpr _tn (EP_Arg _ a) = (False, goArg a)
 goEPExpr tn (EP_PrimApp _ pr al) = (False, ((goPrimApply tn pr al $ map fst alp), (Set.unions $ map snd alp)))
-  where alp = map goArg al
+  where
+    alp = map goArg al
 goEPExpr _ (EP_Interact _ m _ al) = (True, (ip, (Set.unions $ map snd alp)))
-  where alp = map goArg al
-        ip = pretty "<-" <+> goApply ("interact." ++ m) (map fst alp)
+  where
+    alp = map goArg al
+    ip = pretty "<-" <+> goApply ("interact." ++ m) (map fst alp)
 goEPExpr _ (EP_Digest _ al) = (False, ((goApply "stdlib.Keccak256" $ map fst alp), (Set.unions $ map snd alp)))
-  where alp = map goArg al
+  where
+    alp = map goArg al
 goEPExpr _ (EP_ArrayRef _ ae ee) = (False, ((ae_doc <> pretty "[" <> ee_doc <> pretty "]"), (Set.unions [ae_set, ee_set])))
-  where (ae_doc, ae_set) = goArg ae
-        (ee_doc, ee_set) = goArg ee
+  where
+    (ae_doc, ae_set) = goArg ae
+    (ee_doc, ee_set) = goArg ee
 
 goAssert :: Doc a -> Doc a
-goAssert a = goApply "stdlib.Assert" [ a ] <> semi
+goAssert a = goApply "stdlib.Assert" [a] <> semi
 
 goTransfer :: BLVar -> Doc a -> Doc a
-goTransfer to a = pretty "// XXX " <> goApply "txn.transfer" [ goVar to, a ] <> semi
+goTransfer to a = pretty "// XXX " <> goApply "txn.transfer" [goVar to, a] <> semi
 
 goEPStmt :: EPStmt b -> Doc a -> (Doc a, Set.Set BLVar)
 goEPStmt (EP_Claim _ CT_Possible _) kp = (kp, Set.empty)
 goEPStmt (EP_Claim _ CT_Assert _) kp = (kp, Set.empty)
-goEPStmt (EP_Claim _ _ a) kp = (vsep [ goAssert ap, kp ], afvs)
-  where (ap, afvs) = goArg a
-goEPStmt (EP_Transfer _ to a) kp = (vsep [ goTransfer to ap, kp ], fvs)
-  where (ap, afvs) = goArg a
-        fvs = Set.insert to afvs
+goEPStmt (EP_Claim _ _ a) kp = (vsep [goAssert ap, kp], afvs)
+  where
+    (ap, afvs) = goArg a
+goEPStmt (EP_Transfer _ to a) kp = (vsep [goTransfer to ap, kp], fvs)
+  where
+    (ap, afvs) = goArg a
+    fvs = Set.insert to afvs
 
 add_from :: Int -> FromSpec -> (Doc a, Set.Set BLVar) -> (Doc a, Set.Set BLVar)
 add_from tn (FS_Join p) (x, s) =
-  (vsep [ pretty "var" <+> goVar p <+> pretty "=" <+> goTxn tn <> pretty ".From" <> semi
-        , x ]
-  , s)
+  ( vsep
+      [ pretty "var" <+> goVar p <+> pretty "=" <+> goTxn tn <> pretty ".From" <> semi,
+        x
+      ],
+    s
+  )
 add_from _ (FS_From p) (x, s) = (x, Set.insert p s)
 
 goEPTail :: Int -> BLVar -> EPTail b -> (Doc a, Set.Set BLVar)
 goEPTail _tn _who (EP_Ret _ al) = ((goReturn $ goStructMake "Ret" $ map fst alp), Set.unions $ map snd alp)
-  where alp = map goArg al
+  where
+    alp = map goArg al
 goEPTail tn who (EP_If _ ca tt ft) = (tp, tfvs)
-  where (ttp', ttfvs) = goEPTail tn who tt
-        (ftp', ftfvs) = goEPTail tn who ft
-        (cap, cafvs) = goArg ca
-        tp = goIf cap ttp' ftp'
-        tfvs = Set.unions [ cafvs, ttfvs, ftfvs ]
+  where
+    (ttp', ttfvs) = goEPTail tn who tt
+    (ftp', ftfvs) = goEPTail tn who ft
+    (cap, cafvs) = goArg ca
+    tp = goIf cap ttp' ftp'
+    tfvs = Set.unions [cafvs, ttfvs, ftfvs]
 goEPTail tn who (EP_Let _ bv ee kt) = (tp, tfvs)
-  where used = elem bv ktfvs
-        tp = if keep then
-               vsep [ bvdeclp, ktp ]
-             else
-               ktp
-        keep = used || forcep
-        tfvs' = Set.difference ktfvs (Set.singleton bv)
-        tfvs = if keep then Set.union eefvs tfvs' else tfvs'
-        bvdeclp = goVarDecl bv <+> pretty "=" <+> eep <> semi
-        (forcep, (eep, eefvs)) = goEPExpr tn ee
-        (ktp, ktfvs) = goEPTail tn who kt
+  where
+    used = elem bv ktfvs
+    tp =
+      if keep
+        then vsep [bvdeclp, ktp]
+        else ktp
+    keep = used || forcep
+    tfvs' = Set.difference ktfvs (Set.singleton bv)
+    tfvs = if keep then Set.union eefvs tfvs' else tfvs'
+    bvdeclp = goVarDecl bv <+> pretty "=" <+> eep <> semi
+    (forcep, (eep, eefvs)) = goEPExpr tn ee
+    (ktp, ktfvs) = goEPTail tn who kt
 goEPTail tn who (EP_Do _ es kt) = (tp, tfvs)
-  where (tp, esfvs) = goEPStmt es ktp
-        tfvs = Set.union esfvs kfvs
-        (ktp, kfvs) = goEPTail tn who kt
+  where
+    (tp, esfvs) = goEPStmt es ktp
+    tfvs = Set.union esfvs kfvs
+    (ktp, kfvs) = goEPTail tn who kt
 goEPTail tn who (EP_SendRecv _ svs m_send_amt (fs_ok, i_ok, msg, k_ok) mto) = (tp, tfvs)
-  where tp = vsep [ dp, k_p ]
-        k_okp' = mk_k_okp' k_okp
-        (delayp, to_fvss, k_p) =
-          case mto of
-            Nothing -> (pretty "false", mempty, k_okp')
-            Just (delay, k_to) -> (t_delayp, Set.unions [ tofvs, delayfvs ], kp)
-              where (k_top, tofvs) = goEPTail tn' who k_to
-                    (t_delayp, delayfvs) = goArg delay
-                    kp = goIf (goTimeoutFlag tn') k_top k_okp'
-        tfvs = Set.unions [ Set.fromList svs, Set.fromList msg, k_fvs, extra_fvs ]
-        vs = goMsgEncode $ svs ++ msg
-        (k_okp, k_fvs) = add_from tn' fs_ok $ goEPTail tn' who k_ok
-        tn' = tn+1
-        (dp, extra_fvs, mk_k_okp') =
-          case m_send_amt of
-            Just amt -> (t_dp, t_extra_fvs, t_mk_k_okp')
-              where t_dp = pretty "var" <+> goTxn tn' <+> pretty "=" <+>
-                         pretty "<-" <+> (goApply "ctc.SendRecv"
-                                          [ goString $ gopart_name who
-                                          , goString (solMsg_fun i_ok), vs, amtp
-                                          , goString (solMsg_evt i_ok)
-                                          , delayp ]) <> semi
-                    t_mk_k_okp' x = x
-                    (amtp, amtfvs) = goArg amt
-                    t_extra_fvs = Set.unions [ to_fvss, amtfvs ]
-            Nothing -> (t_dp, t_extra_fvs, t_mk_k_okp')
-              where t_dp = pretty "var" <+> goTxn tn' <+> pretty "=" <+>
-                         pretty "<-" <+> (goApply "ctc.Recv"
-                                          [ goString $ gopart_name who
-                                          , goString (solMsg_evt i_ok)
-                                          , delayp ]) <> semi
-                    t_extra_fvs = mempty
-                    t_mk_k_okp' x = vsep $ msg_vsps ++ [ x ]
-                    msg_vsps = zipWith (\v vpre -> pretty "var" <+> (goVar v) <+> pretty "=" <+> goApply ("stdlib.MsgDecode_" ++ goVarType_short_str v) [ (goTxn tn') <> pretty ".Data", vpre ] <> semi) msg (goMsgDecodePaths msg)
+  where
+    tp = vsep [dp, k_p]
+    k_okp' = mk_k_okp' k_okp
+    (delayp, to_fvss, k_p) =
+      case mto of
+        Nothing -> (pretty "false", mempty, k_okp')
+        Just (delay, k_to) -> (t_delayp, Set.unions [tofvs, delayfvs], kp)
+          where
+            (k_top, tofvs) = goEPTail tn' who k_to
+            (t_delayp, delayfvs) = goArg delay
+            kp = goIf (goTimeoutFlag tn') k_top k_okp'
+    tfvs = Set.unions [Set.fromList svs, Set.fromList msg, k_fvs, extra_fvs]
+    vs = goMsgEncode $ svs ++ msg
+    (k_okp, k_fvs) = add_from tn' fs_ok $ goEPTail tn' who k_ok
+    tn' = tn + 1
+    (dp, extra_fvs, mk_k_okp') =
+      case m_send_amt of
+        Just amt -> (t_dp, t_extra_fvs, t_mk_k_okp')
+          where
+            t_dp =
+              pretty "var" <+> goTxn tn' <+> pretty "="
+                <+> pretty "<-"
+                <+> ( goApply
+                        "ctc.SendRecv"
+                        [ goString $ gopart_name who,
+                          goString (solMsg_fun i_ok),
+                          vs,
+                          amtp,
+                          goString (solMsg_evt i_ok),
+                          delayp
+                        ]
+                    )
+                  <> semi
+            t_mk_k_okp' x = x
+            (amtp, amtfvs) = goArg amt
+            t_extra_fvs = Set.unions [to_fvss, amtfvs]
+        Nothing -> (t_dp, t_extra_fvs, t_mk_k_okp')
+          where
+            t_dp =
+              pretty "var" <+> goTxn tn' <+> pretty "="
+                <+> pretty "<-"
+                <+> ( goApply
+                        "ctc.Recv"
+                        [ goString $ gopart_name who,
+                          goString (solMsg_evt i_ok),
+                          delayp
+                        ]
+                    )
+                  <> semi
+            t_extra_fvs = mempty
+            t_mk_k_okp' x = vsep $ msg_vsps ++ [x]
+            msg_vsps = zipWith (\v vpre -> pretty "var" <+> (goVar v) <+> pretty "=" <+> goApply ("stdlib.MsgDecode_" ++ goVarType_short_str v) [(goTxn tn') <> pretty ".Data", vpre] <> semi) msg (goMsgDecodePaths msg)
 goEPTail tn who (EP_Loop _ _which loopvs initas bt) = (tp, tfvs)
-  where tp = vsep $ defsp ++ [ loopp, pretty "panic(\"returned past for\")" ]
-        defp loopv initp = pretty "var" <+> (goVar loopv) <+> pretty "=" <+> initp <> semi
-        defsp = zipWith defp loopvs $ map fst initargs
-        loopp = goWhile (pretty "true") bodyp
-        (bodyp, bodyvs) = goEPTail tn who bt
-        initargs = map goArg initas
-        tfvs = Set.unions $ bodyvs : (map snd initargs)
+  where
+    tp = vsep $ defsp ++ [loopp, pretty "panic(\"returned past for\")"]
+    defp loopv initp = pretty "var" <+> (goVar loopv) <+> pretty "=" <+> initp <> semi
+    defsp = zipWith defp loopvs $ map fst initargs
+    loopp = goWhile (pretty "true") bodyp
+    (bodyp, bodyvs) = goEPTail tn who bt
+    initargs = map goArg initas
+    tfvs = Set.unions $ bodyvs : (map snd initargs)
 goEPTail _tn _who (EP_Continue _ _which loopvs args) = (tp, argvs)
-  where tp = vsep $ setsp ++ [ pretty "continue" ]
-        setsp = zipWith setp loopvs $ map fst argargs
-        setp loopv argp = goVar loopv <+> pretty "=" <+> argp <> semi
-        argvs = Set.unions $ map snd argargs
-        argargs = map goArg args
+  where
+    tp = vsep $ setsp ++ [pretty "continue"]
+    setsp = zipWith setp loopvs $ map fst argargs
+    setp loopv argp = goVar loopv <+> pretty "=" <+> argp <> semi
+    argvs = Set.unions $ map snd argargs
+    argargs = map goArg args
 goEPTail tn who (EP_FromConsensus _ kt) = (tp, kfvs)
-  where tp = vsep [ pretty "// XXX FromConsensus", ktp ]
-        (ktp, kfvs) = goEPTail tn who kt
+  where
+    tp = vsep [pretty "// XXX FromConsensus", ktp]
+    (ktp, kfvs) = goEPTail tn who kt
 
 goPart :: (BLVar, EProgram b) -> Doc a
 goPart (p, ep@(EP_Prog _ et)) =
-  vsep_with_blank [ ity_p, funp ]
-  where tn' = 0
-        pn = gopart_name p
-        ity_n = "Interact_" ++ pn
-        bodyp' = vsep [ pretty "var" <+> goTxn tn' <+> pretty "= stdlib.Txn0" <> semi, pretty "_ = txn0;", bodyp ]
-        (bodyp, _) = goEPTail tn' p et
-        funp = goFunction pn ([ pretty "ctc stdlib.Contract", pretty ("interact " ++ ity_n) ]) bodyp'
-        ity_p = pretty ("type " ++ ity_n ++ " interface") <+> (braces $ nest 2 $ hardline <> (hcat $ intersperse (semi <> hardline) ity_eps ))
-        ity_eps = map ity_mk $ M.toList ity
-        ity = ep_interacts ep
-        ity_mk (n, (arg_tys, rt)) =
-          pretty n <> parens (hcat $ intersperse (comma <> space) $ map goType arg_tys) <+> (pretty "<-chan" <+> (goType rt))
+  vsep_with_blank [ity_p, funp]
+  where
+    tn' = 0
+    pn = gopart_name p
+    ity_n = "Interact_" ++ pn
+    bodyp' = vsep [pretty "var" <+> goTxn tn' <+> pretty "= stdlib.Txn0" <> semi, pretty "_ = txn0;", bodyp]
+    (bodyp, _) = goEPTail tn' p et
+    funp = goFunction pn ([pretty "ctc stdlib.Contract", pretty ("interact " ++ ity_n)]) bodyp'
+    ity_p = pretty ("type " ++ ity_n ++ " interface") <+> (braces $ nest 2 $ hardline <> (hcat $ intersperse (semi <> hardline) ity_eps))
+    ity_eps = map ity_mk $ M.toList ity
+    ity = ep_interacts ep
+    ity_mk (n, (arg_tys, rt)) =
+      pretty n <> parens (hcat $ intersperse (comma <> space) $ map goType arg_tys) <+> (pretty "<-chan" <+> (goType rt))
 
 vsep_with_blank :: [Doc a] -> Doc a
 vsep_with_blank l = vsep $ intersperse emptyDoc l
 
 goStringMap :: M.Map T.Text T.Text -> Doc a
 goStringMap m = pretty "map[string]string" <> (goBraces $ vsep $ map (<> comma) $ map goMapField kvs)
-  where goMapField (k, v) = goText k <> pretty ": " <> goBacktickText v
-        kvs = M.toList m
+  where
+    goMapField (k, v) = goText k <> pretty ": " <> goBacktickText v
+    kvs = M.toList m
 
 goCnp :: (T.Text, M.Map T.Text T.Text) -> Doc a
 goCnp (name, cnp) = pretty "const " <> pretty name <> pretty " = " <> goStringMap cnp <> semi
 
 emit_go :: BLProgram b -> CNP_TMap -> Doc a
 emit_go (BL_Prog _ rts pm _) cnps = modp
-  where modp = vsep_with_blank $ preamble : pkgp : importp : retp : partsp ++ cnpsp ++ [ mainp ]
-        preamble = pretty $ "// Automatically generated with Reach " ++ showVersion version
-        pkgp = pretty $ "package main"
-        importp = pretty $ "import ( \"reach-sh/stdlib\" )"
-        retp = pretty "type Ret struct" <> (braces $ hcat $ intersperse (semi <> space) $ map goType rts)
-        partsp = map goPart $ M.toList pm
-        cnpsp = map goCnp $ M.toList cnps
-        mainp = pretty "func main() { }"
+  where
+    modp = vsep_with_blank $ preamble : pkgp : importp : retp : partsp ++ cnpsp ++ [mainp]
+    preamble = pretty $ "// Automatically generated with Reach " ++ showVersion version
+    pkgp = pretty $ "package main"
+    importp = pretty $ "import ( \"reach-sh/stdlib\" )"
+    retp = pretty "type Ret struct" <> (braces $ hcat $ intersperse (semi <> space) $ map goType rts)
+    partsp = map goPart $ M.toList pm
+    cnpsp = map goCnp $ M.toList cnps
+    mainp = pretty "func main() { }"

--- a/hs/src/Reach/Compiler.hs
+++ b/hs/src/Reach/Compiler.hs
@@ -1,33 +1,32 @@
 module Reach.Compiler where
 
-import Control.Monad.State.Lazy
+import Algebra.Lattice
 import Control.Monad.Except
+import Control.Monad.State.Lazy
+import Data.Bits
+import Data.List (foldl')
 import qualified Data.Map.Strict as M
-import qualified Data.Set as Set
 import qualified Data.Sequence as S
-import Text.Pretty.Simple
+import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as L
 import Data.Text.Prettyprint.Doc
-import Data.List (foldl')
-import System.Exit
-import Algebra.Lattice
-import Data.Bits
-import Test.SmallCheck.Series(Serial)
-import GHC.Generics(Generic)
-
+import GHC.Generics (Generic)
 import Reach.AST
-import Reach.Pretty()
-import Reach.Parser
 import Reach.Backend.Go
 import Reach.Backend.JS
-import Reach.ConsensusNetworkProgram
-import Reach.Connector.ETH_Solidity
-import Reach.Connector.ETH_EVM
 import Reach.Connector.ALGO
+import Reach.Connector.ETH_EVM
+import Reach.Connector.ETH_Solidity
+import Reach.ConsensusNetworkProgram
+import Reach.Parser
+import Reach.Pretty ()
+import Reach.Util
 import Reach.VerifyYices
 import Reach.VerifyZ3
-import Reach.Util
+import System.Exit
+import Test.SmallCheck.Series (Serial)
+import Text.Pretty.Simple
 
 {- Err -}
 
@@ -58,36 +57,37 @@ instance Monad m => Serial m CompileErr
 
 expect_throw :: Show a => Show b => CompileErr -> a -> b -> c
 expect_throw ce w x = error $ show w ++ ": " ++ msg ++ ": " ++ show x
-  where msg = case ce of
-          CE_Shadowed -> "shadowed (duplicated) binding of variables are disallowed"
-          CE_VariableNotParticipant -> "variable used as participant, but not bound to participant"
-          --- This is impossible because all of the type definitions
-          --- are correct and don't mention unbound variables.
-          CE_UnboundTypeVariable -> impossible $ "unbound type variable in primitive type"
-          CE_TypeMismatch -> "wrong type"
-          CE_TypeCount -> "wrong number of types"
-          CE_HigherOrder -> "cannot reference higher-order value"
-          CE_CannotApply -> "cannot apply non-higher-order value"
-          CE_UnboundVariable -> "unbound variable"
-          --- This is impossible, because the decoder checks to make
-          --- sure the variables match and it is actually inside a
-          --- loop.
-          CE_ContinueNotInLoop -> impossible $ "continue not inside loop"
-          --- This should be impossible, because there is no terminator
-          --- except for return and continue, and the body of a loop
-          --- has to return nothing.
-          --- XXX Implement a way for while loops to be exited
-          CE_WhileNoContinue -> "while does not terminate in continue"
-          CE_ContractLimitation -> "contract cannot"
-          CE_ContractReturns -> "consensus step not committed"
-          CE_LocalLimitation -> "local cannot"
-          CE_UnknownRole -> "unknown role"
-          CE_ExpectedPublic -> "expected a public value"
-          CE_UnknownVar -> "variable not know by role"
-          CE_Unreachable -> "Hack: This is used by VerifyZ3"
-          CE_ArrayLenNotConstant -> "array length is not constant"
-          CE_ArrayUnitNotBT -> "array element is not base type"
-          CE_ExpectArray -> "expected an array"
+  where
+    msg = case ce of
+      CE_Shadowed -> "shadowed (duplicated) binding of variables are disallowed"
+      CE_VariableNotParticipant -> "variable used as participant, but not bound to participant"
+      --- This is impossible because all of the type definitions
+      --- are correct and don't mention unbound variables.
+      CE_UnboundTypeVariable -> impossible $ "unbound type variable in primitive type"
+      CE_TypeMismatch -> "wrong type"
+      CE_TypeCount -> "wrong number of types"
+      CE_HigherOrder -> "cannot reference higher-order value"
+      CE_CannotApply -> "cannot apply non-higher-order value"
+      CE_UnboundVariable -> "unbound variable"
+      --- This is impossible, because the decoder checks to make
+      --- sure the variables match and it is actually inside a
+      --- loop.
+      CE_ContinueNotInLoop -> impossible $ "continue not inside loop"
+      --- This should be impossible, because there is no terminator
+      --- except for return and continue, and the body of a loop
+      --- has to return nothing.
+      --- XXX Implement a way for while loops to be exited
+      CE_WhileNoContinue -> "while does not terminate in continue"
+      CE_ContractLimitation -> "contract cannot"
+      CE_ContractReturns -> "consensus step not committed"
+      CE_LocalLimitation -> "local cannot"
+      CE_UnknownRole -> "unknown role"
+      CE_ExpectedPublic -> "expected a public value"
+      CE_UnknownVar -> "variable not know by role"
+      CE_Unreachable -> "Hack: This is used by VerifyZ3"
+      CE_ArrayLenNotConstant -> "array length is not constant"
+      CE_ArrayUnitNotBT -> "array element is not base type"
+      CE_ExpectArray -> "expected an array"
 
 {- -}
 
@@ -99,20 +99,24 @@ map_throw ce w m k =
 
 zipEq :: Show c => CompileErr -> c -> [a] -> [b] -> [(a, b)]
 zipEq ce w x y =
-  if lx == ly then zip x y
-  else expect_throw ce w (show lx ++ " vs " ++ show ly)
-  where lx = length x
-        ly = length y
+  if lx == ly
+    then zip x y
+    else expect_throw ce w (show lx ++ " vs " ++ show ly)
+  where
+    lx = length x
+    ly = length y
 
 zipWithEq :: Show d => CompileErr -> d -> (a -> b -> c) -> [a] -> [b] -> [c]
-zipWithEq ce w f x y = map (\(a,b) -> f a b) $ zipEq ce w x y
+zipWithEq ce w f x y = map (\(a, b) -> f a b) $ zipEq ce w x y
 
 zipWithEqM :: Monad m => Show d => CompileErr -> d -> (a -> b -> m c) -> [a] -> [b] -> m [c]
 zipWithEqM ce w f x y =
-  if lx == ly then zipWithM f x y
-  else expect_throw ce w (show lx ++ " vs " ++ show ly)
-  where lx = length x
-        ly = length y
+  if lx == ly
+    then zipWithM f x y
+    else expect_throw ce w (show lx ++ " vs " ++ show ly)
+  where
+    lx = length x
+    ly = length y
 
 {- Basic Type checking
  -}
@@ -123,7 +127,7 @@ checkFun :: Show a => a -> FunctionType -> [LType] -> LType
 checkFun h topft topdom = toprng
   where
     toprng = case runExcept mrng of
-      Left (ce,x) -> expect_throw ce h x
+      Left (ce, x) -> expect_throw ce h x
       Right v -> v
     mrng = hFun [] M.empty topft topdom
     hTy :: TypeVarEnv -> ExprType -> Except (CompileErr, String) LType
@@ -135,13 +139,13 @@ checkFun h topft topdom = toprng
     hExpr :: [String] -> TypeVarEnv -> ExprType -> LType -> Except (CompileErr, String) TypeVarEnv
     hExpr vs γ et at = case et of
       TY_Con bt ->
-        if at == bt then return γ
-        else throwError (CE_TypeMismatch, ("expected " ++ show bt ++ ", but got: " ++ show at))
+        if at == bt
+          then return γ
+          else throwError (CE_TypeMismatch, ("expected " ++ show bt ++ ", but got: " ++ show at))
       TY_Var v ->
-        if not $ elem v vs then
-          throwError (CE_UnboundTypeVariable, v)
-        else
-          case M.lookup v γ of
+        if not $ elem v vs
+          then throwError (CE_UnboundTypeVariable, v)
+          else case M.lookup v γ of
             Just bt -> hExpr vs γ (TY_Con bt) at
             Nothing -> return $ M.insert v at γ
     hFun :: [String] -> TypeVarEnv -> FunctionType -> [LType] -> Except (CompileErr, String) LType
@@ -197,20 +201,22 @@ ienv_check_part_absent a p σ =
 
 type_count_expect :: Show a => a -> Int -> IVType -> IVType
 type_count_expect a cnt t =
-  if l == cnt then t
-  else expect_throw CE_TypeCount a (cnt, l)
-  where l = length t
+  if l == cnt
+    then t
+    else expect_throw CE_TypeCount a (cnt, l)
+  where
+    l = length t
 
 type_count_expect_one :: Show a => a -> IVType -> LType
 type_count_expect_one a t = case t of
   [lt] -> lt
-  _ -> expect_throw CE_TypeCount a (1::Int, length t)
-
+  _ -> expect_throw CE_TypeCount a (1 :: Int, length t)
 
 type_equal :: Show a => a -> IVType -> IVType -> IVType
 type_equal a at et =
-  if at == et then et
-  else expect_throw CE_TypeMismatch a (et, at)
+  if at == et
+    then et
+    else expect_throw CE_TypeMismatch a (et, at)
 
 type_all_single :: Show a => a -> [IVType] -> IVType
 type_all_single a ts = concat $ map (type_count_expect a 1) ts
@@ -218,7 +224,7 @@ type_all_single a ts = concat $ map (type_count_expect a 1) ts
 type_array_elem :: Show a => a -> IVType -> LType
 type_array_elem a lt =
   case (type_count_expect a 1 lt) of
-    [ LT_FixedArray bt _ ] -> LT_BT bt
+    [LT_FixedArray bt _] -> LT_BT bt
     _ -> expect_throw CE_ExpectArray a lt
 
 iv_single :: Show a => a -> InlineV a -> InlineV a
@@ -234,26 +240,31 @@ purePrim _ = Set.empty
 iv_expr :: Show a => a -> InlineV a -> (Effects, IVType, XILExpr a)
 iv_expr _ (IV_Con a c) = (Set.empty, [LT_BT $ conType c], (XIL_Con a c))
 iv_expr _ (IV_Values a vs) = (vsp, ts, (XIL_Values a es))
-  where (vsp, ts, es) = iv_exprs a vs
-iv_expr _ (IV_Var a (v,t)) = (Set.empty, [t], (XIL_Var a (v,t)))
+  where
+    (vsp, ts, es) = iv_exprs a vs
+iv_expr _ (IV_Var a (v, t)) = (Set.empty, [t], (XIL_Var a (v, t)))
 iv_expr _ (IV_XIL isPure ts x) = (isPure, ts, x)
 iv_expr ra (IV_Clo (ca, _, _) _) = expect_throw CE_HigherOrder ra ca
 iv_expr ra (IV_Prim pa _) = expect_throw CE_HigherOrder ra pa
 iv_expr _ (IV_CloBody h arg_ef make_body body_iv) = (arg_ef \/ body_ef, body_t, make_body body_e)
-  where (body_ef, body_t, body_e) = iv_expr h body_iv
+  where
+    (body_ef, body_t, body_e) = iv_expr h body_iv
 
 iv_expr_expect :: Show a => a -> [LType] -> InlineV a -> (Effects, XILExpr a)
 iv_expr_expect ra et iv =
-  if et == at then (p, e)
-  else expect_throw CE_TypeCount ra (et, at)
-  where (p, at, e) = iv_expr ra iv
+  if et == at
+    then (p, e)
+    else expect_throw CE_TypeCount ra (et, at)
+  where
+    (p, at, e) = iv_expr ra iv
 
 iv_exprs :: Show a => a -> [InlineV a] -> (Effects, IVType, [XILExpr a])
 iv_exprs ra ivs = (iep, its, ies)
-  where pies = map (iv_expr ra) ivs
-        ies = map (\(_,_,z)->z) pies
-        its = type_all_single ra $ map (\(_,y,_)->y) pies
-        iep = joins (map (\(x,_,_)->x) pies)
+  where
+    pies = map (iv_expr ra) ivs
+    ies = map (\(_, _, z) -> z) pies
+    its = type_all_single ra $ map (\(_, y, _) -> y) pies
+    iep = joins (map (\(x, _, _) -> x) pies)
 
 iv_can_copy :: InlineV a -> Bool
 iv_can_copy (IV_XIL _ _ _) = False
@@ -262,14 +273,15 @@ iv_can_copy _ = True
 
 id_map :: Show a => a -> [XLVar] -> [LType] -> ILEnv a
 id_map a vs ts = (M.fromList (zipWithEq CE_TypeCount a iv_id vs ts))
-  where iv_id x bt = (x, IV_Var a (x,bt))
+  where
+    iv_id x bt = (x, IV_Var a (x, bt))
 
 copy_map :: Show a => a -> [XLVar] -> InlineV a -> ILEnv a
 copy_map a vs iv =
   case iv of
     IV_Values _ ivs -> M.fromList (zipEq CE_TypeCount a vs ivs)
     _ -> case vs of
-      [ v ] -> M.singleton v iv
+      [v] -> M.singleton v iv
       _ -> expect_throw CE_TypeCount a (1 :: Integer, length vs)
 
 do_static_prim :: a -> EP_Prim -> [InlineV a] -> Maybe (InlineV a)
@@ -293,11 +305,11 @@ do_static_prim h p argivs =
   where
     nn2b op =
       case argivs of
-        [IV_Con _ (Con_I lhs), IV_Con _ (Con_I  rhs)] -> Just $ IV_Con h $ Con_B $ op lhs rhs
+        [IV_Con _ (Con_I lhs), IV_Con _ (Con_I rhs)] -> Just $ IV_Con h $ Con_B $ op lhs rhs
         _ -> Nothing
     nn2n op =
       case argivs of
-        [IV_Con _ (Con_I lhs), IV_Con _ (Con_I  rhs)] -> Just $ IV_Con h $ Con_I $ op lhs rhs
+        [IV_Con _ (Con_I lhs), IV_Con _ (Con_I rhs)] -> Just $ IV_Con h $ Con_I $ op lhs rhs
         _ -> Nothing
 
 type LoopTy = (IVType, IVType)
@@ -313,55 +325,58 @@ do_inline_funcall outer_loopt ch who f argivs =
       case do_static_prim h p argivs of
         Just iv -> iv
         Nothing ->
-          IV_XIL (arp \/ purePrim p) [ pt ] (XIL_PrimApp ch p pt argies)
-          where (arp, argts, argies) = iv_exprs ch argivs
-                pt = checkFun ch (primType p) argts
+          IV_XIL (arp \/ purePrim p) [pt] (XIL_PrimApp ch p pt argies)
+          where
+            (arp, argts, argies) = iv_exprs ch argivs
+            pt = checkFun ch (primType p) argts
     IV_Clo (lh, formals, orig_body) cloenv ->
       case eff_formals of
         [] -> body_iv
         _ ->
           IV_CloBody lh arp make_eff_body' body_iv
-      where (σ', arp, eff_formals, eff_argies) =
-              foldr proc_clo_arg (cloenv, bottom, [], []) $ zipEq CE_TypeCount ch formals argivs
-            proc_clo_arg (formal, argiv) (i_σ, i_arp, i_eff_formals, i_eff_argies) =
-              if (iv_can_copy argiv) then
-                let o_σ_copy = ienv_insert lh formal argiv i_σ
-                in
-                  (o_σ_copy, i_arp, i_eff_formals, i_eff_argies)
-              else
-                let (this_p, this_ts, this_x) = iv_expr ch argiv
-                    this_t = (type_count_expect_one ch this_ts)
-                    o_σ_let = ienv_insert lh formal (IV_Var ch (formal, this_t)) i_σ
-                    o_arp = i_arp \/ this_p
-                    o_eff_formals = (formal, this_t) : i_eff_formals
-                    o_eff_argies = this_x : i_eff_argies
-                in
-                  (o_σ_let, o_arp, o_eff_formals, o_eff_argies)
-            make_eff_body' = XIL_Let lh who (Just eff_formals) (XIL_Values ch eff_argies)
-            body_iv = peval outer_loopt σ' orig_body
+      where
+        (σ', arp, eff_formals, eff_argies) =
+          foldr proc_clo_arg (cloenv, bottom, [], []) $ zipEq CE_TypeCount ch formals argivs
+        proc_clo_arg (formal, argiv) (i_σ, i_arp, i_eff_formals, i_eff_argies) =
+          if (iv_can_copy argiv)
+            then
+              let o_σ_copy = ienv_insert lh formal argiv i_σ
+               in (o_σ_copy, i_arp, i_eff_formals, i_eff_argies)
+            else
+              let (this_p, this_ts, this_x) = iv_expr ch argiv
+                  this_t = (type_count_expect_one ch this_ts)
+                  o_σ_let = ienv_insert lh formal (IV_Var ch (formal, this_t)) i_σ
+                  o_arp = i_arp \/ this_p
+                  o_eff_formals = (formal, this_t) : i_eff_formals
+                  o_eff_argies = this_x : i_eff_argies
+               in (o_σ_let, o_arp, o_eff_formals, o_eff_argies)
+        make_eff_body' = XIL_Let lh who (Just eff_formals) (XIL_Values ch eff_argies)
+        body_iv = peval outer_loopt σ' orig_body
     IV_CloBody h arg_ef make_body body_iv ->
       IV_CloBody h arg_ef make_body (do_inline_funcall outer_loopt ch who body_iv argivs)
 
 peval_ensure_var :: Show a => a -> LType -> XLVar -> ILEnv a -> XILVar
 peval_ensure_var a bt v σ = iv
-  where iv = case iv_expr_expect a [bt] (peval Nothing σ (XL_Var a v)) of
-          (_, XIL_Var _ iv') -> iv'
-          _ -> error "Expected XIL_VAR" -- XXX
+  where
+    iv = case iv_expr_expect a [bt] (peval Nothing σ (XL_Var a v)) of
+      (_, XIL_Var _ iv') -> iv'
+      _ -> error "Expected XIL_VAR" -- XXX
 
 teval :: Show a => ILEnv a -> XLType a -> LType
 teval σ xt =
   case xt of
     XLT_BT _a bt -> LT_BT bt
     XLT_Array a xte unit -> LT_FixedArray bt how_many
-      where bt = case lte of
-                   LT_BT x -> x
-                   _ -> expect_throw CE_ArrayUnitNotBT a lte
-            lte = teval σ xte
-            how_many =
-              case peval Nothing σ unit of
-                IV_Con _ (Con_I x) -> x
-                _ ->
-                  expect_throw CE_ArrayLenNotConstant a ("XXX Implement show for part of InlineV"::String)
+      where
+        bt = case lte of
+          LT_BT x -> x
+          _ -> expect_throw CE_ArrayUnitNotBT a lte
+        lte = teval σ xte
+        how_many =
+          case peval Nothing σ unit of
+            IV_Con _ (Con_I x) -> x
+            _ ->
+              expect_throw CE_ArrayLenNotConstant a ("XXX Implement show for part of InlineV" :: String)
 
 peval :: Show a => Maybe LoopTy -> ILEnv a -> XLExpr a -> InlineV a
 peval outer_loopt σ e =
@@ -375,58 +390,68 @@ peval outer_loopt σ e =
     XL_Prim a p ->
       IV_Prim a p
     XL_If a c t f ->
-      let (cp, c') = tr a [LT_BT BT_Bool] c in
-        case c' of
-          (XIL_Con _ (Con_B b)) ->
-            peval outer_loopt σ (if b then t else f)
-          _ ->
-            IV_XIL (cp \/ tfp) it (XIL_If a tfp c' it t' f')
-            where tfp = (tp \/ fp)
-                  (tp, tt, t') = r a t
-                  (fp, ft, f') = r a f
-                  it = (type_equal a tt ft)
+      let (cp, c') = tr a [LT_BT BT_Bool] c
+       in case c' of
+            (XIL_Con _ (Con_B b)) ->
+              peval outer_loopt σ (if b then t else f)
+            _ ->
+              IV_XIL (cp \/ tfp) it (XIL_If a tfp c' it t' f')
+              where
+                tfp = (tp \/ fp)
+                (tp, tt, t') = r a t
+                (fp, ft, f') = r a f
+                it = (type_equal a tt ft)
     XL_Claim a ct ae ->
-      let ae' = (sr a [LT_BT BT_Bool] ae) in
-        IV_XIL eff_claim [] (XIL_Claim a ct ae')
+      let ae' = (sr a [LT_BT BT_Bool] ae)
+       in IV_XIL eff_claim [] (XIL_Claim a ct ae')
     XL_ToConsensus a (ok_p, vs, ae) mto be ->
       IV_XIL eff_comm rt (XIL_ToConsensus a ok_info mto_info be')
-      where ok_info = (ok_ij, ok_piv, vilvs, (sr a [LT_BT BT_UInt256] ae))
-            (rt, mto_info) =
-              case mto of
-                Nothing -> (bt, Nothing)
-                Just (de, te) -> ((type_equal a tt bt), Just (de', te'))
-                  where de' = sr a [LT_BT BT_UInt256] de
-                        (_, tt, te') = iv_expr a $ peval outer_loopt σ te
-            ok_piv = peval_ensure_var a (LT_BT BT_Address) ok_p σ_ok
-            ok_ij = ienv_check_part_absent a ok_p σ
-            σ_ok = if ok_ij then ienv_insert a ok_p (IV_Var a (ok_p, (LT_BT BT_Address))) σ else σ
-            (_, bt, be') = iv_expr a $ peval outer_loopt σ_ok be
-            vilvs = zip vs vts
-            (_, vts, _) = iv_exprs a $ map def $ map (XL_Var a) vs
+      where
+        ok_info = (ok_ij, ok_piv, vilvs, (sr a [LT_BT BT_UInt256] ae))
+        (rt, mto_info) =
+          case mto of
+            Nothing -> (bt, Nothing)
+            Just (de, te) -> ((type_equal a tt bt), Just (de', te'))
+              where
+                de' = sr a [LT_BT BT_UInt256] de
+                (_, tt, te') = iv_expr a $ peval outer_loopt σ te
+        ok_piv = peval_ensure_var a (LT_BT BT_Address) ok_p σ_ok
+        ok_ij = ienv_check_part_absent a ok_p σ
+        σ_ok = if ok_ij then ienv_insert a ok_p (IV_Var a (ok_p, (LT_BT BT_Address))) σ else σ
+        (_, bt, be') = iv_expr a $ peval outer_loopt σ_ok be
+        vilvs = zip vs vts
+        (_, vts, _) = iv_exprs a $ map def $ map (XL_Var a) vs
     XL_FromConsensus a be ->
       IV_XIL eff_comm bt (XIL_FromConsensus a be')
-      where (_, bt, be') = r a be
+      where
+        (_, bt, be') = r a be
     XL_Values a es ->
       case es of
-        [ e1 ] -> def e1
+        [e1] -> def e1
         _ -> IV_Values a (map (iv_single a) $ map def es)
     XL_Transfer a p ae ->
       IV_XIL eff_comm [] (XIL_Transfer a (peval_ensure_var a (LT_BT BT_Address) p σ) (sr a [LT_BT BT_UInt256] ae))
     XL_Declassify a de ->
       IV_XIL dp [dt] (XIL_Declassify a dt de')
-      where (dp, dts, de') = r a de
-            dt = (type_count_expect_one a dts)
+      where
+        (dp, dts, de') = r a de
+        dt = (type_count_expect_one a dts)
     XL_Let a mp mvs ve be ->
-      let mip = mp >>= (\p -> Just $ if ienv_check_part_absent a p σ then
-                                       (p, (LT_BT BT_Address))
-                                     else
-                                       peval_ensure_var a (LT_BT BT_Address) p σ) in
-      case mvs of
-        Just [ v1 ] ->
-          do_inline_funcall outer_loopt a mip (IV_Clo (a, [ v1 ], be) σ) [ peval outer_loopt σ ve ]
-        _ ->
-          IV_XIL (vp \/ bp) bt (XIL_Let a mip mvs' ve' be')
-          where (vp, ts, ve') = r a ve
+      let mip =
+            mp
+              >>= ( \p ->
+                      Just $
+                        if ienv_check_part_absent a p σ
+                          then (p, (LT_BT BT_Address))
+                          else peval_ensure_var a (LT_BT BT_Address) p σ
+                  )
+       in case mvs of
+            Just [v1] ->
+              do_inline_funcall outer_loopt a mip (IV_Clo (a, [v1], be) σ) [peval outer_loopt σ ve]
+            _ ->
+              IV_XIL (vp \/ bp) bt (XIL_Let a mip mvs' ve' be')
+              where
+                (vp, ts, ve') = r a ve
                 (bp, bt, be') = iv_expr a $ peval outer_loopt σ' be
                 σ' = M.union σ_new σ
                 mvs' = case mvs of
@@ -437,14 +462,15 @@ peval outer_loopt σ e =
                   Just vs -> id_map a vs ts
     XL_While a lvs ie ce inve be ke ->
       IV_XIL eff_comm (type_equal a bet ket) (XIL_While a lvvs ie' (sr' [LT_BT BT_Bool] ce) (sr' [LT_BT BT_Bool] inve) be' ke')
-      where sr' bt x = snd $ iv_expr_expect a bt $ peval this_loopt σ' x
-            this_loopt = Just (ket, lvts)
-            (_, bet, be') = iv_expr a $ peval this_loopt σ' be
-            (_, ket, ke') = iv_expr a $ peval outer_loopt σ' ke
-            (_, iet, ie') = r a ie
-            lvts = type_count_expect a (length lvs) iet
-            lvvs = zip lvs lvts
-            σ' = foldl' (\σ0 (lv, lvv) -> ienv_insert a lv (IV_Var a lvv) σ0) σ $ zip lvs lvvs
+      where
+        sr' bt x = snd $ iv_expr_expect a bt $ peval this_loopt σ' x
+        this_loopt = Just (ket, lvts)
+        (_, bet, be') = iv_expr a $ peval this_loopt σ' be
+        (_, ket, ke') = iv_expr a $ peval outer_loopt σ' ke
+        (_, iet, ie') = r a ie
+        lvts = type_count_expect a (length lvs) iet
+        lvvs = zip lvs lvts
+        σ' = foldl' (\σ0 (lv, lvv) -> ienv_insert a lv (IV_Var a lvv) σ0) σ $ zip lvs lvvs
     XL_Continue a ne ->
       case outer_loopt of
         Just (ket, lvts) ->
@@ -453,48 +479,53 @@ peval outer_loopt σ e =
           expect_throw CE_ContinueNotInLoop a ("XIL" :: String)
     XL_Interact a m xt args ->
       IV_XIL eff_comm [bt] (XIL_Interact a m bt args')
-      where (_, _, args') = iv_exprs a $ map def args
-            bt = teval σ xt
+      where
+        (_, _, args') = iv_exprs a $ map def args
+        bt = teval σ xt
     XL_Lambda a formals body ->
       IV_Clo (a, formals, body) σ
     XL_FunApp a fe es ->
       do_inline_funcall outer_loopt a Nothing (peval outer_loopt σ fe) (map (peval outer_loopt σ) es)
     XL_Digest a args ->
       IV_XIL argsp [LT_BT BT_UInt256] (XIL_Digest a args')
-      where (argsp, _, args') = iv_exprs a $ map def args
+      where
+        (argsp, _, args') = iv_exprs a $ map def args
     XL_ArrayRef a ae ee ->
       IV_XIL cp [et] (XIL_ArrayRef a et ae' ee')
-      where (aep, at, ae') = r a ae
-            et = type_array_elem a at
-            (eep, ee') = tr a [(LT_BT BT_UInt256)] ee
-            cp = aep \/ eep
-  where def = peval outer_loopt σ
-        r h ne = iv_expr h $ def ne
-        tr h bt ne = iv_expr_expect h bt $ def ne
-        sr h bt ne = snd $ tr h bt ne
-        eff_comm = Set.singleton Eff_Comm
-        eff_claim = Set.singleton Eff_Claim
+      where
+        (aep, at, ae') = r a ae
+        et = type_array_elem a at
+        (eep, ee') = tr a [(LT_BT BT_UInt256)] ee
+        cp = aep \/ eep
+  where
+    def = peval outer_loopt σ
+    r h ne = iv_expr h $ def ne
+    tr h bt ne = iv_expr_expect h bt $ def ne
+    sr h bt ne = snd $ tr h bt ne
+    eff_comm = Set.singleton Eff_Comm
+    eff_claim = Set.singleton Eff_Claim
 
 inline :: Show a => XLProgram a -> XILProgram a
 inline (XL_Prog ph defs ps m) = XIL_Prog ph rts ps' (add_to_m' m')
-  where (_, rts, m') = iv_expr ph iv
-        ps' = M.mapKeys (\p -> (p,(LT_BT BT_Address))) ps
-        iv = peval Nothing σ_top m
-        (add_to_m', σ_top) = foldl' add_tops ((\x->x), M.empty) defs
-        add_tops (adder, σ) d =
-          case d of
-            XL_DefineValues h vs ve ->
-              if iv_can_copy ve_iv then
-                (adder, M.union (copy_map h vs ve_iv) σ)
-              else
-                (adder', M.union (id_map h vs ts) σ)
-              where ve_iv = peval Nothing σ ve
-                    adder' im =
-                      XIL_Let h Nothing (Just ivs) ve' (adder im)
-                    ivs = zipWithEq CE_TypeCount h (,) vs ts
-                    (_, ts, ve') = iv_expr h ve_iv
-            XL_DefineFun h f args body ->
-              (adder, ienv_insert h f (IV_Clo (h, args, body) σ_top) σ)
+  where
+    (_, rts, m') = iv_expr ph iv
+    ps' = M.mapKeys (\p -> (p, (LT_BT BT_Address))) ps
+    iv = peval Nothing σ_top m
+    (add_to_m', σ_top) = foldl' add_tops ((\x -> x), M.empty) defs
+    add_tops (adder, σ) d =
+      case d of
+        XL_DefineValues h vs ve ->
+          if iv_can_copy ve_iv
+            then (adder, M.union (copy_map h vs ve_iv) σ)
+            else (adder', M.union (id_map h vs ts) σ)
+          where
+            ve_iv = peval Nothing σ ve
+            adder' im =
+              XIL_Let h Nothing (Just ivs) ve' (adder im)
+            ivs = zipWithEq CE_TypeCount h (,) vs ts
+            (_, ts, ve') = iv_expr h ve_iv
+        XL_DefineFun h f args body ->
+          (adder, ienv_insert h f (IV_Clo (h, args, body) σ_top) σ)
 
 {- ANF
 
@@ -508,6 +539,7 @@ inline (XL_Prog ph defs ps m) = XIL_Prog ph rts ps' (add_to_m' m')
 data ANFElem a
   = ANFExpr a (Role ILVar) ILVar (ILExpr a)
   | ANFStmt a (Role ILVar) (ILStmt a)
+
 type ANFMonad ann a = State (Int, S.Seq (ANFElem ann)) a
 
 runANF :: ANFMonad ann a -> a
@@ -527,7 +559,7 @@ collectANF f ma = do
 consumeANF :: XILVar -> ANFMonad ann ILVar
 consumeANF s = do
   (nv, vs) <- get
-  put (nv+1, vs)
+  put (nv + 1, vs)
   return (nv, s)
 
 appendANF :: ann -> Role ILVar -> ILStmt ann -> ANFMonad ann ()
@@ -575,7 +607,8 @@ anf_parg (ρ, args) (h, v) =
       return (ρ', args' nv)
     Just (IL_Var _ nv) -> return (ρ, args' nv)
     Just _ -> expect_throw CE_UnknownRole h v
-  where args' nv = args ++ [nv]
+  where
+    args' nv = args ++ [nv]
 
 anf_part :: (XILRenaming ann, ILPartInfo ann) -> (XILVar, ann) -> ANFMonad ann (XILRenaming ann, ILPartInfo ann)
 anf_part (ρ, ips) (p, h) = do
@@ -591,9 +624,11 @@ anf_exprs h0 me ρ es mk =
     [] -> mk h0 []
     e : more ->
       anf_expr me ρ e k1
-      where k1 h1 [ e' ] = anf_exprs h1 me ρ more k2
-              where k2 h2 es' = mk h2 $ e' : es'
-            k1 h1 evs = expect_throw CE_TypeCount h1 (h0, length evs)
+      where
+        k1 h1 [e'] = anf_exprs h1 me ρ more k2
+          where
+            k2 h2 es' = mk h2 $ e' : es'
+        k1 h1 evs = expect_throw CE_TypeCount h1 (h0, length evs)
 
 vsOnly :: [ILArg ann] -> [ILVar]
 vsOnly [] = []
@@ -616,85 +651,115 @@ anf_expr :: Show ann => Role ILVar -> XILRenaming ann -> XILExpr ann -> (ann -> 
 anf_expr me ρ e mk =
   case e of
     XIL_Con h b ->
-      mk h [ IL_Con h b ]
-    XIL_Var h v -> mk h [ anf_renamed_to h ρ v ]
+      mk h [IL_Con h b]
+    XIL_Var h v -> mk h [anf_renamed_to h ρ v]
     XIL_PrimApp h p pt args ->
       anf_exprs h me ρ args (\_ args' -> ret_expr h "PrimApp" pt (IL_PrimApp h p args'))
     XIL_If h effs ce its te fe ->
       anf_expr me ρ ce k
-      where k _ [ ca ] =
-              case Set.null effs of
-                True ->
-                  anf_expr me ρ te
-                  (\ _ tvs ->
-                      anf_expr me ρ fe
-                      (\ _ fvs -> do
-                          ks <- allocANFs h me "PureIf" its $ zipWithEq CE_TypeCount h (\ t f -> IL_PrimApp h (CP IF_THEN_ELSE) [ ca, t, f ]) tvs fvs
-                          mk h $ map (IL_Var h) ks))
-                False -> comm_case
-              where comm_case = do
-                      tt <- anf_tail me ρ te mk
-                      ft <- anf_tail me ρ fe mk
-                      return $ IL_If h ca tt ft
-            k _ es = expect_throw CE_TypeCount h (1 :: Integer, (length es))
+      where
+        k _ [ca] =
+          case Set.null effs of
+            True ->
+              anf_expr
+                me
+                ρ
+                te
+                ( \_ tvs ->
+                    anf_expr
+                      me
+                      ρ
+                      fe
+                      ( \_ fvs -> do
+                          ks <- allocANFs h me "PureIf" its $ zipWithEq CE_TypeCount h (\t f -> IL_PrimApp h (CP IF_THEN_ELSE) [ca, t, f]) tvs fvs
+                          mk h $ map (IL_Var h) ks
+                      )
+                )
+            False -> comm_case
+          where
+            comm_case = do
+              tt <- anf_tail me ρ te mk
+              ft <- anf_tail me ρ fe mk
+              return $ IL_If h ca tt ft
+        k _ es = expect_throw CE_TypeCount h (1 :: Integer, (length es))
     XIL_Claim h ct ae ->
       anf_expr me ρ ae $ \_ aas -> case aas of
-        [ aa ] -> ret_stmt h (IL_Claim h ct aa)
-        _ -> error "Expected exactly one ILArg"  -- XXX
+        [aa] -> ret_stmt h (IL_Claim h ct aa)
+        _ -> error "Expected exactly one ILArg" -- XXX
     XIL_FromConsensus h le -> do
       lt <- anf_tail RoleContract ρ le mk
       return $ IL_FromConsensus h lt
     XIL_ToConsensus h (ok_ij, from, ins, pe) mto ce -> do
       let from' = anf_renamed_to_var h ρ from
-      anf_expr (RolePart from') ρ pe
-        (\ _ pas -> case pas of
-          [pa] -> do
-            let ins' = vsOnly $ map (anf_renamed_to h ρ) ins
-            ct <- anf_tail RoleContract ρ ce mk
-            let done mto' = return $ IL_ToConsensus h (ok_ij, from', ins', pa) mto' ct
-            case mto of
-              Nothing -> done Nothing
-              Just (de, te) ->
-                anf_expr RoleContract ρ de
-                (\ _ das -> case das of
-                    [da] -> do
-                      tt <- anf_tail RoleContract ρ te anf_ktop
-                      done $ Just (da, tt)
-                    _ -> error "Expected [ILArg] to have exactly one element")  -- XXX
-          _ -> error "Expected [ILArg] to have exactly one element") -- XXX
+      anf_expr
+        (RolePart from')
+        ρ
+        pe
+        ( \_ pas -> case pas of
+            [pa] -> do
+              let ins' = vsOnly $ map (anf_renamed_to h ρ) ins
+              ct <- anf_tail RoleContract ρ ce mk
+              let done mto' = return $ IL_ToConsensus h (ok_ij, from', ins', pa) mto' ct
+              case mto of
+                Nothing -> done Nothing
+                Just (de, te) ->
+                  anf_expr
+                    RoleContract
+                    ρ
+                    de
+                    ( \_ das -> case das of
+                        [da] -> do
+                          tt <- anf_tail RoleContract ρ te anf_ktop
+                          done $ Just (da, tt)
+                        _ -> error "Expected [ILArg] to have exactly one element" -- XXX
+                    )
+            _ -> error "Expected [ILArg] to have exactly one element" -- XXX
+        )
     XIL_Values h args ->
       anf_exprs h me ρ args mk
     XIL_Transfer h to ae ->
-      anf_expr me ρ ae
-      (\_ aas -> case aas of
-          [ aa ] -> case map_throw CE_UnknownRole h ρ to of
-            (IL_Var _ tov) -> ret_stmt h (IL_Transfer h tov aa)
-            _ -> error "Expected an IL_Var"  -- XXX
-          _ -> error "Expected [ILArg] to have exactly one element")  -- XXX
+      anf_expr
+        me
+        ρ
+        ae
+        ( \_ aas -> case aas of
+            [aa] -> case map_throw CE_UnknownRole h ρ to of
+              (IL_Var _ tov) -> ret_stmt h (IL_Transfer h tov aa)
+              _ -> error "Expected an IL_Var" -- XXX
+            _ -> error "Expected [ILArg] to have exactly one element" -- XXX
+        )
     XIL_Declassify h dt ae ->
-      anf_expr me ρ ae (\_ aas -> case aas of
-                          [aa] -> ret_expr h "Declassify" dt (IL_Declassify h aa)
-                          _ -> error "Expected [ILArg] to have exactly one element")  -- XXX
+      anf_expr
+        me
+        ρ
+        ae
+        ( \_ aas -> case aas of
+            [aa] -> ret_expr h "Declassify" dt (IL_Declassify h aa)
+            _ -> error "Expected [ILArg] to have exactly one element" -- XXX
+        )
     XIL_Let h mwho mvs ve be ->
       anf_expr who ρ ve k
-      where who = case mwho of
-                    Nothing -> me
-                    Just p -> RolePart $ anf_renamed_to_var h ρ p
-            k _ nvs = anf_expr me ρ' be mk
-              where ρ' = M.union ρvs ρ
-                    ρvs = case mvs of
-                      Nothing -> ρ
-                      Just ovs -> (M.fromList $ zipEq CE_TypeCount h ovs nvs)
+      where
+        who = case mwho of
+          Nothing -> me
+          Just p -> RolePart $ anf_renamed_to_var h ρ p
+        k _ nvs = anf_expr me ρ' be mk
+          where
+            ρ' = M.union ρvs ρ
+            ρvs = case mvs of
+              Nothing -> ρ
+              Just ovs -> (M.fromList $ zipEq CE_TypeCount h ovs nvs)
     XIL_While h loopvs inite untile inve bodye ke ->
       anf_expr me ρ inite k
-      where k _ initas = do
-              (ρ', loopvs') <- makeRenames h ρ loopvs
-              untilt <- anf_tail me ρ' untile anf_ktop
-              invt <- anf_tail me ρ' inve anf_ktop
-              bodyt <- anf_tail me ρ' bodye anf_knocontinue
-              kt <- anf_tail me ρ' ke mk
-              return $ IL_While h loopvs' initas untilt invt bodyt kt
-            anf_knocontinue kh _ = expect_throw CE_WhileNoContinue kh h
+      where
+        k _ initas = do
+          (ρ', loopvs') <- makeRenames h ρ loopvs
+          untilt <- anf_tail me ρ' untile anf_ktop
+          invt <- anf_tail me ρ' inve anf_ktop
+          bodyt <- anf_tail me ρ' bodye anf_knocontinue
+          kt <- anf_tail me ρ' ke mk
+          return $ IL_While h loopvs' initas untilt invt bodyt kt
+        anf_knocontinue kh _ = expect_throw CE_WhileNoContinue kh h
     XIL_Continue h nve ->
       anf_expr me ρ nve (\_ nvas -> return $ IL_Continue h nvas)
     XIL_Interact h m bt args ->
@@ -702,15 +767,22 @@ anf_expr me ρ e mk =
     XIL_Digest h args ->
       anf_exprs h me ρ args (\_ args' -> ret_expr h "Digest" (LT_BT BT_UInt256) (IL_Digest h args'))
     XIL_ArrayRef h bt ae ee ->
-      anf_exprs h me ρ [ae, ee] (\_ ae'_ee' -> case ae'_ee' of
-                                    [ae', ee'] -> ret_expr h "ArrayRef" bt (IL_ArrayRef h ae' ee')
-                                    _ -> error "Expected [ILArg] to have exactly 2 elements") -- XXX
-  where ret_expr h s t ne = do
-          nv <- allocANF h me s t ne
-          mk h [ IL_Var h nv ]
-        ret_stmt h s = do
-          appendANF h me s
-          mk h [ IL_Con h (Con_B True) ]
+      anf_exprs
+        h
+        me
+        ρ
+        [ae, ee]
+        ( \_ ae'_ee' -> case ae'_ee' of
+            [ae', ee'] -> ret_expr h "ArrayRef" bt (IL_ArrayRef h ae' ee')
+            _ -> error "Expected [ILArg] to have exactly 2 elements" -- XXX
+        )
+  where
+    ret_expr h s t ne = do
+      nv <- allocANF h me s t ne
+      mk h [IL_Var h nv]
+    ret_stmt h s = do
+      appendANF h me s
+      mk h [IL_Con h (Con_B True)]
 
 anf_addVar :: ANFElem ann -> ILTail ann -> ILTail ann
 anf_addVar (ANFExpr h mp v e) t = IL_Let h mp v e t
@@ -751,7 +823,7 @@ properties:
 data SecurityLevel
   = Secret
   | Public
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 instance Semigroup SecurityLevel where
   Secret <> _ = Secret
@@ -762,15 +834,18 @@ instance Monoid SecurityLevel where
   mempty = Public
 
 type EPPEnv = M.Map (Role BLVar) (M.Map ILVar SecurityLevel)
+
 type EPPMonad ann a = State (Int, M.Map Int (Maybe (CHandler ann))) a
+
 type EPPRes ann = EPPMonad ann (Set.Set BLVar, CTail ann, M.Map BLVar (EPTail ann))
 
 runEPP :: EPPMonad ann a -> (a, [CHandler ann])
 runEPP am = (a, hs)
-  where (a, (_, hs_as_s)) = runState am (1, M.empty)
-        hs = map force $ M.toAscList hs_as_s
-        force (_, Just h) = h
-        force _ = impossible "EPP: Handler never set!"
+  where
+    (a, (_, hs_as_s)) = runState am (1, M.empty)
+    hs = map force $ M.toAscList hs_as_s
+    force (_, Just h) = h
+    force _ = impossible "EPP: Handler never set!"
 
 localEPP :: EPPMonad ann a -> EPPMonad ann a
 localEPP am = do
@@ -788,12 +863,12 @@ setEPP :: Int -> (Int -> CHandler ann) -> EPPMonad ann ()
 setEPP which mh = do
   (nh, hs) <- get
   let hs' = case M.lookup which hs of
-              Nothing ->
-                impossible "EPP: Handler not acquired!"
-              Just Nothing ->
-                M.insert which (Just $ mh which) hs
-              Just (Just _) ->
-                impossible "EPP: Handler already set!"
+        Nothing ->
+          impossible "EPP: Handler not acquired!"
+        Just Nothing ->
+          M.insert which (Just $ mh which) hs
+        Just (Just _) ->
+          impossible "EPP: Handler already set!"
   put (nh, hs')
   return ()
 
@@ -809,12 +884,13 @@ boundBLVars vs = Set.fromList vs
 
 epp_var :: Show ann => ann -> EPPEnv -> Role BLVar -> ILVar -> (BLVar, SecurityLevel)
 epp_var h γ r iv = (iv, st)
-  where env = case M.lookup r γ of
-          Nothing -> expect_throw CE_UnknownRole h r
-          Just v -> v
-        st = case M.lookup iv env of
-          Nothing -> expect_throw CE_UnknownVar h (r, iv)
-          Just v -> v
+  where
+    env = case M.lookup r γ of
+      Nothing -> expect_throw CE_UnknownRole h r
+      Just v -> v
+    st = case M.lookup iv env of
+      Nothing -> expect_throw CE_UnknownVar h (r, iv)
+      Just v -> v
 
 epp_vars :: Show ann => ann -> EPPEnv -> Role BLVar -> [ILVar] -> [(BLVar, SecurityLevel)]
 epp_vars h γ r ivs = map (epp_var h γ r) ivs
@@ -822,65 +898,83 @@ epp_vars h γ r ivs = map (epp_var h γ r) ivs
 epp_arg :: Show ann => ann -> EPPEnv -> Role BLVar -> ILArg ann -> ((Set.Set BLVar, BLArg ann), SecurityLevel)
 epp_arg _ _ _ (IL_Con h c) = ((Set.empty, BL_Con h c), Public)
 epp_arg _ γ r (IL_Var h iv) = ((Set.singleton bv, BL_Var h bv), st)
-  where (bv, st) = epp_var h γ r iv
+  where
+    (bv, st) = epp_var h γ r iv
 
 epp_args :: Show ann => ann -> EPPEnv -> Role BLVar -> [ILArg ann] -> (Set.Set BLVar, [(BLArg ann, SecurityLevel)])
 epp_args h γ r ivs = (svs, args)
-  where cmb = map (epp_arg h γ r) ivs
-        svs = Set.unions $ map (\((a,_),_) -> a) cmb
-        args = map (\((_,b),c) -> (b,c)) cmb
+  where
+    cmb = map (epp_arg h γ r) ivs
+    svs = Set.unions $ map (\((a, _), _) -> a) cmb
+    args = map (\((_, b), c) -> (b, c)) cmb
 
 epp_e_ctc :: Show ann => EPPEnv -> ILExpr ann -> (SecurityLevel, Set.Set BLVar, CExpr ann)
 epp_e_ctc γ e = case e of
   IL_Declassify h _ -> expect_throw CE_ContractLimitation h ("declassify" :: String)
   IL_PrimApp h (CP cp) args -> (Public, fvs, C_PrimApp h cp args')
-    where (fvs, args') = args_help h args
+    where
+      (fvs, args') = args_help h args
   IL_PrimApp h p _ -> expect_throw CE_ContractLimitation h p
   IL_Interact h _ _ _ -> expect_throw CE_ContractLimitation h ("interact" :: String)
   IL_Digest h args -> (Public, fvs, C_Digest h args')
-    where (fvs, args') = args_help h args
+    where
+      (fvs, args') = args_help h args
   IL_ArrayRef h ae ee -> (Public, fvs, C_ArrayRef h ae' ee')
-    where (fvs, ae', ee') = case args_help h [ae, ee] of
-            (fvs_, [ae'_, ee'_]) -> (fvs_, ae'_, ee'_)
-            _ -> error "Expected list to have exactly 2 elements" -- XXX
-  where args_help h args = (fvs, args')
-          where (fvs, args0) = epp_args h γ RoleContract args
-                args' = map (must_be_public h) $ args0
+    where
+      (fvs, ae', ee') = case args_help h [ae, ee] of
+        (fvs_, [ae'_, ee'_]) -> (fvs_, ae'_, ee'_)
+        _ -> error "Expected list to have exactly 2 elements" -- XXX
+  where
+    args_help h args = (fvs, args')
+      where
+        (fvs, args0) = epp_args h γ RoleContract args
+        args' = map (must_be_public h) $ args0
 
 epp_e_loc :: Show ann => EPPEnv -> ILVar -> ILExpr ann -> (SecurityLevel, Set.Set BLVar, EPExpr ann)
 epp_e_loc γ p e = case e of
   IL_Declassify h a -> (Public, fvs, EP_Arg h a')
-    where ((fvs, a'), _) = earg h a
+    where
+      ((fvs, a'), _) = earg h a
   IL_PrimApp h pr args -> (slvl, fvs, EP_PrimApp h pr args')
-    where (slvl, fvs, args') = args_help h args
+    where
+      (slvl, fvs, args') = args_help h args
   IL_Interact h m bt args -> (Secret, fvs, EP_Interact h m bt args')
-    where (_, fvs, args') = args_help h args
+    where
+      (_, fvs, args') = args_help h args
   IL_Digest h args -> (slvl, fvs, EP_Digest h args')
-    where (slvl, fvs, args') = args_help h args
+    where
+      (slvl, fvs, args') = args_help h args
   IL_ArrayRef h ae ee -> (slvl, fvs, EP_ArrayRef h ae' ee')
-    where (slvl, fvs, ae', ee') = case args_help h [ae, ee] of
-            (slvl_, fvs_, [ae'_, ee'_]) -> (slvl_, fvs_, ae'_, ee'_)
-            _ -> error "Expected list to have exactly 2 elements" -- XXX
- where earg h = epp_arg h γ (RolePart p)
-       args_help h args = (slvl, fvs, args')
-         where (fvs, args'st) = epp_args h γ (RolePart p) args
-               args' = map fst args'st
-               slvl = mconcat $ map snd args'st
+    where
+      (slvl, fvs, ae', ee') = case args_help h [ae, ee] of
+        (slvl_, fvs_, [ae'_, ee'_]) -> (slvl_, fvs_, ae'_, ee'_)
+        _ -> error "Expected list to have exactly 2 elements" -- XXX
+  where
+    earg h = epp_arg h γ (RolePart p)
+    args_help h args = (slvl, fvs, args')
+      where
+        (fvs, args'st) = epp_args h γ (RolePart p) args
+        args' = map fst args'st
+        slvl = mconcat $ map snd args'st
 
 epp_s_ctc :: Show ann => EPPEnv -> ILStmt ann -> (Set.Set BLVar, CStmt ann)
 epp_s_ctc γ e = case e of
   IL_Transfer h r am -> (Set.insert r fvs, C_Transfer h r am')
-    where (fvs, am') = eargt h am
+    where
+      (fvs, am') = eargt h am
   IL_Claim h ct a -> (fvs, C_Claim h ct a')
-    where (fvs, a') = eargt h a
- where earg h = epp_arg h γ RoleContract
-       eargt h a = must_be_public h $ earg h a
+    where
+      (fvs, a') = eargt h a
+  where
+    earg h = epp_arg h γ RoleContract
+    eargt h a = must_be_public h $ earg h a
 
 epp_s_loc :: Show ann => EPPEnv -> ILVar -> ILStmt ann -> (Set.Set BLVar, EPStmt ann)
 epp_s_loc γ p e = case e of
   IL_Transfer h _ _ -> expect_throw CE_LocalLimitation h ("transfer" :: String)
   IL_Claim h ct a -> (fvs, EP_Claim h ct a')
-    where ((fvs, a'), _) = epp_arg h γ (RolePart p) a
+    where
+      ((fvs, a'), _) = epp_arg h γ (RolePart p) a
 
 epp_e_ctc2loc :: CExpr ann -> EPExpr ann
 epp_e_ctc2loc (C_PrimApp h cp al) = (EP_PrimApp h (CP cp) al)
@@ -900,17 +994,20 @@ data EPPCtxt ann
 
 combine_maps :: Ord k => (k -> u -> v -> w) -> [k] -> M.Map k u -> M.Map k v -> M.Map k w
 combine_maps f ks m1 m2 = M.fromList $ map cmb ks
-  where cmb k = (k, f k (m1 M.! k) (m2 M.! k))
+  where
+    cmb k = (k, f k (m1 M.! k) (m2 M.! k))
 
 epp_it_ctc_do_if :: Show ann => ann -> [BLVar] -> (EPPEnv, ILArg ann) -> EPPRes ann -> EPPRes ann -> EPPRes ann
 epp_it_ctc_do_if h ps (γc, ca) tres fres = do
   let (svs_ca, cca') = must_be_public h $ epp_arg h γc RoleContract ca
   (svs_t, ctt', ts1) <- tres
   (svs_f, cft', ts2) <- fres
-  let svs = Set.unions [ svs_ca, svs_t, svs_f ]
+  let svs = Set.unions [svs_ca, svs_t, svs_f]
   let ts3 = combine_maps mkt ps ts1 ts2
-            where mkt p tt' ft' = EP_If h ca' tt' ft'
-                    where (_,ca') = must_be_public h $ epp_arg h γc (RolePart p) ca
+        where
+          mkt p tt' ft' = EP_If h ca' tt' ft'
+            where
+              (_, ca') = must_be_public h $ epp_arg h γc (RolePart p) ca
   return (svs, C_If h cca' ctt' cft', ts3)
 
 epp_it_ctc :: Show ann => [BLVar] -> Int -> EPPEnv -> EPPCtxt ann -> ILTail ann -> EPPRes ann
@@ -919,16 +1016,18 @@ epp_it_ctc ps this_h γ ctxt it = case it of
     case ctxt of
       EC_WhileUntil kres bres -> do
         epp_it_ctc_do_if h ps (γ, arg0) kres bres
-        where arg0 = case args of
-                [arg] -> arg
-                _ -> error "Expected exactly one arg" -- XXX
+        where
+          arg0 = case args of
+            [arg] -> arg
+            _ -> error "Expected exactly one arg" -- XXX
       EC_Invariant -> do
         return (mempty, C_Halt h, mempty)
       _ ->
         expect_throw CE_ContractReturns h ()
   IL_If h ca tt ft -> do
     epp_it_ctc_do_if h ps (γ, ca) (dres tt) (dres ft)
-    where dres wt = epp_it_ctc ps this_h γ ctxt wt
+    where
+      dres wt = epp_it_ctc ps this_h γ ctxt wt
   IL_Let h RoleContract what how next -> do
     let (st, svs_how, how_ctc) = epp_e_ctc γ how
     let whatenv = M.singleton what st
@@ -946,7 +1045,8 @@ epp_it_ctc ps this_h γ ctxt it = case it of
     let svs = Set.union svs1 svs2
     let ct2 = C_Do h how' ct1
     let ts2 = M.map (EP_Do h how'_ep) ts1
-              where how'_ep = epp_s_ctc2loc how'
+          where
+            how'_ep = epp_s_ctc2loc how'
     return (svs, ct2, ts2)
   IL_Do h (RolePart _) _ _ ->
     expect_throw CE_ContractLimitation h ("local action" :: String)
@@ -980,68 +1080,77 @@ epp_it_ctc ps this_h γ ctxt it = case it of
     case ctxt of
       EC_WhileTrial loopvs -> do
         return (svs, trial "ct", ts)
-        where svs = fvs_as
-              (fvs_as, _) = epp_args h γ RoleContract nas
-              trial msg = impossible $ "EPP: WhileTrial: Cannot inspect " ++ msg
-              ts = M.fromList $ map mkt ps
-              mkt p = (p, EP_Continue h 0 loopvs $ trial "continue arg")
+        where
+          svs = fvs_as
+          (fvs_as, _) = epp_args h γ RoleContract nas
+          trial msg = impossible $ "EPP: WhileTrial: Cannot inspect " ++ msg
+          ts = M.fromList $ map mkt ps
+          mkt p = (p, EP_Continue h 0 loopvs $ trial "continue arg")
       EC_WhileBody which loopvs fvs_loop -> do
         return (svs, ct, ts)
-        where (fvs_as, inita'_infos) = epp_args h γ RoleContract nas
-              initas' = map (must_be_public h) inita'_infos
-              svs = Set.union fvs_loop fvs_as
-              fvs_loopl = Set.toList fvs_loop
-              ct = C_Jump h which fvs_loopl loopvs initas'
-              ts = M.fromList $ map mkt ps
-              mkt p = (p, EP_Continue h which loopvs $ (map fst) . snd $ epp_args h γ (RolePart p) nas)
+        where
+          (fvs_as, inita'_infos) = epp_args h γ RoleContract nas
+          initas' = map (must_be_public h) inita'_infos
+          svs = Set.union fvs_loop fvs_as
+          fvs_loopl = Set.toList fvs_loop
+          ct = C_Jump h which fvs_loopl loopvs initas'
+          ts = M.fromList $ map mkt ps
+          mkt p = (p, EP_Continue h which loopvs $ (map fst) . snd $ epp_args h γ (RolePart p) nas)
       _ ->
         expect_throw CE_ContinueNotInLoop h ("EPP" :: String)
 
 epp_it_loc :: Show ann => [BLVar] -> (Int, Set.Set BLVar) -> EPPEnv -> EPPCtxt ann -> CInterval ann -> ILTail ann -> EPPRes ann
 epp_it_loc ps last_hNvs γ ctxt toint it = case it of
-  IL_Ret h al -> return ( Set.empty, C_Halt h, ts)
-    where ts = M.fromList $ map mkt ps
-          mkt p = (p, EP_Ret h $ map fst $ snd $ epp_args h γ (RolePart p) al)
+  IL_Ret h al -> return (Set.empty, C_Halt h, ts)
+    where
+      ts = M.fromList $ map mkt ps
+      mkt p = (p, EP_Ret h $ map fst $ snd $ epp_args h γ (RolePart p) al)
   IL_If h _ _ _ ->
     expect_throw CE_LocalLimitation h ("impure if" :: String)
   IL_Let h who what how next -> do
     let (fmst, extend_ts) =
-          foldr addhow (Nothing, (\x->x)) ps
-          where addhow p (mst, do_extend) =
-                  if not (role_me (RolePart p) who) then
-                    (mst, do_extend)
-                  else
-                    (Just st, do_extend')
-                  where (st, _, how') = epp_e_loc γ p how
-                        do_extend' ts =
-                          M.insert p t' ts'
-                          where t' = EP_Let h what how' t
-                                t = ts' M.! p
-                                ts' = do_extend ts
+          foldr addhow (Nothing, (\x -> x)) ps
+          where
+            addhow p (mst, do_extend) =
+              if not (role_me (RolePart p) who)
+                then (mst, do_extend)
+                else (Just st, do_extend')
+              where
+                (st, _, how') = epp_e_loc γ p how
+                do_extend' ts =
+                  M.insert p t' ts'
+                  where
+                    t' = EP_Let h what how' t
+                    t = ts' M.! p
+                    ts' = do_extend ts
     let γ' = M.mapWithKey addwhat γ
-             where addwhat r env = if role_me r who then
-                                     M.insert what lst env
-                                   else
-                                     env
-                   lst = case fmst of
-                     Nothing -> expect_throw CE_UnknownRole h who
-                     Just v -> v
+          where
+            addwhat r env =
+              if role_me r who
+                then M.insert what lst env
+                else env
+            lst = case fmst of
+              Nothing -> expect_throw CE_UnknownRole h who
+              Just v -> v
     (svs1, ct1, ts1) <- epp_it_loc ps last_hNvs γ' ctxt toint next
     return (svs1, ct1, extend_ts ts1)
   IL_Do h who how next -> do
     (svs1, ct1, ts1) <- epp_it_loc ps last_hNvs γ ctxt toint next
     let ts2 = M.mapWithKey addhow ts1
-              where addhow p t =
-                      if not (role_me (RolePart p) who) then t
-                      else EP_Do h s' t
-                      where (_, s') = epp_s_loc γ p how
+          where
+            addhow p t =
+              if not (role_me (RolePart p) who)
+                then t
+                else EP_Do h s' t
+              where
+                (_, s') = epp_s_loc γ p how
     return (svs1, ct1, ts2)
   IL_ToConsensus h (ok_ij, fromp, what, howmuch) mto next -> do
     hn_okay <- acquireEPP
     let fromr = RolePart fromp
     let (_, howmuch') = must_be_public h $ epp_arg h γ fromr howmuch
     let what' = map (must_be_public h) $ epp_vars h γ fromr what
-    let what'env = M.fromList $ map (\v -> (v,Public)) what'
+    let what'env = M.fromList $ map (\v -> (v, Public)) what'
     let γ' = M.map (M.union what'env) γ
     (svs_okay, ct_okay, ts_okay) <- epp_it_ctc ps hn_okay γ' ctxt next
     let part_may_add True p x = Set.delete p x
@@ -1060,21 +1169,22 @@ epp_it_loc ps last_hNvs γ ctxt toint it = case it of
           let last_h_fvs' = Set.union svs_ok_needs last_h_fvs
           (svs_timeout, _, ts_timeout) <- epp_it_loc ps (last_h, last_h_fvs') γ ctxt toint_to timeout
           return (toint_ok, mdelay, (Set.union delay_vs svs_timeout), ts_timeout)
-    let svs_all = Set.unions [ last_h_fvs, svs_timeout, svs_ok_needs ]
+    let svs_all = Set.unions [last_h_fvs, svs_timeout, svs_ok_needs]
     let svs_all_l = Set.toList svs_all
     let ok_fs = (if ok_ij then FS_Join else FS_From) fromp
     setEPP hn_okay $ C_Handler h ok_fs toint_ok (last_h, svs_all_l) what' ct_okay
     let ct2 = C_Wait h last_h svs_all_l
     let ts2 = combine_maps mkt ps ts_okay ts_timeout
-              where mkt p pt1 pt2 =
-                      let to_info = case mdelay of
-                                          Nothing -> Nothing
-                                          Just delay' -> Just (delay', pt2)
-                          m_send_amt = if (p == fromp)
-                            then Just howmuch'
-                            else Nothing
-                      in
-                        EP_SendRecv h svs_all_l m_send_amt (ok_fs, hn_okay, what', pt1) to_info
+          where
+            mkt p pt1 pt2 =
+              let to_info = case mdelay of
+                    Nothing -> Nothing
+                    Just delay' -> Just (delay', pt2)
+                  m_send_amt =
+                    if (p == fromp)
+                      then Just howmuch'
+                      else Nothing
+               in EP_SendRecv h svs_all_l m_send_amt (ok_fs, hn_okay, what', pt1) to_info
     return (svs_all, ct2, ts2)
   IL_FromConsensus h _ -> expect_throw CE_LocalLimitation h ("transition from consensus" :: String)
   IL_While h _ _ _ _ _ _ -> expect_throw CE_LocalLimitation h ("while" :: String)
@@ -1082,24 +1192,26 @@ epp_it_loc ps last_hNvs γ ctxt toint it = case it of
 
 epp :: Show ann => ILProgram ann -> BLProgram ann
 epp (IL_Prog h rt ips it) = BL_Prog h rt bps cp
-  where cp = C_Prog h chs
-        ps = Set.toList ips
-        bps = M.mapWithKey mkep ets
-        mkep _ ept = EP_Prog h ept
-        ((_, _, ets), chs) = runEPP $ epp_it_loc ps (0, mempty) γ EC_Top default_interval it
-        γi = M.fromList $ map initγ $ Set.toList ips
-        initγ p = (RolePart p, mempty)
-        γ = M.insert RoleContract M.empty γi
+  where
+    cp = C_Prog h chs
+    ps = Set.toList ips
+    bps = M.mapWithKey mkep ets
+    mkep _ ept = EP_Prog h ept
+    ((_, _, ets), chs) = runEPP $ epp_it_loc ps (0, mempty) γ EC_Top default_interval it
+    γi = M.fromList $ map initγ $ Set.toList ips
+    initγ p = (RolePart p, mempty)
+    γ = M.insert RoleContract M.empty γi
 
 data Verifier = Yices | Z3
   deriving (Read, Show, Eq)
 
 data CompilerOpts = CompilerOpts
-  { output :: T.Text -> String -> IO ()
-  , output_name :: T.Text -> String
-  , source :: FilePath
-  , expCon :: Bool  -- ^ Enable experimental connectors
-  , verifier :: Verifier
+  { output :: T.Text -> String -> IO (),
+    output_name :: T.Text -> String,
+    source :: FilePath,
+    -- | Enable experimental connectors
+    expCon :: Bool,
+    verifier :: Verifier
   }
 
 compile :: CompilerOpts -> IO ()
@@ -1119,13 +1231,13 @@ compile copts = do
   let blp = epp ilp
   out "bl" (show (pretty blp))
   cs <- compile_sol (outn "sol") blp
-  let cnps_reg = M.fromList [ (ETH, CNP_ETH cs) ]
+  let cnps_reg = M.fromList [(ETH, CNP_ETH cs)]
   cnps_exp <- case expCon copts of
     False -> return M.empty
     True -> do
       ebc <- emit_evm (outn "evm") blp
       tbc <- emit_teal (outn "teal") blp
-      return $ M.fromList [ (ETH_EVM, CNP_ETH (fst cs, ebc)), (ALGO, CNP_ALGO tbc) ]
+      return $ M.fromList [(ETH_EVM, CNP_ETH (fst cs, ebc)), (ALGO, CNP_ALGO tbc)]
   let cnp_tm = cnpToFieldMap $ cnps_reg <> cnps_exp
   out "mjs" (show (emit_js blp cnp_tm))
   out "go" (show (emit_go blp cnp_tm))

--- a/hs/src/Reach/CompilerNL.hs
+++ b/hs/src/Reach/CompilerNL.hs
@@ -1,54 +1,57 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Reach.CompilerNL where
 
-import Debug.Trace
+module Reach.CompilerNL where
 
 import Control.Monad
 import Control.Monad.ST
 import Data.Bits
+import qualified Data.ByteString.Char8 as B
 import Data.FileEmbed
 import Data.Foldable
+import qualified Data.Graph as G
 import Data.IORef
 import Data.List
+import qualified Data.Map.Strict as M
 import Data.Monoid
 import Data.STRef
+import qualified Data.Sequence as Seq
+import Debug.Trace
 import GHC.IO.Encoding
-import GHC.Stack(HasCallStack)
+import GHC.Stack (HasCallStack)
 import Language.JavaScript.Parser
 import Language.JavaScript.Parser.AST
+import Reach.Compiler (CompilerOpts, output, source)
+import Reach.Util
 import Safe (atMay)
 import System.Directory
 import System.FilePath
 import Text.ParserCombinators.Parsec.Number (numberValue)
-import qualified Data.ByteString.Char8 as B
-import qualified Data.Graph as G
-import qualified Data.Map.Strict as M
-import qualified Data.Sequence as Seq
-
-import Reach.Util
-import Reach.Compiler(CompilerOpts, output, source)
 
 -- Helpers
 zipEq :: SrcLoc -> (Int -> Int -> CompilerError s) -> [a] -> [b] -> [(a, b)]
 zipEq at ce x y =
-  if lx == ly then zip x y
-  else expect_throw at (ce lx ly)
-  where lx = length x
-        ly = length y
+  if lx == ly
+    then zip x y
+    else expect_throw at (ce lx ly)
+  where
+    lx = length x
+    ly = length y
 
 foldlk :: (b -> ans) -> (b -> a -> (b -> ans) -> ans) -> b -> [a] -> ans
 foldlk k f z l =
   case l of
     [] -> k z
-    (x:l') -> f z x k'
-      where k' z' = foldlk k f z' l'
+    (x : l') -> f z x k'
+      where
+        k' z' = foldlk k f z' l'
 
 foldrk :: (b -> ans) -> (a -> b -> (b -> ans) -> ans) -> b -> [a] -> ans
 foldrk k f z l =
   case l of
     [] -> k z
-    (x:l') -> foldrk k' f z l'
-      where k' z' = f x z' k
+    (x : l') -> foldrk k' f z l'
+      where
+        k' z' = f x z' k
 
 -- JavaScript Helpers
 jscl_flatten :: JSCommaList a -> [a]
@@ -57,13 +60,14 @@ jscl_flatten (JSLOne a) = [a]
 jscl_flatten (JSLNil) = []
 
 jsctl_flatten :: JSCommaTrailingList a -> [a]
-jsctl_flatten (JSCTLComma a _) = jscl_flatten  a
-jsctl_flatten (JSCTLNone a) = jscl_flatten  a
+jsctl_flatten (JSCTLComma a _) = jscl_flatten a
+jsctl_flatten (JSCTLNone a) = jscl_flatten a
 
 jsa_flatten :: [JSArrayElement] -> [JSExpression]
 jsa_flatten a = concatMap f a
-  where f (JSArrayComma _) = []
-        f (JSArrayElement e) = [e]
+  where
+    f (JSArrayComma _) = []
+    f (JSArrayElement e) = [e]
 
 jse_expect_id :: SrcLoc -> JSExpression -> String
 jse_expect_id at j =
@@ -85,17 +89,18 @@ parseJSArrowFormals at aformals =
 
 jsStmtToExpr :: JSAnnot -> JSStatement -> JSExpression
 jsStmtToExpr a bodys = ce
-  where ce = JSCallExpression rator a rands a
-        rator = JSArrowExpression aformals a bodys
-        aformals = JSParenthesizedArrowParameterList a args a
-        args = JSLNil
-        rands = JSLNil
+  where
+    ce = JSCallExpression rator a rands a
+    rator = JSArrowExpression aformals a bodys
+    aformals = JSParenthesizedArrowParameterList a args a
+    args = JSLNil
+    rands = JSLNil
 
 -- Static Language
 data ReachSource
   = ReachStdLib
   | ReachSourceFile FilePath
-  deriving (Eq,Ord)
+  deriving (Eq, Ord)
 
 instance Show ReachSource where
   show ReachStdLib = "reach standard library"
@@ -103,19 +108,23 @@ instance Show ReachSource where
 
 instance Ord TokenPosn where
   compare (TokenPn x_a x_l x_c) (TokenPn y_a y_l y_c) =
-    compare [x_a, x_l, x_c] [y_a, y_l, y_c] 
+    compare [x_a, x_l, x_c] [y_a, y_l, y_c]
 
 data SrcLoc = SrcLoc (Maybe String) (Maybe TokenPosn) (Maybe ReachSource)
-  deriving (Eq,Ord)
+  deriving (Eq, Ord)
 
 instance Show SrcLoc where
-  show (SrcLoc mlab mtp mrs) = concat $ intersperse ":" $ concat [ sr, loc, lab ]
-    where lab = case mlab of Nothing -> []
-                             Just s -> [s]
-          sr = case mrs of Nothing -> []
-                           Just s -> [show s]
-          loc = case mtp of Nothing -> []
-                            Just (TokenPn _ l c) -> [show l, show c]
+  show (SrcLoc mlab mtp mrs) = concat $ intersperse ":" $ concat [sr, loc, lab]
+    where
+      lab = case mlab of
+        Nothing -> []
+        Just s -> [s]
+      sr = case mrs of
+        Nothing -> []
+        Just s -> [show s]
+      loc = case mtp of
+        Nothing -> []
+        Just (TokenPn _ l c) -> [show l, show c]
 
 srcloc_top :: SrcLoc
 srcloc_top = SrcLoc (Just "<top level>") Nothing Nothing
@@ -131,7 +140,7 @@ type SLVar = String
 data SecurityLevel
   = Secret
   | Public
-  deriving (Show,Eq)
+  deriving (Show, Eq)
 
 instance Semigroup SecurityLevel where
   Secret <> _ = Secret
@@ -151,9 +160,10 @@ data SLType
   | T_Obj (M.Map SLVar SLType)
   | T_Forall SLVar SLType
   | T_Var SLVar
-  deriving (Eq,Show,Ord)
+  deriving (Eq, Show, Ord)
 
 infix 9 -->
+
 (-->) :: [SLType] -> SLType -> SLType
 dom --> rng = T_Fun dom rng
 
@@ -169,24 +179,24 @@ data SLVal
   | SLV_Clo SrcLoc (Maybe SLVar) [SLVar] JSBlock SLEnv
   | SLV_DLVar DLVar
   | SLV_Type SLType
-  --- XXX Add something about whether it's bound?
-  | SLV_Participant SrcLoc SLPart SLVal
+  | --- XXX Add something about whether it's bound?
+    SLV_Participant SrcLoc SLPart SLVal
   | SLV_Prim SLPrimitive
   | SLV_Form SLForm
-  deriving (Eq,Show)
+  deriving (Eq, Show)
 
 data ToConsensusMode
   = TCM_Publish
   | TCM_Pay
   | TCM_Timeout
-  deriving (Eq,Show)
+  deriving (Eq, Show)
 
 data SLForm
   = SLForm_Part_Only SLVal
-  --- XXX Maybe should be DLVar
-  | SLForm_Part_ToConsensus SLPart (Maybe ToConsensusMode) (Maybe [SLVar]) (Maybe SLVar) (Maybe SLVar)
+  | --- XXX Maybe should be DLVar
+    SLForm_Part_ToConsensus SLPart (Maybe ToConsensusMode) (Maybe [SLVar]) (Maybe SLVar) (Maybe SLVar)
   | SLForm_Part_OnlyAns SLPart SLEnv SLVal
-  deriving (Eq,Show)
+  deriving (Eq, Show)
 
 data ConsensusPrimOp
   = ADD
@@ -208,12 +218,12 @@ data ConsensusPrimOp
   | BAND
   | BIOR
   | BXOR
-  deriving (Show,Eq,Ord)
+  deriving (Show, Eq, Ord)
 
 data PrimOp
   = CP ConsensusPrimOp
   | RANDOM
-  deriving (Show,Eq,Ord)
+  deriving (Show, Eq, Ord)
 
 primOpType :: PrimOp -> SLType
 primOpType (CP ADD) = [T_UInt256, T_UInt256] --> T_UInt256
@@ -249,7 +259,7 @@ data SLPrimitive
   | SLPrim_DApp
   | SLPrim_DApp_Delay SrcLoc [SLVal] SLEnv
   | SLPrim_op PrimOp
-  deriving (Eq,Show)
+  deriving (Eq, Show)
 
 type SLEnv = M.Map SLVar SLVal
 
@@ -257,20 +267,25 @@ mt_env :: SLEnv
 mt_env = mempty
 
 base_env :: SLEnv
-base_env = M.fromList
-  [ ("makeEnum", SLV_Prim SLPrim_makeEnum)
-  , ("declassify", SLV_Prim SLPrim_declassify)
-  , ("commit", SLV_Prim SLPrim_commit)
-  , ("assume", SLV_Prim SLPrim_assume)
-  , ("Null", SLV_Type T_Null)
-  , ("Bool", SLV_Type T_Bool)
-  , ("UInt256", SLV_Type T_UInt256)
-  , ("Bytes", SLV_Type T_Bytes)
-  , ("Array", SLV_Prim SLPrim_Array)
-  , ("Fun", SLV_Prim SLPrim_Fun)
-  , ("Reach", (SLV_Object srcloc_top $
-               M.fromList
-                [ ("DApp", SLV_Prim SLPrim_DApp) ]))]
+base_env =
+  M.fromList
+    [ ("makeEnum", SLV_Prim SLPrim_makeEnum),
+      ("declassify", SLV_Prim SLPrim_declassify),
+      ("commit", SLV_Prim SLPrim_commit),
+      ("assume", SLV_Prim SLPrim_assume),
+      ("Null", SLV_Type T_Null),
+      ("Bool", SLV_Type T_Bool),
+      ("UInt256", SLV_Type T_UInt256),
+      ("Bytes", SLV_Type T_Bytes),
+      ("Array", SLV_Prim SLPrim_Array),
+      ("Fun", SLV_Prim SLPrim_Fun),
+      ( "Reach",
+        ( SLV_Object srcloc_top $
+            M.fromList
+              [("DApp", SLV_Prim SLPrim_DApp)]
+        )
+      )
+    ]
 
 env_insert :: HasCallStack => SrcLoc -> SLVar -> SLVal -> SLEnv -> SLEnv
 env_insert at k v env =
@@ -298,23 +313,23 @@ data DLConstant
   | DLC_Bool Bool
   | DLC_Int Int
   | DLC_Bytes B.ByteString
-  deriving (Eq,Show,Ord)
+  deriving (Eq, Show, Ord)
 
 data DLVar = DLVar SrcLoc String SLType Int
-  deriving (Eq,Show,Ord)
+  deriving (Eq, Show, Ord)
 
 data DLArg
   = DLA_Var DLVar
   | DLA_Con DLConstant
   | DLA_Array [DLArg]
   | DLA_Obj (M.Map String DLArg)
-  deriving (Eq,Show)
+  deriving (Eq, Show)
 
 data DLExpr
   = DLE_PrimOp SrcLoc PrimOp [DLArg]
   | DLE_ArrayRef SrcLoc DLArg DLArg
   | DLE_Interact SrcLoc String [DLArg]
-  deriving (Eq,Show)
+  deriving (Eq, Show)
 
 expr_pure :: DLExpr -> Bool
 expr_pure e =
@@ -324,25 +339,25 @@ expr_pure e =
     DLE_Interact _ _ _ -> False
 
 data ClaimType
-  = CT_Assert   --- Verified on all paths
-  | CT_Assume   --- Always assumed true
-  | CT_Require  --- Verified in honest, assumed in dishonest. (This may
-                --- sound backwards, but by verifying it in honest
-                --- mode, then we are checking that the other
-                --- participants fulfill the promise when acting
-                --- honestly.)
+  = CT_Assert --- Verified on all paths
+  | CT_Assume --- Always assumed true
+  | CT_Require --- Verified in honest, assumed in dishonest. (This may
+  --- sound backwards, but by verifying it in honest
+  --- mode, then we are checking that the other
+  --- participants fulfill the promise when acting
+  --- honestly.)
   | CT_Possible --- Check if an assignment of variables exists to make
-                --- this true.
-  deriving (Show,Eq,Ord)
-           
+  --- this true.
+  deriving (Show, Eq, Ord)
+
 data DLStmt
   = DLS_Let SrcLoc DLVar DLExpr
-  | DLS_Claim SrcLoc [ SLCtxtFrame ] ClaimType DLArg
+  | DLS_Claim SrcLoc [SLCtxtFrame] ClaimType DLArg
   | DLS_If SrcLoc DLArg DLStmts DLStmts
-  --- XXX These are only allowed in Steps... some sort of dep type?
-  | DLS_Only SrcLoc SLPart DLStmts
+  | --- XXX These are only allowed in Steps... some sort of dep type?
+    DLS_Only SrcLoc SLPart DLStmts
   | DLS_All SrcLoc DLStmt
-  deriving (Eq,Show)
+  deriving (Eq, Show)
 
 stmt_pure :: DLStmt -> Bool
 stmt_pure s =
@@ -367,12 +382,13 @@ tp JSNoAnnot = Nothing
 srcloc_jsa :: String -> JSAnnot -> SrcLoc -> SrcLoc
 srcloc_jsa lab a at = srcloc_at lab (tp a) at
 
-srcloc_after_semi :: String -> JSAnnot -> JSSemi -> SrcLoc -> SrcLoc 
+srcloc_after_semi :: String -> JSAnnot -> JSSemi -> SrcLoc -> SrcLoc
 srcloc_after_semi lab a sp at =
   case sp of
     JSSemi x -> srcloc_jsa (alab ++ " semicolon") x at
     _ -> srcloc_jsa alab a at
-  where alab = "after " ++ lab
+  where
+    alab = "after " ++ lab
 
 --- XXX Maybe this is dumb
 data CompilerError s
@@ -400,7 +416,7 @@ data CompilerError s
   | Err_Eval_NotApplicable SLVal
   | Err_Eval_NotApplicableVals SLVal
   | Err_Eval_NotObject SLVal
-  | Err_Eval_RefEmptyArray 
+  | Err_Eval_RefEmptyArray
   | Err_Eval_RefOutOfBounds Int Int
   | Err_Eval_RefNotArray SLVal
   | Err_Eval_RefNotInt SLVal
@@ -437,7 +453,7 @@ data CompilerError s
   | Err_Type_NotApplicable SLType
   | Err_Type_TooFewArguments [SLType]
   | Err_Type_TooManyArguments [SLVal]
-  deriving (Eq,Show)
+  deriving (Eq, Show)
 
 --- XXX Add ctxt frame stack and display
 expect_throw :: HasCallStack => SrcLoc -> CompilerError s -> b
@@ -445,9 +461,11 @@ expect_throw src ce = error $ "error: " ++ (show src) ++ ": " ++ (take 512 $ sho
 
 -- Parser
 type BundleMap a b = ((M.Map a [a]), (M.Map a (Maybe b)))
+
 type JSBundleMap = BundleMap ReachSource [JSModuleItem]
-data JSBundle = JSBundle [(ReachSource,[JSModuleItem])]
-  deriving (Eq,Show)
+
+data JSBundle = JSBundle [(ReachSource, [JSModuleItem])]
+  deriving (Eq, Show)
 
 gatherDeps_imd :: SrcLoc -> IORef JSBundleMap -> JSImportDeclaration -> IO JSImportDeclaration
 gatherDeps_imd at fmr j =
@@ -486,10 +504,10 @@ updatePartialAvoidCycles at fmr mfrom def_a get_key ret_key err_key proc_key = d
       content <- proc_key key
       (dm', fm') <- readIORef fmr
       let fm'' = (M.insert key (Just content) fm')
-          add_key ml = Just $ key : (maybe [] (\x->x) ml)
+          add_key ml = Just $ key : (maybe [] (\x -> x) ml)
           dm'' = case mfrom of
-                   Just from -> (M.alter add_key from dm')
-                   Nothing -> dm'
+            Just from -> (M.alter add_key from dm')
+            Nothing -> dm'
       writeIORef fmr (dm'', fm'')
       return res
     Just Nothing ->
@@ -503,20 +521,22 @@ gatherDeps_from (SrcLoc _ _ mrs) = mrs
 gatherDeps_file :: SrcLoc -> IORef JSBundleMap -> FilePath -> IO FilePath
 gatherDeps_file at fmr src_rel =
   updatePartialAvoidCycles at fmr (gatherDeps_from at) [ReachStdLib] get_key ret_key err_key proc_key
-  where get_key () = do
-          src_abs <- makeAbsolute src_rel
-          return $ ReachSourceFile src_abs
-        ret_key (ReachSourceFile x) = x
-        ret_key (ReachStdLib) = no_stdlib
-        no_stdlib = impossible $ "gatherDeps_file: source file became stdlib"
-        err_key x = Err_Parse_CyclicImport x
-        proc_key (ReachStdLib) = no_stdlib
-        proc_key src@(ReachSourceFile src_abs) = do
-          let at' = srcloc_src src
-          setLocaleEncoding utf8
-          content <- readFile src_abs
-          withCurrentDirectory (takeDirectory src_abs)
-            (gatherDeps_ast at' fmr $ readJsModule content)
+  where
+    get_key () = do
+      src_abs <- makeAbsolute src_rel
+      return $ ReachSourceFile src_abs
+    ret_key (ReachSourceFile x) = x
+    ret_key (ReachStdLib) = no_stdlib
+    no_stdlib = impossible $ "gatherDeps_file: source file became stdlib"
+    err_key x = Err_Parse_CyclicImport x
+    proc_key (ReachStdLib) = no_stdlib
+    proc_key src@(ReachSourceFile src_abs) = do
+      let at' = srcloc_src src
+      setLocaleEncoding utf8
+      content <- readFile src_abs
+      withCurrentDirectory
+        (takeDirectory src_abs)
+        (gatherDeps_ast at' fmr $ readJsModule content)
 
 stdlib_str :: String
 stdlib_str = $(embedStringFile "./rsh/stdlib.rsh")
@@ -524,20 +544,22 @@ stdlib_str = $(embedStringFile "./rsh/stdlib.rsh")
 gatherDeps_stdlib :: SrcLoc -> IORef JSBundleMap -> IO ()
 gatherDeps_stdlib at fmr =
   updatePartialAvoidCycles at fmr (gatherDeps_from at) [] get_key ret_key err_key proc_key
-  where get_key () = return $ ReachStdLib
-        ret_key _ = ()
-        err_key x = Err_Parse_CyclicImport x
-        proc_key _ = do
-          let at' = srcloc_src ReachStdLib
-          (gatherDeps_ast at' fmr $ readJsModule stdlib_str)
+  where
+    get_key () = return $ ReachStdLib
+    ret_key _ = ()
+    err_key x = Err_Parse_CyclicImport x
+    proc_key _ = do
+      let at' = srcloc_src ReachStdLib
+      (gatherDeps_ast at' fmr $ readJsModule stdlib_str)
 
 map_order :: Ord a => M.Map a [a] -> [a]
 map_order dm = order
-  where order = map (getNodePart . nodeFromVertex) order_v
-        order_v = G.topSort graph
-        (graph, nodeFromVertex, _vertexFromKey) = G.graphFromEdges edgeList
-        edgeList = map (\(from,to) -> (from,from,to)) $ M.toList dm
-        getNodePart (n, _, _) = n
+  where
+    order = map (getNodePart . nodeFromVertex) order_v
+    order_v = G.topSort graph
+    (graph, nodeFromVertex, _vertexFromKey) = G.graphFromEdges edgeList
+    edgeList = map (\(from, to) -> (from, from, to)) $ M.toList dm
+    getNodePart (n, _, _) = n
 
 gatherDeps_top :: FilePath -> IO JSBundle
 gatherDeps_top src_p = do
@@ -547,15 +569,17 @@ gatherDeps_top src_p = do
   gatherDeps_stdlib at fmr
   (dm, fm) <- readIORef fmr
   return $ JSBundle $ map (\k -> (k, ensureJust (fm M.! k))) $ map_order dm
-  where ensureJust Nothing = impossible "gatherDeps: Did not close all Reach files"
-        ensureJust (Just x) = x
+  where
+    ensureJust Nothing = impossible "gatherDeps: Did not close all Reach files"
+    ensureJust (Just x) = x
 
 -- Compiler
 
 data SLCtxt s = SLCtxt
-  { ctxt_mode :: SLCtxtMode
-  , ctxt_id :: Maybe (STRef s Int)
-  , ctxt_stack :: [ SLCtxtFrame ] }
+  { ctxt_mode :: SLCtxtMode,
+    ctxt_id :: Maybe (STRef s Int),
+    ctxt_stack :: [SLCtxtFrame]
+  }
   deriving (Eq)
 
 instance Show (SLCtxt s) where
@@ -574,8 +598,8 @@ data SLCtxtMode
 ctxt_alloc :: SLCtxt s -> SrcLoc -> ST s Int
 ctxt_alloc ctxt at = do
   let idr = case ctxt_id ctxt of
-              Just x -> x
-              Nothing -> expect_throw at $ Err_Eval_IllegalLift ctxt
+        Just x -> x
+        Nothing -> expect_throw at $ Err_Eval_IllegalLift ctxt
   x <- readSTRef idr
   writeSTRef idr $ x + 1
   return x
@@ -604,7 +628,7 @@ type SLCPSd s = SLKont s -> ST s SLRes
 
 ctxt_stack_push :: SLCtxt s -> SLCtxtFrame -> SLCtxt s
 ctxt_stack_push ctxt f =
-  (ctxt { ctxt_stack = f : (ctxt_stack ctxt) })
+  (ctxt {ctxt_stack = f : (ctxt_stack ctxt)})
 
 binaryToPrim :: SrcLoc -> SLEnv -> JSBinOp -> SLVal
 binaryToPrim at env o =
@@ -630,8 +654,9 @@ binaryToPrim at env o =
     JSBinOpBitOr a -> prim a (CP BIOR)
     JSBinOpBitXor a -> prim a (CP BXOR)
     j -> expect_throw at $ Err_Parse_IllegalBinOp j
-  where fun a s = env_lookup (srcloc_jsa "binop" a at) s env
-        prim _a p = SLV_Prim $ SLPrim_op p
+  where
+    fun a s = env_lookup (srcloc_jsa "binop" a at) s env
+    prim _a p = SLV_Prim $ SLPrim_op p
 
 unaryToPrim :: SrcLoc -> SLEnv -> JSUnaryOp -> SLVal
 unaryToPrim at env o =
@@ -639,7 +664,8 @@ unaryToPrim at env o =
     JSUnaryOpMinus a -> fun a "minus"
     JSUnaryOpNot a -> fun a "not"
     j -> expect_throw at $ Err_Parse_IllegalUnaOp j
-  where fun a s = env_lookup (srcloc_jsa "unop" a at) s env
+  where
+    fun a s = env_lookup (srcloc_jsa "unop" a at) s env
 
 typeOf :: SrcLoc -> SLVal -> (SLType, DLArg)
 typeOf at v =
@@ -649,20 +675,23 @@ typeOf at v =
     SLV_Int _ i -> (T_UInt256, DLA_Con $ DLC_Int i)
     SLV_Bytes _ bs -> (T_Bytes, DLA_Con $ DLC_Bytes bs)
     SLV_Array at' vs -> (T_Array ts, DLA_Array das)
-      where tdas = map (typeOf at') vs
-            ts = map fst tdas
-            das = map snd tdas
+      where
+        tdas = map (typeOf at') vs
+        ts = map fst tdas
+        das = map snd tdas
     SLV_Object at' fenv -> (T_Obj tenv, DLA_Obj aenv)
-      where cenv = M.map (typeOf at') fenv
-            tenv = M.map fst cenv
-            aenv = M.map snd cenv
+      where
+        cenv = M.map (typeOf at') fenv
+        tenv = M.map fst cenv
+        aenv = M.map snd cenv
     SLV_Clo _ _ _ _ _ -> none
     SLV_DLVar dv@(DLVar _ _ t _) -> (t, DLA_Var dv)
     SLV_Type _ -> none
     SLV_Participant _ _ _ -> none --- XXX get the address
     SLV_Prim _ -> none --- XXX interacts may work
     SLV_Form _ -> none
-  where none = expect_throw at $ Err_Type_None v
+  where
+    none = expect_throw at $ Err_Type_None v
 
 type TypeEnv s = M.Map SLVar (STRef s (Maybe SLType))
 
@@ -688,23 +717,24 @@ typeCheck_help at env ty val val_ty res =
         True -> return res
         False ->
           expect_throw at $ Err_Type_Mismatch ty val_ty val
-  
+
 typeCheck :: SrcLoc -> TypeEnv s -> SLType -> SLVal -> ST s DLArg
 typeCheck at env ty val = typeCheck_help at env ty val val_ty res
-  where (val_ty, res) = typeOf at val
-  
+  where
+    (val_ty, res) = typeOf at val
+
 typeChecks :: SrcLoc -> TypeEnv s -> [SLType] -> [SLVal] -> ST s [DLArg]
 typeChecks at env ts vs =
   case (ts, vs) of
     ([], []) ->
       return []
-    ((t:ts'), (v:vs')) -> do
+    ((t : ts'), (v : vs')) -> do
       d <- typeCheck at env t v
       ds' <- typeChecks at env ts' vs'
       return $ d : ds'
-    ((_:_), _) ->
+    ((_ : _), _) ->
       expect_throw at $ Err_Type_TooFewArguments ts
-    (_, (_:_)) ->
+    (_, (_ : _)) ->
       expect_throw at $ Err_Type_TooManyArguments vs
 
 checkAndConvert_i :: SrcLoc -> TypeEnv s -> SLType -> [SLVal] -> ST s (SLType, [DLArg])
@@ -743,8 +773,9 @@ evalDot at obj field =
         _ -> illegal_field
     v ->
       expect_throw at (Err_Eval_NotObject v)
-  where illegal_field =
-          expect_throw at (Err_Dot_InvalidField obj field)
+  where
+    illegal_field =
+      expect_throw at (Err_Dot_InvalidField obj field)
 
 evalForm :: SLCtxt s -> SrcLoc -> SLEnv -> SLForm -> [JSExpression] -> SLCPSd s
 evalForm ctxt at env f args k =
@@ -754,13 +785,16 @@ evalForm ctxt at env f args k =
         SLC_Step penvs -> do
           --- XXX remove do
           let penv = penvs M.! who
-          let k' elifts eargs =                
+          let k' elifts eargs =
                 case eargs of
-                  [ thunk ] -> do
+                  [thunk] -> do
                     let ctxt_localstep =
-                          (SLCtxt { ctxt_mode = SLC_LocalStep
-                                  , ctxt_id = ctxt_id ctxt
-                                  , ctxt_stack = ctxt_stack ctxt })
+                          ( SLCtxt
+                              { ctxt_mode = SLC_LocalStep,
+                                ctxt_id = ctxt_id ctxt,
+                                ctxt_stack = ctxt_stack ctxt
+                              }
+                          )
                     let k'' (SLRes alifts penv' ans) = do
                           traceM $ "penv' update = " ++ (show $ M.keys $ M.difference penv' penv)
                           k $ SLRes (elifts <> alifts) env $ SLV_Form $ SLForm_Part_OnlyAns who penv' ans
@@ -771,9 +805,12 @@ evalForm ctxt at env f args k =
                   SLRes elifts _ (SLV_Array _ eargs) -> k' elifts eargs
                   _ -> impossible "evalExprs did not return array"
           let ctxt_local =
-                (SLCtxt { ctxt_mode = SLC_Local
-                        , ctxt_id = ctxt_id ctxt
-                        , ctxt_stack = ctxt_stack ctxt })
+                ( SLCtxt
+                    { ctxt_mode = SLC_Local,
+                      ctxt_id = ctxt_id ctxt,
+                      ctxt_stack = ctxt_stack ctxt
+                    }
+                )
           evalExprs ctxt_local at penv args k'_res
         _ -> expect_throw at $ Err_Eval_IllegalContext ctxt "part.only"
     SLForm_Part_Only _ -> impossible "SLForm_Part_Only args"
@@ -785,7 +822,8 @@ evalForm ctxt at env f args k =
             Just TCM_Publish ->
               case mpub of
                 Nothing -> retV $ SLV_Form $ SLForm_Part_ToConsensus who Nothing (Just msg) mpay mtime
-                  where msg = map (jse_expect_id at) args
+                  where
+                    msg = map (jse_expect_id at) args
                 Just _ ->
                   expect_throw at $ Err_ToConsensus_Double TCM_Publish
             Just TCM_Pay ->
@@ -795,9 +833,10 @@ evalForm ctxt at env f args k =
             Nothing ->
               expect_throw at $ Err_Eval_NotApplicable rator
         _ -> expect_throw at $ Err_Eval_IllegalContext ctxt "toConsensus"
-  where illegal_args = expect_throw at (Err_Form_InvalidArgs f args)
-        rator = SLV_Form f
-        retV v = k $ SLRes mempty env v
+  where
+    illegal_args = expect_throw at (Err_Form_InvalidArgs f args)
+    rator = SLV_Form f
+    retV v = k $ SLRes mempty env v
 
 evalPrimOp :: SLCtxt s -> SrcLoc -> SLEnv -> PrimOp -> [SLVal] -> SLCPSd s
 evalPrimOp ctxt at env p args k =
@@ -841,29 +880,31 @@ evalPrim ctxt at env p args k =
       evalPrimOp ctxt at env op args k
     SLPrim_Fun ->
       case args of
-        [ (SLV_Array _ dom_arr), (SLV_Type rng) ] ->
+        [(SLV_Array _ dom_arr), (SLV_Type rng)] ->
           retV $ SLV_Type $ T_Fun dom rng
-          where dom = map expect_ty dom_arr
+          where
+            dom = map expect_ty dom_arr
         _ -> illegal_args
     SLPrim_Array ->
       retV $ SLV_Type $ T_Array $ map expect_ty args
     SLPrim_makeEnum ->
       case args of
-        [ SLV_Int _ i ] ->
-          retV $ SLV_Array at' (enum_pred : map (SLV_Int at') [ 0 .. (i-1) ])
-          where at' = (srcloc_at "makeEnum" Nothing at)
-                --- FIXME This sucks... maybe parse an embed string? Would that suck less?
-                enum_pred = SLV_Clo at' fname ["x"] pbody mempty
-                fname = Nothing --- FIXME syntax-local-infer-name
-                pbody = JSBlock JSNoAnnot [(JSReturn JSNoAnnot (Just (JSExpressionBinary lhs (JSBinOpAnd JSNoAnnot) rhs)) JSSemiAuto)] JSNoAnnot
-                lhs = (JSExpressionBinary (JSDecimal JSNoAnnot "0") (JSBinOpLe JSNoAnnot) (JSIdentifier JSNoAnnot "x"))
-                rhs = (JSExpressionBinary (JSIdentifier JSNoAnnot "x") (JSBinOpLt JSNoAnnot) (JSDecimal JSNoAnnot (show i)))
+        [SLV_Int _ i] ->
+          retV $ SLV_Array at' (enum_pred : map (SLV_Int at') [0 .. (i -1)])
+          where
+            at' = (srcloc_at "makeEnum" Nothing at)
+            --- FIXME This sucks... maybe parse an embed string? Would that suck less?
+            enum_pred = SLV_Clo at' fname ["x"] pbody mempty
+            fname = Nothing --- FIXME syntax-local-infer-name
+            pbody = JSBlock JSNoAnnot [(JSReturn JSNoAnnot (Just (JSExpressionBinary lhs (JSBinOpAnd JSNoAnnot) rhs)) JSSemiAuto)] JSNoAnnot
+            lhs = (JSExpressionBinary (JSDecimal JSNoAnnot "0") (JSBinOpLe JSNoAnnot) (JSIdentifier JSNoAnnot "x"))
+            rhs = (JSExpressionBinary (JSIdentifier JSNoAnnot "x") (JSBinOpLt JSNoAnnot) (JSDecimal JSNoAnnot (show i)))
         _ -> illegal_args
     SLPrim_DApp ->
       case ctxt_mode ctxt of
         SLC_Module ->
           case args of
-            [ (SLV_Object _ _), (SLV_Array _ _), (SLV_Clo _ _ _ _ _) ] ->
+            [(SLV_Object _ _), (SLV_Array _ _), (SLV_Clo _ _ _ _ _)] ->
               retV $ SLV_Prim $ SLPrim_DApp_Delay at args env
             _ -> illegal_args
         _ ->
@@ -880,32 +921,34 @@ evalPrim ctxt at env p args k =
           expect_throw at (Err_Eval_IllegalContext ctxt "interact")
     SLPrim_declassify ->
       case args of
-        [ val ] ->
+        [val] ->
           --- XXX do declassify
           retV $ val
         _ -> illegal_args
     SLPrim_commit ->
       case args of
-        [ ] -> retV $ SLV_Prim SLPrim_committed
+        [] -> retV $ SLV_Prim SLPrim_committed
         _ -> illegal_args
     SLPrim_committed -> illegal_args
     SLPrim_assume ->
       case ctxt_mode ctxt of
         SLC_LocalStep ->
           k $ SLRes lifts env $ SLV_Null at
-          where darg =
-                  case checkAndConvert at (T_Fun [T_Bool] T_Null) args of
-                    (_, [x]) -> x
-                    _ -> illegal_args
-                lifts = return (DLS_Claim at (ctxt_stack ctxt) CT_Assume darg)
+          where
+            darg =
+              case checkAndConvert at (T_Fun [T_Bool] T_Null) args of
+                (_, [x]) -> x
+                _ -> illegal_args
+            lifts = return (DLS_Claim at (ctxt_stack ctxt) CT_Assume darg)
         _ -> illegal_args
-  where illegal_args = expect_throw at (Err_Prim_InvalidArgs p args)
-        retV v = k $ SLRes mempty env v
-        rator = SLV_Prim p
-        expect_ty v =
-          case v of
-            SLV_Type t -> t
-            _ -> illegal_args
+  where
+    illegal_args = expect_throw at (Err_Prim_InvalidArgs p args)
+    retV v = k $ SLRes mempty env v
+    rator = SLV_Prim p
+    expect_ty v =
+      case v of
+        SLV_Type t -> t
+        _ -> illegal_args
 
 evalApplyVals :: SLCtxt s -> SrcLoc -> SLEnv -> SLVal -> [SLVal] -> SLCPSd s
 evalApplyVals ctxt at env rator randvs k =
@@ -914,10 +957,11 @@ evalApplyVals ctxt at env rator randvs k =
       evalPrim ctxt at env p randvs k
     SLV_Clo clo_at mname formals (JSBlock body_a body _) clo_env ->
       evalStmt ctxt' body_at env' body k
-      where body_at = srcloc_jsa "block" body_a clo_at
-            env' = foldl' (env_insertp clo_at) clo_env kvs
-            kvs = zipEq clo_at Err_Apply_ArgCount formals randvs
-            ctxt' = ctxt_stack_push ctxt (SLC_CloApp at clo_at mname)
+      where
+        body_at = srcloc_jsa "block" body_a clo_at
+        env' = foldl' (env_insertp clo_at) clo_env kvs
+        kvs = zipEq clo_at Err_Apply_ArgCount formals randvs
+        ctxt' = ctxt_stack_push ctxt (SLC_CloApp at clo_at mname)
     v ->
       expect_throw at (Err_Eval_NotApplicableVals v)
 
@@ -928,9 +972,10 @@ evalApply ctxt at env rator rands k =
     SLV_Clo _ _ _ _ _ -> vals
     SLV_Form f -> evalForm ctxt at env f rands k
     v -> expect_throw at (Err_Eval_NotApplicable v)
-  where vals = evalExprs ctxt at env rands k'
-        k' (SLRes rlifts _ (SLV_Array _ randvs)) = evalApplyVals ctxt at env rator randvs $ kKeepLifts rlifts k
-        k' _ = impossible "evalExprs didn't return Array"
+  where
+    vals = evalExprs ctxt at env rands k'
+    k' (SLRes rlifts _ (SLV_Array _ randvs)) = evalApplyVals ctxt at env rator randvs $ kKeepLifts rlifts k
+    k' _ = impossible "evalExprs didn't return Array"
 
 evalPropertyName :: SLCtxt s -> SrcLoc -> SLEnv -> JSPropertyName -> SLCPSd s
 evalPropertyName ctxt at env pn k =
@@ -939,49 +984,56 @@ evalPropertyName ctxt at env pn k =
     JSPropertyString _ s -> k_res $ trimQuotes s
     JSPropertyNumber an _ ->
       expect_throw at_n (Err_Obj_IllegalField pn)
-      where at_n = srcloc_jsa "number" an at
+      where
+        at_n = srcloc_jsa "number" an at
     JSPropertyComputed an e _ ->
       evalExpr ctxt at_n env e k
-      where at_n = srcloc_jsa "computed field name" an at
-  where k_res s = k $ SLRes mempty env $ SLV_Bytes at $ bpack s
+      where
+        at_n = srcloc_jsa "computed field name" an at
+  where
+    k_res s = k $ SLRes mempty env $ SLV_Bytes at $ bpack s
 
 evalPropertyPair :: SLCtxt s -> SrcLoc -> SLEnv -> SLRes -> JSObjectProperty -> SLCPSd s
 evalPropertyPair ctxt at env ores@(SLRes olifts _ ov) p k =
   case p of
     JSPropertyNameandValue pn a vs ->
       evalPropertyName ctxt at' env pn k_value
-      where at' = srcloc_jsa "property binding" a at
-            k_value (SLRes flifts _ fv) =
-              case fv of
-                SLV_Bytes _ fb ->
-                  case vs of
-                    [ e ] ->
-                      let f = B.unpack fb in
-                        evalExpr ctxt at' env e (kKeepLifts flifts $ k_insert flifts f)
-                    _ ->
-                      expect_throw at' (Err_Obj_IllegalFieldValues vs)
+      where
+        at' = srcloc_jsa "property binding" a at
+        k_value (SLRes flifts _ fv) =
+          case fv of
+            SLV_Bytes _ fb ->
+              case vs of
+                [e] ->
+                  let f = B.unpack fb
+                   in evalExpr ctxt at' env e (kKeepLifts flifts $ k_insert flifts f)
                 _ ->
-                  expect_throw at' $ Err_Obj_IllegalComputedField fv
-            k_insert flifts f (SLRes vlifts _ v) =
-              k $ SLRes (olifts <> flifts <> vlifts) env $ SLV_Object at $ env_insert at' f v fenv
+                  expect_throw at' (Err_Obj_IllegalFieldValues vs)
+            _ ->
+              expect_throw at' $ Err_Obj_IllegalComputedField fv
+        k_insert flifts f (SLRes vlifts _ v) =
+          k $ SLRes (olifts <> flifts <> vlifts) env $ SLV_Object at $ env_insert at' f v fenv
     JSPropertyIdentRef a v ->
       evalPropertyPair ctxt at env ores p' k
-      where p' = JSPropertyNameandValue pn a vs
-            pn = JSPropertyIdent a v
-            vs = [ JSIdentifier a v ]
+      where
+        p' = JSPropertyNameandValue pn a vs
+        pn = JSPropertyIdent a v
+        vs = [JSIdentifier a v]
     JSObjectSpread a se ->
       evalExpr ctxt at' env se k'
-      where k' (SLRes slifts _ sv) =
-              case sv of
-                SLV_Object _ senv ->
-                  k $ SLRes (olifts <> slifts) env $ SLV_Object at $ env_merge at' fenv senv
-                _ -> expect_throw at (Err_Obj_SpreadNotObj sv)
-            at' = srcloc_jsa "...obj" a at
+      where
+        k' (SLRes slifts _ sv) =
+          case sv of
+            SLV_Object _ senv ->
+              k $ SLRes (olifts <> slifts) env $ SLV_Object at $ env_merge at' fenv senv
+            _ -> expect_throw at (Err_Obj_SpreadNotObj sv)
+        at' = srcloc_jsa "...obj" a at
     _ ->
       expect_throw at (Err_Obj_IllegalJS p)
-  where fenv = case ov of
-                 (SLV_Object _ x) -> x
-                 _ -> impossible "evalPropertyPair not given SLV_Object"
+  where
+    fenv = case ov of
+      (SLV_Object _ x) -> x
+      _ -> impossible "evalPropertyPair not given SLV_Object"
 
 evalExpr :: SLCtxt s -> SrcLoc -> SLEnv -> JSExpression -> SLCPSd s
 evalExpr ctxt at env e k =
@@ -994,13 +1046,15 @@ evalExpr ctxt at env e k =
         "true" -> retV $ SLV_Bool at' True
         "false" -> retV $ SLV_Bool at' False
         _ -> expect_throw at' (Err_Parse_IllegalLiteral l)
-      where at' = (srcloc_jsa "literal" a at)
+      where
+        at' = (srcloc_jsa "literal" a at)
     JSHexInteger a ns -> retV $ SLV_Int (srcloc_jsa "hex" a at) $ numberValue 16 ns
     JSOctal a ns -> retV $ SLV_Int (srcloc_jsa "octal" a at) $ numberValue 8 ns
     JSStringLiteral a s -> retV $ SLV_Bytes (srcloc_jsa "string" a at) (bpack (trimQuotes s))
     JSRegEx _ _ -> illegal
     JSArrayLiteral a as _ -> evalExprs ctxt at' env (jsa_flatten as) k
-      where at' = (srcloc_jsa "array" a at)
+      where
+        at' = (srcloc_jsa "array" a at)
     JSAssignExpression _ _ _ -> illegal
     JSAwaitExpression _ _ -> illegal
     JSCallExpression rator a rands _ -> doCall rator a $ jscl_flatten rands
@@ -1008,47 +1062,51 @@ evalExpr ctxt at env e k =
     JSCallExpressionSquare arr a idx _ -> doRef arr a idx
     JSClassExpression _ _ _ _ _ _ -> illegal
     JSCommaExpression _ _ _ -> illegal
-    JSExpressionBinary lhs op rhs -> doCallV mempty (binaryToPrim at env op) JSNoAnnot [ lhs, rhs ]
+    JSExpressionBinary lhs op rhs -> doCallV mempty (binaryToPrim at env op) JSNoAnnot [lhs, rhs]
     JSExpressionParen a ie _ -> evalExpr ctxt (srcloc_jsa "paren" a at) env ie k
     JSExpressionPostfix _ _ -> illegal
     JSExpressionTernary ce a te _ fe ->
       evalExpr ctxt at' env ce k_c
-      where at' = srcloc_jsa "if" a at
-            k_c cr = evalExpr ctxt at' env te (k_t cr)
-            k_t cr ta = evalExpr ctxt at' env fe (k_fin cr ta)
-            k_fin (SLRes clifts _ cv) (SLRes tlifts _ tv) (SLRes flifts _ fv) =
-              case cv of
-                SLV_Bool _ cb -> do
-                  k $ SLRes (clifts <> elifts) env ev
-                  where (elifts, ev) = if cb then (tlifts, tv) else (flifts, fv)
-                SLV_DLVar dv@(DLVar _ _ T_Bool _) ->
-                  case stmts_pure tlifts && stmts_pure flifts of
-                    True ->
-                      evalPrim ctxt at mempty (SLPrim_op $ CP IF_THEN_ELSE) [ cv, tv, fv ] $ kKeepLifts (clifts <> tlifts <> flifts) k
-                    False -> do
-                      --- XXX A consensus must duplicate continuation but a local doesn't need to
-                      let ilifts = return $ DLS_If at (DLA_Var dv) tlifts flifts
-                      let lifts' = clifts <> ilifts
-                      --- XXX Don't ignore tv and fv
-                      expect_throw at' (Err_XXX $ "impure if " ++ show lifts')
-                _ ->
-                  expect_throw at' (Err_Eval_IfCondNotBool cv)
+      where
+        at' = srcloc_jsa "if" a at
+        k_c cr = evalExpr ctxt at' env te (k_t cr)
+        k_t cr ta = evalExpr ctxt at' env fe (k_fin cr ta)
+        k_fin (SLRes clifts _ cv) (SLRes tlifts _ tv) (SLRes flifts _ fv) =
+          case cv of
+            SLV_Bool _ cb -> do
+              k $ SLRes (clifts <> elifts) env ev
+              where
+                (elifts, ev) = if cb then (tlifts, tv) else (flifts, fv)
+            SLV_DLVar dv@(DLVar _ _ T_Bool _) ->
+              case stmts_pure tlifts && stmts_pure flifts of
+                True ->
+                  evalPrim ctxt at mempty (SLPrim_op $ CP IF_THEN_ELSE) [cv, tv, fv] $ kKeepLifts (clifts <> tlifts <> flifts) k
+                False -> do
+                  --- XXX A consensus must duplicate continuation but a local doesn't need to
+                  let ilifts = return $ DLS_If at (DLA_Var dv) tlifts flifts
+                  let lifts' = clifts <> ilifts
+                  --- XXX Don't ignore tv and fv
+                  expect_throw at' (Err_XXX $ "impure if " ++ show lifts')
+            _ ->
+              expect_throw at' (Err_Eval_IfCondNotBool cv)
     JSArrowExpression aformals a bodys ->
       retV $ SLV_Clo at' fname formals body env
-      where at' = srcloc_jsa "arrow" a at
-            fname = Nothing --- FIXME syntax-local-infer-name
-            body = case bodys of
-                     JSStatementBlock ba bodyss aa _ -> JSBlock ba bodyss aa
-                     _ -> JSBlock JSNoAnnot [bodys] JSNoAnnot
-            formals = parseJSArrowFormals at' aformals
+      where
+        at' = srcloc_jsa "arrow" a at
+        fname = Nothing --- FIXME syntax-local-infer-name
+        body = case bodys of
+          JSStatementBlock ba bodyss aa _ -> JSBlock ba bodyss aa
+          _ -> JSBlock JSNoAnnot [bodys] JSNoAnnot
+        formals = parseJSArrowFormals at' aformals
     JSFunctionExpression a name _ jsformals _ body ->
       retV $ SLV_Clo at' fname formals body env
-      where at' = srcloc_jsa "function exp" a at
-            fname =
-              case name of
-                JSIdentNone -> Nothing --- FIXME syntax-local-infer-name
-                JSIdentName na _ -> expect_throw (srcloc_jsa "function name" na at') Err_Fun_NamesIllegal
-            formals = parseJSFormals at' jsformals
+      where
+        at' = srcloc_jsa "function exp" a at
+        fname =
+          case name of
+            JSIdentNone -> Nothing --- FIXME syntax-local-infer-name
+            JSIdentName na _ -> expect_throw (srcloc_jsa "function name" na at') Err_Fun_NamesIllegal
+        formals = parseJSFormals at' jsformals
     JSGeneratorExpression _ _ _ _ _ _ _ -> illegal
     JSMemberDot obj a field -> doDot obj a field
     JSMemberExpression rator a rands _ -> doCall rator a $ jscl_flatten rands
@@ -1057,116 +1115,131 @@ evalExpr ctxt at env e k =
     JSNewExpression _ _ -> illegal
     JSObjectLiteral a plist _ ->
       foldlk k (evalPropertyPair ctxt at' env) (SLRes mempty env $ SLV_Object at' mempty) $ jsctl_flatten plist
-      where at' = srcloc_jsa "obj" a at
+      where
+        at' = srcloc_jsa "obj" a at
     JSSpreadExpression _ _ -> illegal
     JSTemplateLiteral _ _ _ _ -> illegal
-    JSUnaryExpression op ue -> doCallV mempty (unaryToPrim at env op) JSNoAnnot [ ue ]
+    JSUnaryExpression op ue -> doCallV mempty (unaryToPrim at env op) JSNoAnnot [ue]
     JSVarInitExpression _ _ -> illegal
     JSYieldExpression _ _ -> illegal
     JSYieldFromExpression _ _ _ -> illegal
-  where illegal = expect_throw at (Err_Eval_IllegalJS e)
-        retV v = k $ SLRes mempty env $ v
-        doCallV rlifts ratorv a rands = evalApply ctxt at' env ratorv rands $ kKeepLifts rlifts k
-          where at' = srcloc_jsa "application" a at
-        doCall rator a rands = evalExpr ctxt at' env rator k'
-          where k' (SLRes rlifts _ ratorv) = doCallV rlifts ratorv a rands
-                at' = srcloc_jsa "application, rator" a at
-        doDot obj a field = evalExpr ctxt at' env obj k'
-          where k' (SLRes olifts _ objv) = k $ SLRes olifts env $ evalDot at' objv fields
-                at' = srcloc_jsa "dot" a at
-                fields = (jse_expect_id at') field
-        doRef arr a idx = evalExpr ctxt at' env arr k'
-          where at' = srcloc_jsa "array ref" a at
-                k' arrr =
-                  evalExpr ctxt at' env idx (k'' arrr)
-                k'' (SLRes alifts _ arrv) (SLRes ilifts _ idxv) =
-                  case idxv of
-                    SLV_Int _ idxi ->
-                      case arrv of
-                        SLV_Array _ arrvs ->
-                          case atMay arrvs idxi of
-                            Nothing ->
-                              expect_throw at' $ Err_Eval_RefOutOfBounds (length arrvs) idxi
-                            Just ansv ->
-                              k $ SLRes (alifts <> ilifts) env ansv
-                        SLV_DLVar adv@(DLVar _ _ (T_Array ts) _) ->
-                          case atMay ts idxi of
-                            Nothing ->
-                              expect_throw at' $ Err_Eval_RefOutOfBounds (length ts) idxi
-                            Just t -> retRef t arr_dla idx_dla
-                              where arr_dla = DLA_Var adv
-                                    idx_dla = DLA_Con (DLC_Int idxi)
-                        _ ->
-                          expect_throw at' $ Err_Eval_RefNotArray arrv
-                    SLV_DLVar idxdv@(DLVar _ _ T_UInt256 _) ->
-                      case arr_ty of
-                        T_Array [] ->
-                          expect_throw at' $ Err_Eval_RefEmptyArray 
-                        T_Array (t:ts) ->
-                          case getAll $ foldMap (All . (t ==)) ts of
-                            False ->
-                              expect_throw at' $ Err_EvalRefIndirectNotHomogeneous (t:ts)
-                            True -> retRef t arr_dla idx_dla
-                              where idx_dla = DLA_Var idxdv
-                        _ ->
-                          expect_throw at' $ Err_Eval_RefNotArray arrv
-                      where (arr_ty, arr_dla) = typeOf at' arrv
-                    _ ->
-                      expect_throw at' $ Err_Eval_RefNotInt idxv
-                  where retRef t arr_dla idx_dla = do
-                          (dv, lifts') <- ctxt_lift_expr ctxt at' (DLVar at' "ref" t) (DLE_ArrayRef at' arr_dla idx_dla)
-                          let ansv = SLV_DLVar dv
-                          k $ SLRes (alifts <> ilifts <> lifts') env ansv
+  where
+    illegal = expect_throw at (Err_Eval_IllegalJS e)
+    retV v = k $ SLRes mempty env $ v
+    doCallV rlifts ratorv a rands = evalApply ctxt at' env ratorv rands $ kKeepLifts rlifts k
+      where
+        at' = srcloc_jsa "application" a at
+    doCall rator a rands = evalExpr ctxt at' env rator k'
+      where
+        k' (SLRes rlifts _ ratorv) = doCallV rlifts ratorv a rands
+        at' = srcloc_jsa "application, rator" a at
+    doDot obj a field = evalExpr ctxt at' env obj k'
+      where
+        k' (SLRes olifts _ objv) = k $ SLRes olifts env $ evalDot at' objv fields
+        at' = srcloc_jsa "dot" a at
+        fields = (jse_expect_id at') field
+    doRef arr a idx = evalExpr ctxt at' env arr k'
+      where
+        at' = srcloc_jsa "array ref" a at
+        k' arrr =
+          evalExpr ctxt at' env idx (k'' arrr)
+        k'' (SLRes alifts _ arrv) (SLRes ilifts _ idxv) =
+          case idxv of
+            SLV_Int _ idxi ->
+              case arrv of
+                SLV_Array _ arrvs ->
+                  case atMay arrvs idxi of
+                    Nothing ->
+                      expect_throw at' $ Err_Eval_RefOutOfBounds (length arrvs) idxi
+                    Just ansv ->
+                      k $ SLRes (alifts <> ilifts) env ansv
+                SLV_DLVar adv@(DLVar _ _ (T_Array ts) _) ->
+                  case atMay ts idxi of
+                    Nothing ->
+                      expect_throw at' $ Err_Eval_RefOutOfBounds (length ts) idxi
+                    Just t -> retRef t arr_dla idx_dla
+                      where
+                        arr_dla = DLA_Var adv
+                        idx_dla = DLA_Con (DLC_Int idxi)
+                _ ->
+                  expect_throw at' $ Err_Eval_RefNotArray arrv
+            SLV_DLVar idxdv@(DLVar _ _ T_UInt256 _) ->
+              case arr_ty of
+                T_Array [] ->
+                  expect_throw at' $ Err_Eval_RefEmptyArray
+                T_Array (t : ts) ->
+                  case getAll $ foldMap (All . (t ==)) ts of
+                    False ->
+                      expect_throw at' $ Err_EvalRefIndirectNotHomogeneous (t : ts)
+                    True -> retRef t arr_dla idx_dla
+                      where
+                        idx_dla = DLA_Var idxdv
+                _ ->
+                  expect_throw at' $ Err_Eval_RefNotArray arrv
+              where
+                (arr_ty, arr_dla) = typeOf at' arrv
+            _ ->
+              expect_throw at' $ Err_Eval_RefNotInt idxv
+          where
+            retRef t arr_dla idx_dla = do
+              (dv, lifts') <- ctxt_lift_expr ctxt at' (DLVar at' "ref" t) (DLE_ArrayRef at' arr_dla idx_dla)
+              let ansv = SLV_DLVar dv
+              k $ SLRes (alifts <> ilifts <> lifts') env ansv
 
 evalExprs :: SLCtxt s -> SrcLoc -> SLEnv -> [JSExpression] -> SLCPSd s
 evalExprs ctxt at env rands k =
   case rands of
     [] -> k $ SLRes mempty env (SLV_Array at [])
-    (rand0:rands') ->
+    (rand0 : rands') ->
       evalExpr ctxt at env rand0 k'
-      where k' (SLRes lifts0 _ val0) =
-              evalExprs ctxt at env rands' k''
-              where k'' (SLRes liftsN _ valsv) =
-                      case valsv of
-                        SLV_Array _ vals ->
-                          k $ SLRes (lifts0 <> liftsN) env (SLV_Array at $ val0:vals)
-                        _ ->
-                          impossible "evalExprs did not return array"
+      where
+        k' (SLRes lifts0 _ val0) =
+          evalExprs ctxt at env rands' k''
+          where
+            k'' (SLRes liftsN _ valsv) =
+              case valsv of
+                SLV_Array _ vals ->
+                  k $ SLRes (lifts0 <> liftsN) env (SLV_Array at $ val0 : vals)
+                _ ->
+                  impossible "evalExprs did not return array"
 
 evalDecl :: SLCtxt s -> SrcLoc -> SLRes -> JSExpression -> SLCPSd s
 evalDecl ctxt at (SLRes lifts env _) decl k =
   case decl of
     JSVarInitExpression lhs (JSVarInit va rhs) ->
       evalExpr ctxt vat' env rhs k'
-      where vat' = srcloc_jsa "var initializer" va at
-            k' (SLRes rhs_lifts _ v) = do
-              (lhs_lifts, env') <-
-                case lhs of
-                  (JSIdentifier a x) ->
-                    return $ (mempty, env_insert (srcloc_jsa "id" a at) x v env)
-                  (JSArrayLiteral a xs _) -> do
-                    (vs_lifts, vs) <-
-                      case v of
-                        SLV_Array _ x -> return (mempty, x)
-                        SLV_DLVar dv@(DLVar _ _ (T_Array ts) _) -> do
-                          vs_liftsl_and_dvs <- zipWithM mk_ref ts [0..]
-                          let (vs_liftsl, dvs) = unzip vs_liftsl_and_dvs
-                          let vs_lifts = mconcat vs_liftsl
-                          return (vs_lifts, dvs)
-                          where mk_ref t i = do
-                                  let e = (DLE_ArrayRef vat' (DLA_Var dv) (DLA_Con (DLC_Int i)))
-                                  (dvi, i_lifts) <- ctxt_lift_expr ctxt at (DLVar vat' "array idx" t) e
-                                  return $ (i_lifts, SLV_DLVar dvi)
-                        _ ->
-                          expect_throw at' (Err_Decl_NotArray v)
-                    let kvs = zipEq at' Err_Decl_WrongArrayLength ks vs
-                    return $ (vs_lifts, foldl' (env_insertp at') env kvs)
-                    where ks = map (jse_expect_id at') $ jsa_flatten xs
-                          at' = srcloc_jsa "array" a at
-                  _ ->
-                    expect_throw at (Err_DeclLHS_IllegalJS lhs)
-              traceM $ "evalDecl: defining " ++ (show $ M.keys $ M.difference env' env) ++ " at " ++ show vat'
-              k $ SLRes (lifts <> rhs_lifts <> lhs_lifts) env' $ SLV_Null at
+      where
+        vat' = srcloc_jsa "var initializer" va at
+        k' (SLRes rhs_lifts _ v) = do
+          (lhs_lifts, env') <-
+            case lhs of
+              (JSIdentifier a x) ->
+                return $ (mempty, env_insert (srcloc_jsa "id" a at) x v env)
+              (JSArrayLiteral a xs _) -> do
+                (vs_lifts, vs) <-
+                  case v of
+                    SLV_Array _ x -> return (mempty, x)
+                    SLV_DLVar dv@(DLVar _ _ (T_Array ts) _) -> do
+                      vs_liftsl_and_dvs <- zipWithM mk_ref ts [0 ..]
+                      let (vs_liftsl, dvs) = unzip vs_liftsl_and_dvs
+                      let vs_lifts = mconcat vs_liftsl
+                      return (vs_lifts, dvs)
+                      where
+                        mk_ref t i = do
+                          let e = (DLE_ArrayRef vat' (DLA_Var dv) (DLA_Con (DLC_Int i)))
+                          (dvi, i_lifts) <- ctxt_lift_expr ctxt at (DLVar vat' "array idx" t) e
+                          return $ (i_lifts, SLV_DLVar dvi)
+                    _ ->
+                      expect_throw at' (Err_Decl_NotArray v)
+                let kvs = zipEq at' Err_Decl_WrongArrayLength ks vs
+                return $ (vs_lifts, foldl' (env_insertp at') env kvs)
+                where
+                  ks = map (jse_expect_id at') $ jsa_flatten xs
+                  at' = srcloc_jsa "array" a at
+              _ ->
+                expect_throw at (Err_DeclLHS_IllegalJS lhs)
+          traceM $ "evalDecl: defining " ++ (show $ M.keys $ M.difference env' env) ++ " at " ++ show vat'
+          k $ SLRes (lifts <> rhs_lifts <> lhs_lifts) env' $ SLV_Null at
     _ ->
       expect_throw at (Err_Decl_IllegalJS decl)
 
@@ -1180,152 +1253,183 @@ evalStmt :: SLCtxt s -> SrcLoc -> SLEnv -> [JSStatement] -> SLCPSd s
 evalStmt ctxt at env ss k =
   case ss of
     [] -> k $ SLRes mempty env $ SLV_Null at
-    ((JSStatementBlock a ss' _ sp):ks) ->
-      evalStmt ctxt at_in env ss'
-      (\(SLRes lifts _ _XXX_v) ->
-          evalStmt ctxt at_after env ks $ kKeepLifts lifts k)
-      where at_in = srcloc_jsa "block" a at
-            at_after = srcloc_after_semi "block" a sp at
-    (s@(JSBreak a _ _):_) -> illegal a s "break"
-    (s@(JSLet a _ _):_) -> illegal a s "let"
-    (s@(JSClass a _ _ _ _ _ _):_) -> illegal a s "class"
-    ((JSConstant a decls sp):ks) ->
+    ((JSStatementBlock a ss' _ sp) : ks) ->
+      evalStmt
+        ctxt
+        at_in
+        env
+        ss'
+        ( \(SLRes lifts _ _XXX_v) ->
+            evalStmt ctxt at_after env ks $ kKeepLifts lifts k
+        )
+      where
+        at_in = srcloc_jsa "block" a at
+        at_after = srcloc_after_semi "block" a sp at
+    (s@(JSBreak a _ _) : _) -> illegal a s "break"
+    (s@(JSLet a _ _) : _) -> illegal a s "let"
+    (s@(JSClass a _ _ _ _ _ _) : _) -> illegal a s "class"
+    ((JSConstant a decls sp) : ks) ->
       evalDecls ctxt at_in env decls k'
-      where at_after = srcloc_after_semi lab a sp at
-            at_in = srcloc_jsa lab a at
-            lab = "const"
-            k' (SLRes lifts env' _) = evalStmt ctxt at_after env' ks $ kKeepLifts lifts k
-    ((JSContinue a _ _):_) ->
+      where
+        at_after = srcloc_after_semi lab a sp at
+        at_in = srcloc_jsa lab a at
+        lab = "const"
+        k' (SLRes lifts env' _) = evalStmt ctxt at_after env' ks $ kKeepLifts lifts k
+    ((JSContinue a _ _) : _) ->
       expect_throw (srcloc_jsa "continue" a at) (Err_Block_Continue)
-    (s@(JSDoWhile a _ _ _ _ _ _):_) -> illegal a s "do while"
-    (s@(JSFor a _ _ _ _ _ _ _ _):_) -> illegal a s "for"
-    (s@(JSForIn a _ _ _ _ _ _):_) -> illegal a s "for in"
-    (s@(JSForVar a _ _ _ _ _ _ _ _ _):_) -> illegal a s "for var"
-    (s@(JSForVarIn a _ _ _ _ _ _ _):_) -> illegal a s "for var in"
-    (s@(JSForLet a _ _ _ _ _ _ _ _ _):_) -> illegal a s "for let"
-    (s@(JSForLetIn a _ _ _ _ _ _ _):_) -> illegal a s "for let in"
-    (s@(JSForLetOf a _ _ _ _ _ _ _):_) -> illegal a s "for let of"
-    (s@(JSForConst a _ _ _ _ _ _ _ _ _):_) -> illegal a s "for const"
-    (s@(JSForConstIn a _ _ _ _ _ _ _):_) -> illegal a s "for const in"
-    (s@(JSForConstOf a _ _ _ _ _ _ _):_) -> illegal a s "for const of"
-    (s@(JSForOf a _ _ _ _ _ _):_) -> illegal a s "for of"
-    (s@(JSForVarOf a _ _ _ _ _ _ _):_) -> illegal a s "for var of"
-    (s@(JSAsyncFunction a _ _ _ _ _ _ _):_) -> illegal a s "async function"
-    ((JSFunction a name _ jsformals _ body sp):ks) ->
+    (s@(JSDoWhile a _ _ _ _ _ _) : _) -> illegal a s "do while"
+    (s@(JSFor a _ _ _ _ _ _ _ _) : _) -> illegal a s "for"
+    (s@(JSForIn a _ _ _ _ _ _) : _) -> illegal a s "for in"
+    (s@(JSForVar a _ _ _ _ _ _ _ _ _) : _) -> illegal a s "for var"
+    (s@(JSForVarIn a _ _ _ _ _ _ _) : _) -> illegal a s "for var in"
+    (s@(JSForLet a _ _ _ _ _ _ _ _ _) : _) -> illegal a s "for let"
+    (s@(JSForLetIn a _ _ _ _ _ _ _) : _) -> illegal a s "for let in"
+    (s@(JSForLetOf a _ _ _ _ _ _ _) : _) -> illegal a s "for let of"
+    (s@(JSForConst a _ _ _ _ _ _ _ _ _) : _) -> illegal a s "for const"
+    (s@(JSForConstIn a _ _ _ _ _ _ _) : _) -> illegal a s "for const in"
+    (s@(JSForConstOf a _ _ _ _ _ _ _) : _) -> illegal a s "for const of"
+    (s@(JSForOf a _ _ _ _ _ _) : _) -> illegal a s "for of"
+    (s@(JSForVarOf a _ _ _ _ _ _ _) : _) -> illegal a s "for var of"
+    (s@(JSAsyncFunction a _ _ _ _ _ _ _) : _) -> illegal a s "async function"
+    ((JSFunction a name _ jsformals _ body sp) : ks) ->
       evalStmt ctxt at_after env' ks k
-      where clo = SLV_Clo at' (Just f) formals body env
-            formals = parseJSFormals at' jsformals
-            at' = srcloc_jsa lab a at
-            at_after = srcloc_after_semi lab a sp at
-            lab = "function def"
-            env' = env_insert at f clo env
-            f = case name of
-                  JSIdentNone -> expect_throw at' (Err_TopFun_NoName)
-                  JSIdentName _ x -> x
-    (s@(JSGenerator a _ _ _ _ _ _ _):_) -> illegal a s "generator"
-    ((JSIf a la ce ra ts):ks) ->
-      evalStmt ctxt at env ((JSIfElse a la ce ra ts ea fs):ks) k
-      where ea = ra
-            fs = (JSEmptyStatement ea)
-    ((JSIfElse a _ ce ta ts fa fs):ks) ->
+      where
+        clo = SLV_Clo at' (Just f) formals body env
+        formals = parseJSFormals at' jsformals
+        at' = srcloc_jsa lab a at
+        at_after = srcloc_after_semi lab a sp at
+        lab = "function def"
+        env' = env_insert at f clo env
+        f = case name of
+          JSIdentNone -> expect_throw at' (Err_TopFun_NoName)
+          JSIdentName _ x -> x
+    (s@(JSGenerator a _ _ _ _ _ _ _) : _) -> illegal a s "generator"
+    ((JSIf a la ce ra ts) : ks) ->
+      evalStmt ctxt at env ((JSIfElse a la ce ra ts ea fs) : ks) k
+      where
+        ea = ra
+        fs = (JSEmptyStatement ea)
+    ((JSIfElse a _ ce ta ts fa fs) : ks) ->
       evalExpr ctxt at' env e' k'
-      where e' = JSExpressionTernary ce a te a fe
-            te = jsStmtToExpr ta ts
-            fe = jsStmtToExpr fa fs
-            k' (SLRes lifts _ _XXX_v) =
-              --- XXX Should we ignore v? I don't think so, because we
-              --- need to make its return matches ks
-              evalStmt ctxt at' env ks $ kKeepLifts lifts k
-            at' = srcloc_jsa "if" a at
-    (s@(JSLabelled _ a _):_) -> illegal a s "labelled"
-    ((JSEmptyStatement a):ks) ->
+      where
+        e' = JSExpressionTernary ce a te a fe
+        te = jsStmtToExpr ta ts
+        fe = jsStmtToExpr fa fs
+        k' (SLRes lifts _ _XXX_v) =
+          --- XXX Should we ignore v? I don't think so, because we
+          --- need to make its return matches ks
+          evalStmt ctxt at' env ks $ kKeepLifts lifts k
+        at' = srcloc_jsa "if" a at
+    (s@(JSLabelled _ a _) : _) -> illegal a s "labelled"
+    ((JSEmptyStatement a) : ks) ->
       evalStmt ctxt at' env ks k
-      where at' = srcloc_jsa "empty" a at
-    ((JSExpressionStatement e sp):ks) ->
+      where
+        at' = srcloc_jsa "empty" a at
+    ((JSExpressionStatement e sp) : ks) ->
       evalExpr ctxt at env e k'
-      where at_after =
-              srcloc_after_semi "expr stmt" JSNoAnnot sp at
-            k' (SLRes elifts _ ev) =
-              case (ctxt_mode ctxt, ev) of
-                (SLC_Step penvs, SLV_Form (SLForm_Part_OnlyAns who penv' only_v)) ->
-                  case typeOf at_after only_v of
-                    (T_Null, _) ->
-                      evalStmt ctxt' at_after env ks $ kKeepLifts elifts k
-                      where ctxt' = ctxt { ctxt_mode = SLC_Step $ M.insert who penv' penvs }
-                    _ -> expect_throw at (Err_Block_NotNull ev) --- XXX rename to expression not null? or ignore?
-                (SLC_Step penvs, SLV_Form (SLForm_Part_ToConsensus who Nothing mmsg _XXX_mamt _XXX_mtime)) -> do
-                  let penv = penvs M.! who
-                  traceM $ "to_consensus from " ++ show who
-                  --- XXX at and at_after here might be bad... add to ToConsensus?
-                  (msg_env, _XXX_tmsg) <-
-                    case mmsg of
-                      Nothing -> return (mempty, [])
-                      Just msg -> do
-                        let mk var = do
-                              let val = env_lookup at_after var penv
-                              let (t, _) = typeOf at_after val
-                              x <- ctxt_alloc ctxt at
-                              return $ DLVar at_after "msg" t x
-                        tvs <- mapM mk msg
-                        return $ (foldl' (env_insertp at_after) mempty $ zip msg $ map SLV_DLVar tvs, tvs)
-                  --- We go back to the original env from before the to-consensus step
-                  let env' = env_merge at_after env msg_env
-                  let penvs' = M.mapWithKey (\p old ->
-                                                case p == who of
-                                                  True -> old
-                                                  False -> env_merge at_after old msg_env) penvs
-                  let ctxt_cstep =
-                        (SLCtxt { ctxt_mode = SLC_ConsensusStep penvs'
-                                , ctxt_id = ctxt_id ctxt
-                                , ctxt_stack = ctxt_stack ctxt })
-                  --- XXX lift toconsensus
-                  evalStmt ctxt_cstep at_after env' ks $ kKeepLifts elifts k
-                (SLC_ConsensusStep penvs, SLV_Prim SLPrim_committed) -> do
-                  let ctxt_step = (SLCtxt { ctxt_mode = SLC_Step penvs
-                                          , ctxt_id = ctxt_id ctxt
-                                          , ctxt_stack = ctxt_stack ctxt })
-                  evalStmt ctxt_step at_after env ks $ kKeepLifts elifts k
-                _ ->
-                  case typeOf at_after ev of
-                    (T_Null, _) -> evalStmt ctxt at_after env ks $ kKeepLifts elifts k
-                    _ -> expect_throw at (Err_Block_NotNull ev) --- XXX rename to expression not null? or ignore?
-    ((JSAssignStatement _lhs op _rhs _asp):ks) ->
+      where
+        at_after =
+          srcloc_after_semi "expr stmt" JSNoAnnot sp at
+        k' (SLRes elifts _ ev) =
+          case (ctxt_mode ctxt, ev) of
+            (SLC_Step penvs, SLV_Form (SLForm_Part_OnlyAns who penv' only_v)) ->
+              case typeOf at_after only_v of
+                (T_Null, _) ->
+                  evalStmt ctxt' at_after env ks $ kKeepLifts elifts k
+                  where
+                    ctxt' = ctxt {ctxt_mode = SLC_Step $ M.insert who penv' penvs}
+                _ -> expect_throw at (Err_Block_NotNull ev) --- XXX rename to expression not null? or ignore?
+            (SLC_Step penvs, SLV_Form (SLForm_Part_ToConsensus who Nothing mmsg _XXX_mamt _XXX_mtime)) -> do
+              let penv = penvs M.! who
+              traceM $ "to_consensus from " ++ show who
+              --- XXX at and at_after here might be bad... add to ToConsensus?
+              (msg_env, _XXX_tmsg) <-
+                case mmsg of
+                  Nothing -> return (mempty, [])
+                  Just msg -> do
+                    let mk var = do
+                          let val = env_lookup at_after var penv
+                          let (t, _) = typeOf at_after val
+                          x <- ctxt_alloc ctxt at
+                          return $ DLVar at_after "msg" t x
+                    tvs <- mapM mk msg
+                    return $ (foldl' (env_insertp at_after) mempty $ zip msg $ map SLV_DLVar tvs, tvs)
+              --- We go back to the original env from before the to-consensus step
+              let env' = env_merge at_after env msg_env
+              let penvs' =
+                    M.mapWithKey
+                      ( \p old ->
+                          case p == who of
+                            True -> old
+                            False -> env_merge at_after old msg_env
+                      )
+                      penvs
+              let ctxt_cstep =
+                    ( SLCtxt
+                        { ctxt_mode = SLC_ConsensusStep penvs',
+                          ctxt_id = ctxt_id ctxt,
+                          ctxt_stack = ctxt_stack ctxt
+                        }
+                    )
+              --- XXX lift toconsensus
+              evalStmt ctxt_cstep at_after env' ks $ kKeepLifts elifts k
+            (SLC_ConsensusStep penvs, SLV_Prim SLPrim_committed) -> do
+              let ctxt_step =
+                    ( SLCtxt
+                        { ctxt_mode = SLC_Step penvs,
+                          ctxt_id = ctxt_id ctxt,
+                          ctxt_stack = ctxt_stack ctxt
+                        }
+                    )
+              evalStmt ctxt_step at_after env ks $ kKeepLifts elifts k
+            _ ->
+              case typeOf at_after ev of
+                (T_Null, _) -> evalStmt ctxt at_after env ks $ kKeepLifts elifts k
+                _ -> expect_throw at (Err_Block_NotNull ev) --- XXX rename to expression not null? or ignore?
+    ((JSAssignStatement _lhs op _rhs _asp) : ks) ->
       case (op, ks) of
-        ((JSAssign _), ((JSContinue a _bl sp):cont_ks)) ->
+        ((JSAssign _), ((JSContinue a _bl sp) : cont_ks)) ->
           expect_empty_tail lab a sp at cont_ks res
-          where lab = "continue"
-                at' = srcloc_jsa lab a at
-                res = expect_throw at' (Err_XXX lab)
+          where
+            lab = "continue"
+            at' = srcloc_jsa lab a at
+            res = expect_throw at' (Err_XXX lab)
         _ ->
           expect_throw (srcloc_jsa "assign" JSNoAnnot at) (Err_Block_Assign)
-    ((JSMethodCall e a args ra sp):ks) ->
+    ((JSMethodCall e a args ra sp) : ks) ->
       evalStmt ctxt at env ss' k
-      where ss' = (JSExpressionStatement e' sp):ks
-            e' = (JSCallExpression e a args ra)
-    ((JSReturn a me sp):ks) ->
+      where
+        ss' = (JSExpressionStatement e' sp) : ks
+        e' = (JSCallExpression e a args ra)
+    ((JSReturn a me sp) : ks) ->
       expect_empty_tail lab a sp at ks res
-      where lab = "return"
-            at' = srcloc_jsa lab a at
-            retk = expect_throw at' (Err_XXX "retk")
-            res = case me of
-                    Nothing -> retk $ SLV_Null at'
-                    Just e -> evalExpr ctxt at' env e retk
-    (s@(JSSwitch a _ _ _ _ _ _ _):_) -> illegal a s "switch"
-    (s@(JSThrow a _ _):_) -> illegal a s "throw"
-    (s@(JSTry a _ _ _):_) -> illegal a s "try"
-    ((JSVariable a _while_decls _vsp):ks) ->
+      where
+        lab = "return"
+        at' = srcloc_jsa lab a at
+        retk = expect_throw at' (Err_XXX "retk")
+        res = case me of
+          Nothing -> retk $ SLV_Null at'
+          Just e -> evalExpr ctxt at' env e retk
+    (s@(JSSwitch a _ _ _ _ _ _ _) : _) -> illegal a s "switch"
+    (s@(JSThrow a _ _) : _) -> illegal a s "throw"
+    (s@(JSTry a _ _ _) : _) -> illegal a s "try"
+    ((JSVariable a _while_decls _vsp) : ks) ->
       case ks of
-        ((JSMethodCall (JSIdentifier _ "invariant") _ _invariant_args _ _isp):
-          (JSWhile _ _ _while_cond _ _while_body):_while_ks) ->
-          expect_throw at' (Err_XXX "while")
+        ( (JSMethodCall (JSIdentifier _ "invariant") _ _invariant_args _ _isp)
+            : (JSWhile _ _ _while_cond _ _while_body)
+            : _while_ks
+          ) ->
+            expect_throw at' (Err_XXX "while")
         _ ->
           expect_throw at' (Err_Block_Variable)
-      where at' = (srcloc_jsa "var" a at)
-    ((JSWhile a _ _ _ _):_) ->
+      where
+        at' = (srcloc_jsa "var" a at)
+    ((JSWhile a _ _ _ _) : _) ->
       expect_throw (srcloc_jsa "while" a at) (Err_Block_While)
-    (s@(JSWith a _ _ _ _ _):_) -> illegal a s "with"
-  where illegal a s lab =
-          expect_throw (srcloc_jsa lab a at) (Err_Block_IllegalJS s)
+    (s@(JSWith a _ _ _ _ _) : _) -> illegal a s "with"
+  where
+    illegal a s lab =
+      expect_throw (srcloc_jsa lab a at) (Err_Block_IllegalJS s)
 
 expect_empty_tail :: String -> JSAnnot -> JSSemi -> SrcLoc -> [JSStatement] -> a -> a
 expect_empty_tail lab a sp at ks res =
@@ -1333,27 +1437,29 @@ expect_empty_tail lab a sp at ks res =
     [] -> res
     _ ->
       expect_throw at' (Err_TailNotEmpty ks)
-      where at' = srcloc_after_semi lab a sp at
+      where
+        at' = srcloc_after_semi lab a sp at
 
 evalTopBody :: SLCtxt s -> SrcLoc -> SLLibs -> SLEnv -> SLEnv -> [JSModuleItem] -> SLCPSd s
 evalTopBody ctxt at libm env exenv body k =
   case body of
     [] -> k $ SLRes mempty exenv $ SLV_Null at
-    mi:body' ->
+    mi : body' ->
       case mi of
         (JSModuleImportDeclaration _ im) ->
           case im of
             JSImportDeclarationBare a libn sp ->
               evalTopBody ctxt at_after libm env' exenv body' k
-              where at_after = srcloc_after_semi lab a sp at
-                    at' = srcloc_jsa lab a at
-                    lab = "import"
-                    env' = env_merge at' env libex
-                    libex =
-                      case M.lookup (ReachSourceFile libn) libm of
-                        Just x -> x
-                        Nothing ->
-                          impossible $ "dependency not found"
+              where
+                at_after = srcloc_after_semi lab a sp at
+                at' = srcloc_jsa lab a at
+                lab = "import"
+                env' = env_merge at' env libex
+                libex =
+                  case M.lookup (ReachSourceFile libn) libm of
+                    Just x -> x
+                    Nothing ->
+                      impossible $ "dependency not found"
             --- XXX support more kinds
             _ -> expect_throw at (Err_Import_IllegalJS im)
         (JSModuleExportDeclaration a ed) ->
@@ -1361,80 +1467,92 @@ evalTopBody ctxt at libm env exenv body k =
             JSExport s _ -> doStmt at' True s
             --- XXX support more kinds
             _ -> expect_throw at' (Err_Export_IllegalJS ed)
-          where at' = srcloc_jsa "export" a at
+          where
+            at' = srcloc_jsa "export" a at
         (JSModuleStatementListItem s) -> doStmt at False s
-      where doStmt at' isExport sm =
-              evalStmt ctxt at' env [sm] $
-              (\case
-                  SLRes Seq.Empty env' (SLV_Null _) ->
-                    let exenv' = case isExport of
-                                   True ->
-                                     --- If this is an exporting statement,
-                                     --- then add to the export environment
-                                     --- everything that is new.
-                                     env_merge at' exenv (M.difference env' env)
-                                   False ->
-                                     exenv
-                    in
-                      evalTopBody ctxt at' libm env' exenv' body' k
-                  SLRes _ _ v ->
-                    expect_throw at' $ Err_Module_Return v)
+      where
+        doStmt at' isExport sm =
+          evalStmt ctxt at' env [sm] $
+            ( \case
+                SLRes Seq.Empty env' (SLV_Null _) ->
+                  let exenv' = case isExport of
+                        True ->
+                          --- If this is an exporting statement,
+                          --- then add to the export environment
+                          --- everything that is new.
+                          env_merge at' exenv (M.difference env' env)
+                        False ->
+                          exenv
+                   in evalTopBody ctxt at' libm env' exenv' body' k
+                SLRes _ _ v ->
+                  expect_throw at' $ Err_Module_Return v
+            )
 
 type SLMod = (ReachSource, [JSModuleItem])
+
 type SLLibs = (M.Map ReachSource SLEnv)
 
 evalLib :: SLMod -> SLLibs -> ST s SLLibs
 evalLib (src, body) libm = do
   let ctxt_top =
-        (SLCtxt { ctxt_mode = SLC_Module
-                , ctxt_id = Nothing
-                , ctxt_stack = [] })
+        ( SLCtxt
+            { ctxt_mode = SLC_Module,
+              ctxt_id = Nothing,
+              ctxt_stack = []
+            }
+        )
   (SLRes flifts exenv _) <- evalTopBody ctxt_top prev_at libm stdlib_env mt_env body' return
   case flifts == mempty of
     False -> impossible $ "evalLib had lifts"
     True -> return $ M.insert src exenv libm
-  where stdlib_env =
-          case src of
-            ReachStdLib -> base_env
-            ReachSourceFile _ -> M.union (libm M.! ReachStdLib) base_env
-        at = (srcloc_src src)
-        (prev_at, body') =
-          case body of
-            ((JSModuleStatementListItem (JSExpressionStatement (JSStringLiteral a "\'reach 0.1\'") sp)):j) ->
-              ((srcloc_after_semi "header" a sp at), j)
-            _ -> expect_throw at (Err_NoHeader body)
+  where
+    stdlib_env =
+      case src of
+        ReachStdLib -> base_env
+        ReachSourceFile _ -> M.union (libm M.! ReachStdLib) base_env
+    at = (srcloc_src src)
+    (prev_at, body') =
+      case body of
+        ((JSModuleStatementListItem (JSExpressionStatement (JSStringLiteral a "\'reach 0.1\'") sp)) : j) ->
+          ((srcloc_after_semi "header" a sp at), j)
+        _ -> expect_throw at (Err_NoHeader body)
 
 evalLibs :: [SLMod] -> ST s SLLibs
 evalLibs mods = foldrM evalLib mempty mods
 
 makeInteract :: SrcLoc -> SLEnv -> SLVal
 makeInteract at spec = SLV_Object at spec'
-  where spec' = M.mapWithKey wrap_ty spec
-        wrap_ty k (SLV_Type t) = SLV_Prim $ SLPrim_interact at k t
-        wrap_ty _ v = expect_throw at $ Err_DApp_InvalidInteract v
+  where
+    spec' = M.mapWithKey wrap_ty spec
+    wrap_ty k (SLV_Type t) = SLV_Prim $ SLPrim_interact at k t
+    wrap_ty _ v = expect_throw at $ Err_DApp_InvalidInteract v
 
 compileDApp :: SLVal -> ST s SLRes
 compileDApp topv =
   case topv of
-    SLV_Prim (SLPrim_DApp_Delay at [ (SLV_Object _ _opts), (SLV_Array _ parts), clo ] top_env) -> do
+    SLV_Prim (SLPrim_DApp_Delay at [(SLV_Object _ _opts), (SLV_Array _ parts), clo] top_env) -> do
       --- xxx look at opts
       idxr <- newSTRef $ 0
       let ctxt_step =
-            (SLCtxt { ctxt_mode = SLC_Step penvs
-                    , ctxt_id = Just idxr
-                    , ctxt_stack = [] })
+            ( SLCtxt
+                { ctxt_mode = SLC_Step penvs,
+                  ctxt_id = Just idxr,
+                  ctxt_stack = []
+                }
+            )
       evalApplyVals ctxt_step at' mt_env clo partvs k
-      where k v = expect_throw at' (Err_XXX $ "compileDApp after: " ++ show v)
-            at' = srcloc_at "compileDApp" Nothing at
-            penvs = M.fromList $ map make_penv partvs
-            make_penv (SLV_Participant _ pn io) =
-              (pn, env_insert at' "interact" io top_env)
-            make_penv _ = impossible "SLPrim_DApp_Delay make_penv" 
-            partvs = map make_part parts
-            make_part v =
-              case v of
-                SLV_Array p_at [ SLV_Bytes _ bs, SLV_Object iat io ] -> SLV_Participant p_at bs (makeInteract iat io)
-                _ -> expect_throw at' (Err_DApp_InvalidPartSpec v)
+      where
+        k v = expect_throw at' (Err_XXX $ "compileDApp after: " ++ show v)
+        at' = srcloc_at "compileDApp" Nothing at
+        penvs = M.fromList $ map make_penv partvs
+        make_penv (SLV_Participant _ pn io) =
+          (pn, env_insert at' "interact" io top_env)
+        make_penv _ = impossible "SLPrim_DApp_Delay make_penv"
+        partvs = map make_part parts
+        make_part v =
+          case v of
+            SLV_Array p_at [SLV_Bytes _ bs, SLV_Object iat io] -> SLV_Participant p_at bs (makeInteract iat io)
+            _ -> expect_throw at' (Err_DApp_InvalidPartSpec v)
     _ ->
       expect_throw srcloc_top (Err_Top_NotDApp topv)
 
@@ -1444,13 +1562,14 @@ compileBundle (JSBundle mods) top = runST $ do
   let exe_ex = libm M.! exe
   --- XXX use env_lookup
   let topv = case M.lookup top exe_ex of
-               Just x -> x
-               Nothing ->
-                 expect_throw srcloc_top (Err_Eval_UnboundId top $ M.keys exe_ex)
+        Just x -> x
+        Nothing ->
+          expect_throw srcloc_top (Err_Eval_UnboundId top $ M.keys exe_ex)
   compileDApp topv
-  where exe = case mods of
-                [] -> impossible $ "compileBundle: no files"
-                ((x,_):_) -> x
+  where
+    exe = case mods of
+      [] -> impossible $ "compileBundle: no files"
+      ((x, _) : _) -> x
 
 -- Main entry point
 compileNL :: CompilerOpts -> IO ()

--- a/hs/src/Reach/CompilerTool.hs
+++ b/hs/src/Reach/CompilerTool.hs
@@ -2,21 +2,20 @@ module Reach.CompilerTool where
 
 import Control.Monad.Except
 import qualified Filesystem.Path.CurrentOS as FP
+import Reach.Compiler
+import Reach.CompilerNL (compileNL)
 import System.Directory
 
-import Reach.Compiler
-import Reach.CompilerNL(compileNL)
-
 data CompilerToolOpts = CompilerToolOpts
-  { cto_outputDir :: FilePath
-  , cto_source :: FilePath
-  , cto_expCon :: Bool
-  , cto_expComp :: Bool
-  , cto_verifier :: Verifier
+  { cto_outputDir :: FilePath,
+    cto_source :: FilePath,
+    cto_expCon :: Bool,
+    cto_expComp :: Bool,
+    cto_verifier :: Verifier
   }
 
 makeCompilerOpts :: CompilerToolOpts -> IO CompilerOpts
-makeCompilerOpts CompilerToolOpts{..} = do
+makeCompilerOpts CompilerToolOpts {..} = do
   let srcp = cto_source
   let srcbp = FP.basename $ FP.decodeString srcp
   let outd = cto_outputDir
@@ -24,16 +23,17 @@ makeCompilerOpts CompilerToolOpts{..} = do
   let outn ext = FP.encodeString $ FP.append outdp $ srcbp `FP.addExtension` ext
   let out ext con = writeFile (outn ext) con
   createDirectoryIfMissing True outd
-  return $ CompilerOpts
-    { output = out
-    , output_name = outn
-    , source = srcp
-    , expCon = cto_expCon
-    , verifier = cto_verifier
-    }
+  return $
+    CompilerOpts
+      { output = out,
+        output_name = outn,
+        source = srcp,
+        expCon = cto_expCon,
+        verifier = cto_verifier
+      }
 
 compilerToolMain :: CompilerToolOpts -> IO ()
-compilerToolMain ctool_opts@CompilerToolOpts{..} = do
+compilerToolMain ctool_opts@CompilerToolOpts {..} = do
   copts <- makeCompilerOpts ctool_opts
   when (cto_expComp) (compileNL copts)
   compile copts

--- a/hs/src/Reach/Connector/ALGO.hs
+++ b/hs/src/Reach/Connector/ALGO.hs
@@ -1,36 +1,39 @@
 module Reach.Connector.ALGO where
 
-import System.IO
-import System.Process
-import System.Exit
 import Control.Monad.Extra
 import Control.Monad.State.Lazy
-import qualified Data.Map.Strict as M
-import Data.List
 import Data.ByteString.Base64 (encodeBase64')
 ---import Data.ByteString.Internal (unpackChars)
 import qualified Data.ByteString.Char8 as C
+import Data.List
+import qualified Data.Map.Strict as M
 ---import qualified Data.ByteString as BS
 
 import Reach.AST
-import Reach.Util
 import Reach.Connector.ETH_Solidity
-  ( CCounts
-  , usesCTail )
+  ( CCounts,
+    usesCTail,
+  )
+import Reach.Util
+import System.Exit
+import System.IO
+import System.Process
 
 type CompiledTeal = (String, String, String)
 
 type LabelM ann a = State LabelSt a
+
 type LabelSt = Int
 
 labelRun :: LabelM ann a -> a
 labelRun lm = ans
-  where (ans, _) = runState lm 0
+  where
+    (ans, _) = runState lm 0
 
 data TEAL
   = TEAL TEALs
 
-type TEALs = [ TEALLine ]
+type TEALs = [TEALLine]
 
 instance Show TEAL where
   show (TEAL tls) = concat $ intersperse "\n" $ map show tls
@@ -45,84 +48,89 @@ instance Show TEALLine where
   show (TL_Label l) = l ++ ":"
   show (TL_Code s) = concat $ intersperse " " s
 
-type CompileSt a
-  = ( String, Int, M.Map BLVar (VarRHS a) )
+type CompileSt a =
+  (String, Int, M.Map BLVar (VarRHS a))
+
 data VarRHS a
   = VR_Expr (CExpr a)
   | VR_Slot Int
   | VR_Arg Int LType
   | VR_Code TEALs
 
-type TxnSt
-  = Int
+type TxnSt =
+  Int
 
 txn_init :: TxnSt
 txn_init = 2
 
-txn_alloc :: TxnSt -> ( Int, TxnSt )
-txn_alloc i = ( i, i + 1)
+txn_alloc :: TxnSt -> (Int, TxnSt)
+txn_alloc i = (i, i + 1)
 
 cs_init :: String -> CompileSt a
-cs_init lab = ( lab, 0, M.empty )
+cs_init lab = (lab, 0, M.empty)
 
 cs_var_loc :: CompileSt a -> BLVar -> (Int, CompileSt a)
 cs_var_loc cs bv = (loc, cs')
-  where cs' = ( lab, loc + 1, M.insert bv (VR_Slot loc) vmap )
-        ( lab, loc, vmap ) = cs
+  where
+    cs' = (lab, loc + 1, M.insert bv (VR_Slot loc) vmap)
+    (lab, loc, vmap) = cs
 
 cs_var_locs :: CompileSt a -> [BLVar] -> CompileSt a
 cs_var_locs cs bvs = foldl' h cs bvs
-  where h cs0 bv = snd $ cs_var_loc cs0 bv
+  where
+    h cs0 bv = snd $ cs_var_loc cs0 bv
 
 cs_var_set :: CompileSt a -> BLVar -> VarRHS a -> CompileSt a
 cs_var_set cs bv vr = cs'
-  where cs' = ( lab, loc, M.insert bv vr vmap )
-        ( lab, loc, vmap ) = cs
+  where
+    cs' = (lab, loc, M.insert bv vr vmap)
+    (lab, loc, vmap) = cs
 
-cs_var_args :: CompileSt a -> [ BLVar ] -> CompileSt a
+cs_var_args :: CompileSt a -> [BLVar] -> CompileSt a
 cs_var_args cs as = cs'
-  where h (cs0, i) a = ((cs_var_set cs0 a (VR_Arg i (blvar_type a))), i+1)
-        --- The first argument is 3 because 0 is the handler and 1 is
-        --- the last time and 2 is the value
-        (cs', _) = foldl' h (cs, 3) as
+  where
+    h (cs0, i) a = ((cs_var_set cs0 a (VR_Arg i (blvar_type a))), i + 1)
+    --- The first argument is 3 because 0 is the handler and 1 is
+    --- the last time and 2 is the value
+    (cs', _) = foldl' h (cs, 3) as
 
 cs_label :: CompileSt a -> String
-cs_label ( lab, _, _ ) = lab
+cs_label (lab, _, _) = lab
 
 label_ext :: String -> Int -> String
 label_ext lab ext = lab ++ "_" ++ (show ext)
 
 alloc_lab :: CompileSt a -> LabelM ann String
 alloc_lab cs = do
-  let ( lab, _, _ ) = cs
+  let (lab, _, _) = cs
   lab_i <- get
   put $ lab_i + 1
   return $ label_ext lab lab_i
 
 bracket :: String -> TEALs -> TEALs
-bracket lab ls = TL_Comment ("<" ++ lab ++ ">") : ls ++ [ TL_Comment ("</" ++ lab ++ ">") ]
+bracket lab ls = TL_Comment ("<" ++ lab ++ ">") : ls ++ [TL_Comment ("</" ++ lab ++ ">")]
 
 xxx :: String -> TEALs
-xxx x = [ TL_Comment $ "XXX " ++ x ]
+xxx x = [TL_Comment $ "XXX " ++ x]
 
 label :: String -> TEALs
-label lab = [ TL_Label lab ]
+label lab = [TL_Label lab]
 
-code :: String -> [ String ] -> TEALs
-code op args = [ TL_Code $ op : args ]
+code :: String -> [String] -> TEALs
+code op args = [TL_Code $ op : args]
 
 comp_con :: Constant -> TEALs
 comp_con c =
   case c of
     Con_I i ->
-      code "int" [ show i ]
+      code "int" [show i]
     Con_B t ->
       comp_con $ Con_I $ if t then 1 else 0
     Con_BS bs ->
-      code "byte" [ "base64(" ++ (C.unpack (encodeBase64' bs)) ++ ")" ]
+      code "byte" ["base64(" ++ (C.unpack (encodeBase64' bs)) ++ ")"]
 
 comp_arg :: Int -> TEALs
-comp_arg a = code "txna" [ "ApplicationArgs", show a ]
+comp_arg a = code "txna" ["ApplicationArgs", show a]
 
 comp_blvar :: CompileSt a -> BLVar -> LabelM ann TEALs
 comp_blvar cs bv =
@@ -130,18 +138,20 @@ comp_blvar cs bv =
     Nothing ->
       impossible $ "unbound variable: " ++ show bv
     Just (VR_Arg a lt) ->
-      return $ comp_arg a
-               ++ case lt of
-                    LT_BT BT_UInt256 -> code "btoi" []
-                    LT_BT BT_Bool -> code "btoi" []
-                    _ -> []
+      return $
+        comp_arg a
+          ++ case lt of
+            LT_BT BT_UInt256 -> code "btoi" []
+            LT_BT BT_Bool -> code "btoi" []
+            _ -> []
     Just (VR_Slot s) ->
-      return $ code "load" [ show s ]
+      return $ code "load" [show s]
     Just (VR_Code ls) ->
       return ls
     Just (VR_Expr ce) ->
       comp_cexpr cs ce
-  where ( _, _, vmap ) = cs
+  where
+    (_, _, vmap) = cs
 
 comp_blarg_ty :: CompileSt a -> BLArg a -> LabelM ann (LType, TEALs)
 comp_blarg_ty cs a =
@@ -182,20 +192,25 @@ comp_hash hm cs as = do
         case hm of
           HM_Digest -> (0, [])
           HM_State i use_this_block -> (hm_len, hm_ls)
-            where hm_len = 2
-                  hm_ls = comp_con (Con_I $ fromIntegral i)
-                    ++ code "itob" []
-                    ++ (if use_this_block then
-                          (code "global" [ "Round" ]
-                           ++ code "itob" [])
-                        else
-                          comp_arg 1)
-                    ++ code "concat" []
+            where
+              hm_len = 2
+              hm_ls =
+                comp_con (Con_I $ fromIntegral i)
+                  ++ code "itob" []
+                  ++ ( if use_this_block
+                         then
+                           ( code "global" ["Round"]
+                               ++ code "itob" []
+                           )
+                         else comp_arg 1
+                     )
+                  ++ code "concat" []
   as_ls <- concatMapM (uncurry $ comp_blarg_for_hash cs) (zip [pre_len ..] as)
-  return $ pre_ls
-    ++ as_ls
-    ++ code "keccak256" []
-    ++ code "btoi" []
+  return $
+    pre_ls
+      ++ as_ls
+      ++ code "keccak256" []
+      ++ code "btoi" []
 
 comp_cexpr :: CompileSt a -> CExpr a -> LabelM ann TEALs
 comp_cexpr cs e =
@@ -227,25 +242,29 @@ comp_cexpr cs e =
           false_ls <- comp_blarg cs a_false
           true_ls <- comp_blarg cs a_true
           cont_lab <- alloc_lab cs
-          return $ cond_ls
-            ++ code "bnz" [true_lab]
-            ++ false_ls
-            ++ code "b" [cont_lab]
-            ++ label true_lab
-            ++ true_ls
-            ++ label cont_lab
-          where  (a_cond, a_true, a_false) = case as of
-                   [c,t,f] -> (c,t,f)
-                   _ -> error "Expected exactly three elements"  -- XXX
+          return $
+            cond_ls
+              ++ code "bnz" [true_lab]
+              ++ false_ls
+              ++ code "b" [cont_lab]
+              ++ label true_lab
+              ++ true_ls
+              ++ label cont_lab
+          where
+            (a_cond, a_true, a_false) = case as of
+              [c, t, f] -> (c, t, f)
+              _ -> error "Expected exactly three elements" -- XXX
         BALANCE ->
-          return $ comp_con (Con_I 0)
-            ++ code "balance" []
+          return $
+            comp_con (Con_I 0)
+              ++ code "balance" []
         TXN_VALUE ->
-          return $ code "gtxn" [ "1", "Amount" ]
+          return $ code "gtxn" ["1", "Amount"]
         BYTES_EQ -> p_op "=="
-     where p_op o = do
-             asl <- concatMapM (comp_blarg cs) as
-             return $ asl ++ code o []
+      where
+        p_op o = do
+          asl <- concatMapM (comp_blarg cs) as
+          return $ asl ++ code o []
 
 comp_cstmt :: CompileSt a -> TxnSt -> CStmt a -> LabelM ann (TxnSt, TEALs)
 comp_cstmt cs ts s =
@@ -254,65 +273,74 @@ comp_cstmt cs ts s =
     C_Claim _ CT_Assert _ -> return $ (ts, [])
     C_Claim _ _ a -> do
       a_ls <- comp_blarg cs a
-      return $ (ts, a_ls
-        ++ code "bz" [ "revert" ])
+      return $
+        ( ts,
+          a_ls
+            ++ code "bz" ["revert"]
+        )
     C_Transfer _ p a -> do
       a_ls <- comp_blarg cs a
       p_ls <- comp_blvar cs p
       let (txn_i, ts') = txn_alloc ts
       let txn_is = show txn_i
-      return $ (ts', comp_con (Con_I $ fromIntegral $ txn_i)
-        ++ code "global" [ "GroupSize" ]
-        ++ code ">" [ ]
-        ++ code "bnz" [ "revert" ]
-        ++ code "gtxn" [ txn_is, "TypeEnum" ]
-        ++ code "int" [ "pay" ]
-        ++ code "!=" [ ]
-        ++ code "bnz" [ "revert" ]
-        ++ code "gtxn" [ txn_is, "Amount" ]
-        ++ a_ls
-        ++ code "!=" [ ]
-        ++ code "bnz" [ "revert" ]
-        ++ code "gtxn" [ txn_is, "Receiver" ]
-        ++ p_ls
-        ++ code "!=" [ ]
-        ++ code "bnz" [ "revert" ]
-        ++ code "gtxn" [ txn_is, "Sender" ]
-        ++ comp_con (Con_BS "me")
-        ++ code "app_global_get" [ ]
-        ++ code "!=" [ ]
-        ++ code "bnz" [ "revert" ])
+      return $
+        ( ts',
+          comp_con (Con_I $ fromIntegral $ txn_i)
+            ++ code "global" ["GroupSize"]
+            ++ code ">" []
+            ++ code "bnz" ["revert"]
+            ++ code "gtxn" [txn_is, "TypeEnum"]
+            ++ code "int" ["pay"]
+            ++ code "!=" []
+            ++ code "bnz" ["revert"]
+            ++ code "gtxn" [txn_is, "Amount"]
+            ++ a_ls
+            ++ code "!=" []
+            ++ code "bnz" ["revert"]
+            ++ code "gtxn" [txn_is, "Receiver"]
+            ++ p_ls
+            ++ code "!=" []
+            ++ code "bnz" ["revert"]
+            ++ code "gtxn" [txn_is, "Sender"]
+            ++ comp_con (Con_BS "me")
+            ++ code "app_global_get" []
+            ++ code "!=" []
+            ++ code "bnz" ["revert"]
+        )
 
 txn_ensure_size :: TxnSt -> TEALs
 txn_ensure_size sz =
   comp_con (Con_I $ fromIntegral sz)
-  ++ code "global" [ "GroupSize" ]
-  ++ code "!=" [ ]
-  ++ code "bnz" [ "revert" ]
+    ++ code "global" ["GroupSize"]
+    ++ code "!=" []
+    ++ code "bnz" ["revert"]
 
 comp_ctail :: CCounts -> CompileSt a -> TxnSt -> CTail a -> LabelM ann TEALs
 comp_ctail ccs cs ts t =
   case t of
     C_Halt _ ->
-      return $ txn_ensure_size ts
-      ++ code "b" ["halt"]
+      return $
+        txn_ensure_size ts
+          ++ code "b" ["halt"]
     C_Wait loc i svs -> do
       hash_ls <- comp_hash (HM_State i True) cs (map (BL_Var loc) svs)
-      return $ txn_ensure_size ts
-        ++ comp_con (Con_BS "state")
-        ++ hash_ls
-        ++ code "app_global_put" []
-        ++ code "b" ["done"]
+      return $
+        txn_ensure_size ts
+          ++ comp_con (Con_BS "state")
+          ++ hash_ls
+          ++ code "app_global_put" []
+          ++ code "b" ["done"]
     C_If _ ca tt ft -> do
       ca_ls <- comp_blarg cs ca
       true_lab <- alloc_lab cs
       ft_ls <- comp_ctail ccs cs ts ft
       tt_ls <- comp_ctail ccs cs ts tt
-      return $ ca_ls
-        ++ code "bnz" [true_lab]
-        ++ ft_ls
-        ++ label true_lab
-        ++ tt_ls
+      return $
+        ca_ls
+          ++ code "bnz" [true_lab]
+          ++ ft_ls
+          ++ label true_lab
+          ++ tt_ls
     C_Let _ bv ce kt ->
       case M.lookup bv ccs of
         Just 0 -> comp_ctail ccs cs ts kt
@@ -320,180 +348,199 @@ comp_ctail ccs cs ts t =
         _ -> do
           ce_ls <- comp_cexpr cs ce
           kt_ls <- comp_ctail ccs cs_scratch ts kt
-          return $ ce_ls
-            ++ code "store" [show bv_loc]
-            ++ kt_ls
-      where cs_later = cs_var_set cs bv (VR_Expr ce)
-            (bv_loc, cs_scratch) = cs_var_loc cs bv
+          return $
+            ce_ls
+              ++ code "store" [show bv_loc]
+              ++ kt_ls
+      where
+        cs_later = cs_var_set cs bv (VR_Expr ce)
+        (bv_loc, cs_scratch) = cs_var_loc cs bv
     C_Do _ ds kt -> do
       (ts', ds_ls) <- comp_cstmt cs ts ds
       kt_ls <- comp_ctail ccs cs ts' kt
       return $ ds_ls ++ kt_ls
     C_Jump loc which vs _ as ->
-      if ts /= txn_init then
-        impossible $ "jump preceded by transfers"
-      else
-        do
+      if ts /= txn_init
+        then impossible $ "jump preceded by transfers"
+        else do
           args <- concatMapM (comp_blarg cs) $ (map (BL_Var loc) vs) ++ as
-          return $ args
-            ++ stack_to_slot ((length vs) + (length as))
-            ++ code "b" [ "l" ++ show which ]
-        where stack_to_slot n =
-                if n == 0 then
-                  []
-                else
-                  code "store" [ show $ n - 1 ]
-                  ++ stack_to_slot (n - 1)
+          return $
+            args
+              ++ stack_to_slot ((length vs) + (length as))
+              ++ code "b" ["l" ++ show which]
+      where
+        stack_to_slot n =
+          if n == 0
+            then []
+            else
+              code "store" [show $ n - 1]
+                ++ stack_to_slot (n - 1)
 
 comp_chandler :: String -> CHandler a -> (String, TEALs)
 comp_chandler next_lab (C_Handler loc from_spec interval (last_i, svs) msg body i) = (lab, bracket ("Handler " ++ show i) $ label lab ++ pre_ls ++ labelRun bodym)
-  where lab = "h" ++ show i
-        cs0 = cs_init lab
-        all_args = svs ++ msg
-        cs1 = cs_var_args cs0 $ all_args
-        cs = case from_spec of
-               FS_Join from ->
-                 cs_var_set cs1 from (VR_Code (code "gtxn" [ "0", "Sender" ]))
-               FS_From _ -> cs1
-        pre_ls =
-          --- FIXME some of these checks could be combined across all handlers
-          --- check account 0 is me
-          comp_con (Con_BS "me")
-          ++ code "txna" [ "Accounts", "0" ]
-          ++ code "==" []
-          ++ code "bz" [ "revert" ]
-          --- check number of arguments
-          ++ code "txn" [ "NumAppArgs" ]
-          ++ (comp_con $ Con_I $ fromIntegral $ 3 + length all_args)
-          ++ code "==" []
-          ++ code "bz" [ next_lab ]
-          --- check message number
-          ++ comp_arg 0
-          ++ code "btoi" []
-          ++ (comp_con $ Con_I $ fromIntegral i)
+  where
+    lab = "h" ++ show i
+    cs0 = cs_init lab
+    all_args = svs ++ msg
+    cs1 = cs_var_args cs0 $ all_args
+    cs = case from_spec of
+      FS_Join from ->
+        cs_var_set cs1 from (VR_Code (code "gtxn" ["0", "Sender"]))
+      FS_From _ -> cs1
+    pre_ls =
+      --- FIXME some of these checks could be combined across all handlers
+      --- check account 0 is me
+      comp_con (Con_BS "me")
+        ++ code "txna" ["Accounts", "0"]
+        ++ code "==" []
+        ++ code "bz" ["revert"]
+        --- check number of arguments
+        ++ code "txn" ["NumAppArgs"]
+        ++ (comp_con $ Con_I $ fromIntegral $ 3 + length all_args)
+        ++ code "==" []
+        ++ code "bz" [next_lab]
+        --- check message number
+        ++ comp_arg 0
+        ++ code "btoi" []
+        ++ (comp_con $ Con_I $ fromIntegral i)
+        ++ code "!=" []
+        ++ code "bnz" [next_lab]
+        --- check that this is an app txn
+        ++ code "gtxn" ["0", "TypeEnum"]
+        ++ code "int" ["appl"]
+        ++ code "==" []
+        ++ code "bz" ["revert"]
+        --- check that txn 1 is a pay to me
+        ++ code "gtxn" ["1", "TypeEnum"]
+        ++ code "int" ["pay"]
+        ++ code "==" []
+        ++ code "bz" ["revert"]
+        ++ code "gtxn" ["1", "Receiver"]
+        ++ comp_con (Con_BS "me")
+        ++ code "app_global_get" []
+        ++ code "==" []
+        ++ code "bz" ["revert"]
+        --- check that the amount agrees with argument 2
+        ++ code "gtxn" ["1", "Amount"]
+        ++ comp_arg 2
+        ++ code "btoi" []
+        ++ code "==" []
+        ++ code "bz" ["revert"]
+    bodym = do
+      sender_ls <-
+        case from_spec of
+          FS_Join _ -> return []
+          FS_From from -> do
+            from_ls <- comp_blvar cs from
+            return $
+              code "gtxn" ["0", "Sender"]
+                ++ from_ls
+                ++ code "!=" []
+                ++ code "bnz" ["revert"]
+      let C_Between int_from int_to = interval
+      let comp_int_side _sign [] = return $ []
+          comp_int_side sign delays = do
+            delays_ls <- mapM (comp_blarg cs) delays
+            return $
+              []
+                -- begin timeout checking
+                ++ ( foldl'
+                       (\x y -> x ++ y ++ code "+" [])
+                       (comp_arg 1 ++ code "btoi" [])
+                       delays_ls
+                   )
+                -- the stack contains the deadline
+                ++ code "global" ["Round"]
+                ++ ( if sign
+                       then -- if this is a timeout, then the round must be
+                       -- after the deadline: deadline < running-time
+                         code "<" []
+                       else -- if this is not a timeout, then the round must be
+                       -- before the deadline: running-time <= deadline ==
+                       -- deadline >= running-time
+                         code ">=" []
+                   )
+                ++ code "bz" ["revert"]
+      -- end of timeout checking
+      int_from_ls <- comp_int_side True int_from
+      int_to_ls <- comp_int_side False int_to
+      hash_ls <- comp_hash (HM_State last_i False) cs (map (BL_Var loc) svs)
+      body_ls <- comp_ctail (usesCTail body) cs txn_init body
+      return $
+        sender_ls
+          ++ int_from_ls
+          ++ int_to_ls
+          ++ hash_ls
+          ++ comp_con (Con_BS "state")
+          ++ code "app_global_get" []
           ++ code "!=" []
-          ++ code "bnz" [ next_lab ]
-          --- check that this is an app txn
-          ++ code "gtxn" [ "0", "TypeEnum" ]
-          ++ code "int" [ "appl" ]
-          ++ code "==" []
-          ++ code "bz" [ "revert" ]
-          --- check that txn 1 is a pay to me
-          ++ code "gtxn" [ "1", "TypeEnum" ]
-          ++ code "int" [ "pay" ]
-          ++ code "==" [ ]
-          ++ code "bz" [ "revert" ]
-          ++ code "gtxn" [ "1", "Receiver" ]
-          ++ comp_con (Con_BS "me")
-          ++ code "app_global_get" [ ]
-          ++ code "==" []
-          ++ code "bz" [ "revert" ]
-          --- check that the amount agrees with argument 2
-          ++ code "gtxn" [ "1", "Amount" ]
-          ++ comp_arg 2
-          ++ code "btoi" []
-          ++ code "==" []
-          ++ code "bz" [ "revert" ]
-        bodym = do
-          sender_ls <-
-            case from_spec of
-              FS_Join _ -> return []
-              FS_From from -> do
-                from_ls <- comp_blvar cs from
-                return $ code "gtxn" [ "0", "Sender" ]
-                  ++ from_ls
-                  ++ code "!=" []
-                  ++ code "bnz" [ "revert" ]
-          let C_Between int_from int_to = interval
-          let comp_int_side _sign [] = return $ []
-              comp_int_side sign delays = do
-                delays_ls <- mapM (comp_blarg cs) delays
-                return $ []
-                  -- begin timeout checking
-                  ++ (foldl' (\x y -> x ++ y ++ code "+" [])
-                      (comp_arg 1 ++ code "btoi" [])
-                      delays_ls)
-                  -- the stack contains the deadline
-                  ++ code "global" [ "Round" ]
-                  ++ (if sign then
-                        -- if this is a timeout, then the round must be
-                        -- after the deadline: deadline < running-time
-                        code "<" []
-                      else
-                        -- if this is not a timeout, then the round must be
-                        -- before the deadline: running-time <= deadline ==
-                        -- deadline >= running-time
-                        code ">=" [])
-                  ++ code "bz" [ "revert" ]
-                  -- end of timeout checking
-          int_from_ls <- comp_int_side True int_from
-          int_to_ls <- comp_int_side False int_to
-          hash_ls <- comp_hash (HM_State last_i False) cs (map (BL_Var loc) svs)
-          body_ls <- comp_ctail (usesCTail body) cs txn_init body
-          return $ sender_ls
-            ++ int_from_ls
-            ++ int_to_ls
-            ++ hash_ls
-            ++ comp_con (Con_BS "state")
-            ++ code "app_global_get" [ ]
-            ++ code "!=" []
-            ++ code "bnz" [ "revert" ]
-            ++ body_ls
+          ++ code "bnz" ["revert"]
+          ++ body_ls
 comp_chandler next_lab (C_Loop _ _svs _args _inv _body _i) = (next_lab, [])
 
 comp_cloop :: CHandler a -> TEALs
 comp_cloop (C_Handler _ _from_spec _interval _ _msg _body _i) = []
 comp_cloop (C_Loop _ svs args _inv body i) = bracket ("Loop " ++ show i) $ label lab ++ labelRun (comp_ctail (usesCTail body) cs txn_init body)
-  where lab = "l" ++ show i
-        cs0 = cs_init lab
-        cs = cs_var_locs cs0 $ svs ++ args
+  where
+    lab = "l" ++ show i
+    cs0 = cs_init lab
+    cs = cs_var_locs cs0 $ svs ++ args
 
 cp_to_teal :: CProgram a -> TEAL
 cp_to_teal (C_Prog _ hs) = TEAL ls
-  where ls = dispatch_ls ++ handlers_ls ++ loop_ls ++ standard_ls
-        dispatch_ls = bracket "Constructor / Dispatcher" $
-                      code "txn" [ "NumAppArgs" ]
-                      ++ (comp_con $ Con_I $ 0)
-                      ++ code "==" []
-                      ++ code "bz" [ next_lab ]
-                      --- Check that global(me) is null
-                      ++ comp_con (Con_BS "me")
-                      ++ code "app_global_get" [ ]
-                      ++ comp_con (Con_BS "")
-                      ++ code "==" []
-                      ++ code "bnz" [ "revert" ]
-                      --- Set global(me)
-                      ++ comp_con (Con_BS "me")
-                      ++ code "txna" [ "Accounts", "0" ]
-                      ++ code "app_global_put" []
-                      --- Set global(state)
-                      ++ comp_con (Con_BS "state")
-                      ++ labelRun (comp_hash (HM_State 0 True) (impossible "TEAL constructor does not use vars") [])
-                      ++ code "app_global_put" []
-                      ++ comp_con (Con_I 1)
-                      ++ code "return" []
-          where next_lab = "h1"
-        handlers_ls = bracket "Handlers" $ snd $ foldl' fh ("revert", []) (reverse hs)
-          where fh (next_lab, prev_ls) h = (this_lab, both_ls)
-                  where (this_lab, this_ls) = comp_chandler next_lab h
-                        both_ls = this_ls ++ prev_ls
-        loop_ls = bracket "Loops" $ concatMap comp_cloop hs
-        standard_ls = bracket "Standard" $ revert_ls ++ halt_ls ++ done_ls
-        halt_ls = label "halt"
-                  ++ comp_con (Con_BS "state")
-                  ++ code "app_global_del" []
-                  ++ comp_con (Con_BS "me")
-                  ++ code "app_global_del" []
-                  ++ code "b" ["done"]
+  where
+    ls = dispatch_ls ++ handlers_ls ++ loop_ls ++ standard_ls
+    dispatch_ls =
+      bracket "Constructor / Dispatcher" $
+        code "txn" ["NumAppArgs"]
+          ++ (comp_con $ Con_I $ 0)
+          ++ code "==" []
+          ++ code "bz" [next_lab]
+          --- Check that global(me) is null
+          ++ comp_con (Con_BS "me")
+          ++ code "app_global_get" []
+          ++ comp_con (Con_BS "")
+          ++ code "==" []
+          ++ code "bnz" ["revert"]
+          --- Set global(me)
+          ++ comp_con (Con_BS "me")
+          ++ code "txna" ["Accounts", "0"]
+          ++ code "app_global_put" []
+          --- Set global(state)
+          ++ comp_con (Con_BS "state")
+          ++ labelRun (comp_hash (HM_State 0 True) (impossible "TEAL constructor does not use vars") [])
+          ++ code "app_global_put" []
+          ++ comp_con (Con_I 1)
+          ++ code "return" []
+      where
+        next_lab = "h1"
+    handlers_ls = bracket "Handlers" $ snd $ foldl' fh ("revert", []) (reverse hs)
+      where
+        fh (next_lab, prev_ls) h = (this_lab, both_ls)
+          where
+            (this_lab, this_ls) = comp_chandler next_lab h
+            both_ls = this_ls ++ prev_ls
+    loop_ls = bracket "Loops" $ concatMap comp_cloop hs
+    standard_ls = bracket "Standard" $ revert_ls ++ halt_ls ++ done_ls
+    halt_ls =
+      label "halt"
+        ++ comp_con (Con_BS "state")
+        ++ code "app_global_del" []
+        ++ comp_con (Con_BS "me")
+        ++ code "app_global_del" []
+        ++ code "b" ["done"]
 
 revert_ls :: TEALs
-revert_ls = label "revert"
-  ++ comp_con (Con_I 0)
-  ++ code "return" []
+revert_ls =
+  label "revert"
+    ++ comp_con (Con_I 0)
+    ++ code "return" []
+
 done_ls :: TEALs
-done_ls = label "done"
-  ++ comp_con (Con_I 1)
-  ++ code "return" []
+done_ls =
+  label "done"
+    ++ comp_con (Con_I 1)
+    ++ code "return" []
 
 -- FIXME Do something like a "peep-hole optimizer" so we can detect "btoi -> itob" sequences
 
@@ -501,7 +548,7 @@ compile_teal :: String -> TEAL -> IO String
 compile_teal _which t = do
   let ts = show t
   (Just hin, Just hout, Just herr, hP) <-
-    createProcess (proc "goal" ["clerk", "compile", "-"]){ std_in = CreatePipe, std_out = CreatePipe, std_err = CreatePipe }
+    createProcess (proc "goal" ["clerk", "compile", "-"]) {std_in = CreatePipe, std_out = CreatePipe, std_err = CreatePipe}
   hPutStr hin ts
   hClose hin
   hSetBinaryMode hout True
@@ -510,33 +557,39 @@ compile_teal _which t = do
   ec <- waitForProcess hP
   case ec of
     ExitFailure _ ->
-      die $ "goal clerk compile failed:\n"
-      ++ "STDOUT:\n" ++ (C.unpack stdout_bs) ++ "\n"
-      ++ "STDERR:\n" ++ stderr_s ++ "\n"
+      die $
+        "goal clerk compile failed:\n"
+          ++ "STDOUT:\n"
+          ++ (C.unpack stdout_bs)
+          ++ "\n"
+          ++ "STDERR:\n"
+          ++ stderr_s
+          ++ "\n"
     ExitSuccess -> do
       return $ C.unpack $ encodeBase64' stdout_bs
 
 lsp_bc :: TEAL
-lsp_bc = TEAL $
-  --- check that group size is at least 2
-  (comp_con $ Con_I 2)
-  ++ code "global" [ "GroupSize" ]
-  ++ code "<=" []
-  ++ code "bz" [ "revert" ]
-  --- check that 1st txn is appl
-  ++ code "gtxn" [ "0", "TypeEnum" ]
-  ++ code "int" [ "appl" ]
-  ++ code "==" []
-  ++ code "bz" [ "revert" ]
-  --- check that the app id is our first argument
-  ++ code "gtxn" [ "0", "ApplicationID" ]
-  --- FIXME this should be "compile argument", see https://github.com/algorand/go-algorand/issues/1051
-  ++ code "arg" [ "0" ]
-  ++ code "==" []
-  ++ code "bz" [ "revert" ]
-  ++ code "b" [ "done" ]
-  ++ revert_ls
-  ++ done_ls
+lsp_bc =
+  TEAL $
+    --- check that group size is at least 2
+    (comp_con $ Con_I 2)
+      ++ code "global" ["GroupSize"]
+      ++ code "<=" []
+      ++ code "bz" ["revert"]
+      --- check that 1st txn is appl
+      ++ code "gtxn" ["0", "TypeEnum"]
+      ++ code "int" ["appl"]
+      ++ code "==" []
+      ++ code "bz" ["revert"]
+      --- check that the app id is our first argument
+      ++ code "gtxn" ["0", "ApplicationID"]
+      --- FIXME this should be "compile argument", see https://github.com/algorand/go-algorand/issues/1051
+      ++ code "arg" ["0"]
+      ++ code "==" []
+      ++ code "bz" ["revert"]
+      ++ code "b" ["done"]
+      ++ revert_ls
+      ++ done_ls
 
 emit_teal :: FilePath -> BLProgram a -> IO CompiledTeal
 emit_teal tf (BL_Prog _ _ _ cp) = do
@@ -546,4 +599,4 @@ emit_teal tf (BL_Prog _ _ _ cp) = do
   tc_lsp <- compile_teal "LSP" lsp_bc
   tc_ap <- compile_teal "AP" ap_bc
   tc_csp <- compile_teal "CSP" (TEAL $ comp_con (Con_I 1))
-  return ( tc_lsp, tc_ap, tc_csp )
+  return (tc_lsp, tc_ap, tc_csp)

--- a/hs/src/Reach/Connector/ETH_EVM.hs
+++ b/hs/src/Reach/Connector/ETH_EVM.hs
@@ -1,98 +1,112 @@
 module Reach.Connector.ETH_EVM where
 
 import Control.Monad.State.Lazy
-import qualified Data.Word as W
 --import qualified Data.HexString as H
-import qualified Data.ByteString.Builder as BB
+
+import Crypto.Hash
+import Data.ByteArray (convert)
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Char8 as BC
+import Data.Foldable
+import Data.List
 import qualified Data.Map.Strict as M
+import Data.Monoid
 import qualified Data.Sequence as Q
 import qualified Data.Set as S
-import Data.Foldable
-import Data.Monoid
-import Crypto.Hash
-import Data.List
-import Data.ByteArray (convert)
-
+import qualified Data.Word as W
 import qualified EVM.Bytecode as EVM
 --- https://ethervm.io/
 
 import Reach.AST
-import Reach.Util
 import Reach.Connector.ETH_Solidity
-  ( CCounts
-  , usesCTail )
+  ( CCounts,
+    usesCTail,
+  )
+import Reach.Util
 
 m_insertSafe :: Show k => Ord k => k -> v -> M.Map k v -> M.Map k v
 m_insertSafe k v m =
   case M.lookup k m of
     Nothing -> M.insert k v m
     Just _ ->
-      error $ "m_insertSafe: Key already set: " ++ show k ++ " inside: " ++ (show $ map (\(x,_)->x) $ M.toAscList m)
+      error $ "m_insertSafe: Key already set: " ++ show k ++ " inside: " ++ (show $ map (\(x, _) -> x) $ M.toAscList m)
 
 type ASMMonad ann a = State ASMSt a
+
 type Label = Int
+
 data LabelInfo = LabelInfo Int Int
   deriving (Show, Eq, Ord)
+
 data ASMOp
   = Op EVM.Opcode
   | LabelRef Label Int (LabelInfo -> EVM.Opcode)
+
 type ASMSt =
-  ( LinkerSt
-  , CompileSt )
+  ( LinkerSt,
+    CompileSt
+  )
+
 type ASMSeq =
   Q.Seq ASMOp
+
 type LinkerSt =
-  ( Label --- next
-  , M.Map Label ASMSeq --- label to code map
-  , LabelSt -- standard labels
-  , ASMSeq --- code
+  ( Label, --- next
+    M.Map Label ASMSeq, --- label to code map
+    LabelSt, -- standard labels
+    ASMSeq --- code
   )
+
 type LabelSt =
-  ( Label --- halt
-  , Label --- revert
-  , M.Map Int Label --- handlers
+  ( Label, --- halt
+    Label, --- revert
+    M.Map Int Label --- handlers
   )
+
 data VarRHS
   = VR_Mem Int
   | VR_Op EVM.Opcode
+
 type CompileSt =
-  ( Int --- stack depth
-  , Int --- mem free pointer
-  , M.Map BLVar VarRHS --- variable to mem addr
-  , M.Map BC.ByteString Int --- bytestring to addr
+  ( Int, --- stack depth
+    Int, --- mem free pointer
+    M.Map BLVar VarRHS, --- variable to mem addr
+    M.Map BC.ByteString Int --- bytestring to addr
   )
 
 --- FIXME Add JUMPDEST
 
 empty_asm_st :: ASMSt
-empty_asm_st = ( empty_linker_st, empty_compile_st )
+empty_asm_st = (empty_linker_st, empty_compile_st)
+
 empty_linker_st :: LinkerSt
-empty_linker_st = ( 0, M.empty, empty_label_st, Q.empty )
+empty_linker_st = (0, M.empty, empty_label_st, Q.empty)
+
 empty_label_st :: LabelSt
-empty_label_st = ( 0, 0, M.empty )
+empty_label_st = (0, 0, M.empty)
+
 empty_compile_st :: CompileSt
-empty_compile_st = ( 0, 0, M.empty, M.empty )
+empty_compile_st = (0, 0, M.empty, M.empty)
 
 asm_fresh_label_obs :: (Label -> ASMMonad ann a) -> ASMMonad ann a
 asm_fresh_label_obs obs_and_code = do
-  ( ls, cs ) <- get
-  let ( this_label, defs, lst, orig_code ) = ls
+  (ls, cs) <- get
+  let (this_label, defs, lst, orig_code) = ls
   let next' = this_label + 1
   let fresh_code = Q.empty
-  let ls' = ( next', defs, lst, fresh_code )
-  put ( ls', cs )
+  let ls' = (next', defs, lst, fresh_code)
+  put (ls', cs)
   res <- obs_and_code this_label
-  ( after_ls, after_cs ) <- get
-  let ( after_next, after_defs, after_lst, after_code ) = after_ls
+  (after_ls, after_cs) <- get
+  let (after_next, after_defs, after_lst, after_code) = after_ls
   let after_defs' = m_insertSafe this_label after_code after_defs
-  let after_ls' = ( after_next, after_defs', after_lst, orig_code )
-  put ( after_ls', after_cs )
+  let after_ls' = (after_next, after_defs', after_lst, orig_code)
+  put (after_ls', after_cs)
   return res
 
 asm_fresh_label :: ASMMonad ann () -> ASMMonad ann Label
-asm_fresh_label new_code = asm_fresh_label_obs (\lab -> do new_code ; return lab)
+asm_fresh_label new_code = asm_fresh_label_obs (\lab -> do new_code; return lab)
 
 asm_with_label_handler :: Int -> ASMMonad ann () -> ASMMonad ann Label
 asm_with_label_handler which hand_code = asm_fresh_label_obs $ \label -> do
@@ -103,58 +117,60 @@ asm_with_label_handler which hand_code = asm_fresh_label_obs $ \label -> do
 -- FIXME Have asm_push/pop/stack be inside of asm_op, or maybe as some sort of pass during assembly
 asm_stack :: Int -> Int -> ASMMonad ann ()
 asm_stack outs ins = do
-  ( ls, cs ) <- get
-  let ( stack, mp, vmap, smap ) = cs
+  (ls, cs) <- get
+  let (stack, mp, vmap, smap) = cs
   let stack' = stack - outs + ins
-  if stack' > 1023 then
-    error "asm_stack: Depth is too deep"
-  else do
-    let cs' = ( stack', mp, vmap, smap )
-    put ( ls, cs' )
+  if stack' > 1023
+    then error "asm_stack: Depth is too deep"
+    else do
+      let cs' = (stack', mp, vmap, smap)
+      put (ls, cs')
 
 asm_rawop :: ASMOp -> ASMMonad ann ()
 asm_rawop aop = do
-  ( ls, cs ) <- get
-  let ( next_label, label_seq, label_refs, code ) = ls
-  let ls' = ( next_label, label_seq, label_refs, code Q.|> aop )
-  put ( ls', cs )
+  (ls, cs) <- get
+  let (next_label, label_seq, label_refs, code) = ls
+  let ls' = (next_label, label_seq, label_refs, code Q.|> aop)
+  put (ls', cs)
 
 asm_labels :: ASMMonad ann LabelSt
 asm_labels = do
-  ( ls, _ ) <- get
-  let ( _, _, l, _ ) = ls
+  (ls, _) <- get
+  let (_, _, l, _) = ls
   return l
 
 asm_labels_set :: Label -> Label -> ASMMonad ann ()
 asm_labels_set halt_lab rev_lab = do
-  ( ls, cs ) <- get
-  let ( next, defs, l, code ) = ls
-  let ( _, _, hs ) = l
-  let l' = ( halt_lab, rev_lab, hs )
-  let ls' = ( next, defs, l', code )
-  put ( ls', cs )
+  (ls, cs) <- get
+  let (next, defs, l, code) = ls
+  let (_, _, hs) = l
+  let l' = (halt_lab, rev_lab, hs)
+  let ls' = (next, defs, l', code)
+  put (ls', cs)
 
 asm_labels_set_handler :: Int -> Label -> ASMMonad ann ()
 asm_labels_set_handler which lab = do
-  ( ls, cs ) <- get
-  let ( next, defs, l, code ) = ls
-  let ( h, r, hs ) = l
+  (ls, cs) <- get
+  let (next, defs, l, code) = ls
+  let (h, r, hs) = l
   let hs' = m_insertSafe which lab hs
-  let l' = ( h, r, hs' )
-  let ls' = ( next, defs, l', code )
-  put ( ls', cs )
+  let l' = (h, r, hs')
+  let ls' = (next, defs, l', code)
+  put (ls', cs)
 
 asm_label_halt :: ASMMonad ann Label
 asm_label_halt = do
-  ( l, _, _ ) <- asm_labels
+  (l, _, _) <- asm_labels
   return l
+
 asm_label_revert :: ASMMonad ann Label
 asm_label_revert = do
-  ( _, l, _ ) <- asm_labels
+  (_, l, _) <- asm_labels
   return l
+
 asm_label_handler :: Int -> ASMMonad ann Label
 asm_label_handler i = do
-  ( _, _, hs ) <- asm_labels
+  (_, _, hs) <- asm_labels
   case M.lookup i hs of
     Just l -> return l
     Nothing ->
@@ -165,6 +181,7 @@ asm_op op = asm_rawop $ Op op
 
 asm_pop :: Int -> ASMMonad ann ()
 asm_pop k = asm_stack k 0
+
 asm_push :: Int -> ASMMonad ann ()
 asm_push k = asm_stack 0 k
 
@@ -174,41 +191,45 @@ evm_op_len o = length $ EVM.encode [o]
 
 assemble :: ASMMonad ann () -> [EVM.Opcode]
 assemble am = map asmfix $ toList image
-  where ((), ((_, defs, _, main), _)) = runState am empty_asm_st
-        asmfix ao =
-          case ao of
-            Op o -> o
-            LabelRef l _ f ->
-              case M.lookup l locs of
-                Nothing -> error $ "Undefined label in assembly: " ++ show l
-                Just li -> f li
-        op_length (Op o) = evm_op_len o
-        op_length (LabelRef _ l _) = l
-        (_, locs, image) = M.foldlWithKey loc1 (main_sz, M.empty, main) defs
-        seq_length = getSum . foldMap (Sum . op_length)
-        main_sz = seq_length main
-        loc1 (start, locs0, before) label body_seq = (end, locs1, after)
-          where sz = seq_length body_seq
-                end = start + sz
-                locs1 = m_insertSafe label (LabelInfo start sz) locs0
-                after = before Q.>< body_seq
+  where
+    ((), ((_, defs, _, main), _)) = runState am empty_asm_st
+    asmfix ao =
+      case ao of
+        Op o -> o
+        LabelRef l _ f ->
+          case M.lookup l locs of
+            Nothing -> error $ "Undefined label in assembly: " ++ show l
+            Just li -> f li
+    op_length (Op o) = evm_op_len o
+    op_length (LabelRef _ l _) = l
+    (_, locs, image) = M.foldlWithKey loc1 (main_sz, M.empty, main) defs
+    seq_length = getSum . foldMap (Sum . op_length)
+    main_sz = seq_length main
+    loc1 (start, locs0, before) label body_seq = (end, locs1, after)
+      where
+        sz = seq_length body_seq
+        end = start + sz
+        locs1 = m_insertSafe label (LabelInfo start sz) locs0
+        after = before Q.>< body_seq
 
 asm_push_label_offset :: Label -> ASMMonad ann ()
-asm_push_label_offset l = asm_rawop $ LabelRef l 2 (\ (LabelInfo off _) -> (EVM.PUSH1 [fromIntegral off]))
+asm_push_label_offset l = asm_rawop $ LabelRef l 2 (\(LabelInfo off _) -> (EVM.PUSH1 [fromIntegral off]))
+
 asm_push_label_size :: Label -> ASMMonad ann ()
-asm_push_label_size l = asm_rawop $ LabelRef l 2 (\ (LabelInfo _ sz) -> (EVM.PUSH1 [fromIntegral sz]))
+asm_push_label_size l = asm_rawop $ LabelRef l 2 (\(LabelInfo _ sz) -> (EVM.PUSH1 [fromIntegral sz]))
 
 asm_mem_ptr :: ASMMonad ann Int
 asm_mem_ptr = do
-  ( _, cs ) <- get
-  let ( _, mp, _, _ ) = cs
+  (_, cs) <- get
+  let (_, mp, _, _) = cs
   return mp
+
 asm_mem_reset :: Int -> ASMMonad ann ()
 asm_mem_reset mp' = do
-  ( ls, cs ) <- get
-  let ( stack, _, vmap, smap ) = cs
-  let cs' = ( stack, mp', vmap, smap )
-  put ( ls, cs' )
+  (ls, cs) <- get
+  let (stack, _, vmap, smap) = cs
+  let cs' = (stack, mp', vmap, smap)
+  put (ls, cs')
 
 is_pointer :: LType -> Bool
 is_pointer (LT_BT bt) =
@@ -233,11 +254,11 @@ size_of_var (_, (_, t)) = size_of_type t
 
 asm_vmap_set :: BLVar -> VarRHS -> ASMMonad ann ()
 asm_vmap_set v vr = do
-  ( ls, cs ) <- get
-  let ( sd,  mp, vmap, smap ) = cs
+  (ls, cs) <- get
+  let (sd, mp, vmap, smap) = cs
   let vmap' = m_insertSafe v vr vmap
-  let cs' = ( sd, mp, vmap', smap )
-  put ( ls, cs' )
+  let cs' = (sd, mp, vmap', smap)
+  put (ls, cs')
 
 asm_malloc :: BLVar -> ASMMonad ann ()
 asm_malloc v = do
@@ -246,11 +267,11 @@ asm_malloc v = do
 
 mem_bump_and_store :: Int -> ASMMonad ann Int
 mem_bump_and_store sz = do
-  ( ls, cs ) <- get
-  let ( sd, mp, vmap, smap ) = cs
+  (ls, cs) <- get
+  let (sd, mp, vmap, smap) = cs
   let mp' = mp + sz
-  let cs' = ( sd, mp', vmap, smap )
-  put ( ls, cs' )
+  let cs' = (sd, mp', vmap, smap)
+  put (ls, cs')
   return mp
 
 comp_bump_and_store :: Int -> ASMMonad ann ()
@@ -265,18 +286,18 @@ comp_bump_and_store_arg a = do
 
 asm_free_all :: ASMMonad ann ()
 asm_free_all = do
-  ( ls, cs ) <- get
-  let ( _sd, _mp, _vmap, _smap ) = cs
+  (ls, cs) <- get
+  let (_sd, _mp, _vmap, _smap) = cs
   --- FIXME check sd for 0
-  put ( ls, empty_compile_st )
+  put (ls, empty_compile_st)
 
 asm_malloc_args :: [BLVar] -> ASMMonad ann ()
 asm_malloc_args args = mapM_ asm_malloc args
 
 asm_vmap_ref :: BLVar -> ASMMonad ann VarRHS
 asm_vmap_ref v = do
-  ( _, cs ) <- get
-  let ( _, _, vmap, _ ) = cs
+  (_, cs) <- get
+  let (_, _, vmap, _) = cs
   case M.lookup v vmap of
     Nothing -> error $ "asm_vmap_ref: Variable not in memory: " ++ show v
     Just addr -> do
@@ -285,59 +306,60 @@ asm_vmap_ref v = do
 comp_jump_to_label :: Label -> Bool -> ASMMonad ann ()
 comp_jump_to_label lab cond = do
   asm_push_label_offset lab
-  if cond then
-    do asm_op EVM.JUMPI
-       asm_pop 2
-  else
-    do asm_op EVM.JUMP
-       asm_pop 1
+  if cond
+    then do
+      asm_op EVM.JUMPI
+      asm_pop 2
+    else do
+      asm_op EVM.JUMP
+      asm_pop 1
 
 comp_jump_to_handler :: Int -> ASMMonad ann ()
 comp_jump_to_handler which = do
   lab <- asm_label_handler which
   comp_jump_to_label lab False
 
-evm_pushN :: [ W.Word8 ] -> EVM.Opcode
+evm_pushN :: [W.Word8] -> EVM.Opcode
 evm_pushN args = op args
   where
     op = case length args of
-           0 -> \ _ -> EVM.PUSH1 [ 0 ]
-           1 -> EVM.PUSH1
-           2 -> EVM.PUSH2
-           3 -> EVM.PUSH3
-           4 -> EVM.PUSH4
-           5 -> EVM.PUSH5
-           6 -> EVM.PUSH6
-           7 -> EVM.PUSH7
-           8 -> EVM.PUSH8
-           9 -> EVM.PUSH9
-           10 -> EVM.PUSH10
-           11 -> EVM.PUSH11
-           12 -> EVM.PUSH12
-           13 -> EVM.PUSH13
-           14 -> EVM.PUSH14
-           15 -> EVM.PUSH15
-           16 -> EVM.PUSH16
-           17 -> EVM.PUSH17
-           18 -> EVM.PUSH18
-           19 -> EVM.PUSH19
-           20 -> EVM.PUSH20
-           21 -> EVM.PUSH21
-           22 -> EVM.PUSH22
-           23 -> EVM.PUSH23
-           24 -> EVM.PUSH24
-           25 -> EVM.PUSH25
-           26 -> EVM.PUSH26
-           27 -> EVM.PUSH27
-           28 -> EVM.PUSH28
-           29 -> EVM.PUSH29
-           30 -> EVM.PUSH30
-           31 -> EVM.PUSH31
-           32 -> EVM.PUSH32
-           _ -> error $ "Constant is too large: " ++ show args
+      0 -> \_ -> EVM.PUSH1 [0]
+      1 -> EVM.PUSH1
+      2 -> EVM.PUSH2
+      3 -> EVM.PUSH3
+      4 -> EVM.PUSH4
+      5 -> EVM.PUSH5
+      6 -> EVM.PUSH6
+      7 -> EVM.PUSH7
+      8 -> EVM.PUSH8
+      9 -> EVM.PUSH9
+      10 -> EVM.PUSH10
+      11 -> EVM.PUSH11
+      12 -> EVM.PUSH12
+      13 -> EVM.PUSH13
+      14 -> EVM.PUSH14
+      15 -> EVM.PUSH15
+      16 -> EVM.PUSH16
+      17 -> EVM.PUSH17
+      18 -> EVM.PUSH18
+      19 -> EVM.PUSH19
+      20 -> EVM.PUSH20
+      21 -> EVM.PUSH21
+      22 -> EVM.PUSH22
+      23 -> EVM.PUSH23
+      24 -> EVM.PUSH24
+      25 -> EVM.PUSH25
+      26 -> EVM.PUSH26
+      27 -> EVM.PUSH27
+      28 -> EVM.PUSH28
+      29 -> EVM.PUSH29
+      30 -> EVM.PUSH30
+      31 -> EVM.PUSH31
+      32 -> EVM.PUSH32
+      _ -> error $ "Constant is too large: " ++ show args
 
-integerToWords :: Integer -> [ W.Word8 ]
-integerToWords i = if i == 0 then [] else (fromIntegral $ i `mod` 256) : (integerToWords $ i `div` 256 )
+integerToWords :: Integer -> [W.Word8]
+integerToWords i = if i == 0 then [] else (fromIntegral $ i `mod` 256) : (integerToWords $ i `div` 256)
 
 type CStrings = S.Set BC.ByteString
 
@@ -346,7 +368,7 @@ smerge m1 m2 = S.union m1 m2
 
 smerges :: [CStrings] -> CStrings
 smerges [] = S.empty
-smerges (m1:ms) = smerge m1 $ smerges ms
+smerges (m1 : ms) = smerge m1 $ smerges ms
 
 stringsConstant :: Constant -> CStrings
 stringsConstant (Con_I _) = S.empty
@@ -362,29 +384,32 @@ stringsCExpr (C_PrimApp _ _ al) = smerges $ map stringsBLArg al
 stringsCExpr (C_Digest _ al) = smerges $ map stringsBLArg al
 stringsCExpr (C_ArrayRef _ ae ee) = smerges $ map stringsBLArg [ae, ee]
 
-stringsCStmt :: CStmt a  -> CStrings
+stringsCStmt :: CStmt a -> CStrings
 stringsCStmt (C_Claim _ _ a) = stringsBLArg a
 stringsCStmt (C_Transfer _ _ a) = stringsBLArg a
 
 stringsCTail :: CTail a -> CStrings
 stringsCTail (C_Halt _) = S.empty
 stringsCTail (C_Wait _ _ _) = S.empty
-stringsCTail (C_If _ ca tt ft) = smerges [ cs1, cs2, cs3 ]
-  where cs1 = stringsBLArg ca
-        cs2 = stringsCTail tt
-        cs3 = stringsCTail ft
+stringsCTail (C_If _ ca tt ft) = smerges [cs1, cs2, cs3]
+  where
+    cs1 = stringsBLArg ca
+    cs2 = stringsCTail tt
+    cs3 = stringsCTail ft
 stringsCTail (C_Let _ _ ce kt) = smerge cs1 cs2
-  where cs1 = stringsCExpr ce
-        cs2 = stringsCTail kt
+  where
+    cs1 = stringsCExpr ce
+    cs2 = stringsCTail kt
 stringsCTail (C_Do _ cs kt) = smerge cs1 cs2
-  where cs1 = stringsCStmt cs
-        cs2 = stringsCTail kt
+  where
+    cs1 = stringsCStmt cs
+    cs2 = stringsCTail kt
 stringsCTail (C_Jump _ _ _ _ as) = smerges $ map stringsBLArg as
 
 asm_constant_bytes_lookup :: BC.ByteString -> ASMMonad ann Int
 asm_constant_bytes_lookup bs = do
-  ( _, cs ) <- get
-  let ( _, _, _, smap ) = cs
+  (_, cs) <- get
+  let (_, _, _, smap) = cs
   case M.lookup bs smap of
     Nothing -> error $ "asm_constant_bytes_lookup: Constant not in memory: " ++ show bs
     Just addr -> do
@@ -392,20 +417,24 @@ asm_constant_bytes_lookup bs = do
 
 comp_load_string :: BC.ByteString -> ASMMonad ann ()
 comp_load_string s = do
-  ( ls, cs ) <- get
-  let ( sd, mp, vmap, smap ) = cs
+  (ls, cs) <- get
+  let (sd, mp, vmap, smap) = cs
   let len = BC.length s
   let bs_ptr = mp
   let bs_data_ptr = bs_ptr + (size_of_type $ LT_BT BT_UInt256)
   let mp' = bs_data_ptr + len
   let smap' = m_insertSafe s mp smap
-  let cs' = ( sd, mp', vmap, smap' )
-  put ( ls, cs' )
-  foldM_ (\ptr c -> do comp_con $ Con_I $ fromIntegral $ fromEnum c
-                       comp_con $ Con_I $ fromIntegral ptr
-                       asm_op $ EVM.MSTORE8
-                       return $ ptr + 8)
-         bs_data_ptr (BC.unpack s)
+  let cs' = (sd, mp', vmap, smap')
+  put (ls, cs')
+  foldM_
+    ( \ptr c -> do
+        comp_con $ Con_I $ fromIntegral $ fromEnum c
+        comp_con $ Con_I $ fromIntegral ptr
+        asm_op $ EVM.MSTORE8
+        return $ ptr + 8
+    )
+    bs_data_ptr
+    (BC.unpack s)
   comp_con $ Con_I $ fromIntegral len
   comp_con $ Con_I $ fromIntegral bs_ptr
   asm_op $ EVM.MSTORE
@@ -420,7 +449,7 @@ comp_con c =
       asm_op $ evm_pushN $ integerToWords i
       asm_push 1
     Con_B t -> do
-      asm_op (EVM.PUSH1 [ if t then 1 else 0 ])
+      asm_op (EVM.PUSH1 [if t then 1 else 0])
       asm_push 1
     Con_BS bs -> do
       bs_addr <- asm_constant_bytes_lookup bs
@@ -428,14 +457,14 @@ comp_con c =
 
 comp_memread :: Int -> ASMMonad ann ()
 comp_memread addr = do
-  asm_op $ EVM.PUSH1 [ fromIntegral $ addr ]
+  asm_op $ EVM.PUSH1 [fromIntegral $ addr]
   asm_push 1
   asm_op $ EVM.MLOAD
   asm_stack 1 1
 
 comp_cdread :: Int -> ASMMonad ann ()
 comp_cdread addr = do
-  asm_op $ EVM.PUSH1 [ fromIntegral $ addr ]
+  asm_op $ EVM.PUSH1 [fromIntegral $ addr]
   asm_push 1
   asm_op $ EVM.CALLDATALOAD
   asm_stack 1 1
@@ -446,10 +475,9 @@ comp_blvar v = do
   vrhs <- asm_vmap_ref v
   case vrhs of
     VR_Mem addr ->
-      if is_pointer bt then
-        comp_con $ Con_I $ fromIntegral addr
-      else
-        comp_memread addr
+      if is_pointer bt
+        then comp_con $ Con_I $ fromIntegral addr
+        else comp_memread addr
     VR_Op o -> do
       asm_op o
       asm_push 1
@@ -463,7 +491,7 @@ comp_blarg a =
 comp_cexpr :: CExpr a -> ASMMonad ann () -> ASMMonad ann ()
 comp_cexpr e km =
   case e of
-    C_Digest _ as -> do comp_hash HM_Digest as ; km
+    C_Digest _ as -> do comp_hash HM_Digest as; km
     C_ArrayRef _ _ae _ee ->
       end_block_op "XXX comp_cexpr C_ArrayRef"
     C_PrimApp _ cp as -> do
@@ -501,19 +529,22 @@ comp_cexpr e km =
         BALANCE -> p_op EVM.BALANCE 0
         TXN_VALUE -> p_op EVM.CALLVALUE 0
         BYTES_EQ -> end_block_op "XXX bytes_eq"
-  where p_op o amt = do asm_op o
-                        asm_stack amt 1
-                        km
-        p_op_not o amt = do asm_op o
-                            asm_stack amt 1
-                            asm_op EVM.NOT
-                            asm_stack 1 1
-                            km
+  where
+    p_op o amt = do
+      asm_op o
+      asm_stack amt 1
+      km
+    p_op_not o amt = do
+      asm_op o
+      asm_stack amt 1
+      asm_op EVM.NOT
+      asm_stack 1 1
+      km
 
 callStipend :: Integer
 callStipend = 2300
 
-comp_cstmt :: CStmt a -> ASMMonad ann  ()
+comp_cstmt :: CStmt a -> ASMMonad ann ()
 comp_cstmt s =
   case s of
     C_Claim _ CT_Possible _ -> return ()
@@ -561,10 +592,9 @@ comp_hash m as = do
       comp_con $ Con_I $ fromIntegral i
       comp_bump_and_store (size_of_type $ LT_BT BT_UInt256)
       --- push block number in hash args
-      if use_this_block then
-        asm_op $ EVM.NUMBER
-      else
-        comp_memread last_time_offset
+      if use_this_block
+        then asm_op $ EVM.NUMBER
+        else comp_memread last_time_offset
       comp_bump_and_store (size_of_type $ LT_BT BT_UInt256)
   --- push variables
   mapM_ comp_bump_and_store_arg as
@@ -608,33 +638,36 @@ comp_set_args args = do
   mem_before <- asm_mem_ptr
   --- copy args to contiguous block at end of memory
   (_, _, copy_m_end) <-
-    foldM (\ (arg_dest, arg_copy, copy_m) arg -> do
-              comp_blarg arg
-              asm_op $ EVM.PUSH1 [ fromIntegral arg_copy ]
-              asm_push 1
-              asm_op $ EVM.MSTORE
-              asm_pop 2
-              let size = (size_of_type $ LT_BT BT_UInt256)
-              let next_copy = arg_copy + size
-              let next_dest = arg_dest + size
-              let copy_m' = do
-                    copy_m
-                    asm_op $ EVM.PUSH1 [ fromIntegral arg_copy ]
-                    asm_push 1
-                    asm_op $ EVM.MLOAD
-                    asm_stack 1 1
-                    asm_op $ EVM.PUSH1 [ fromIntegral arg_dest ]
-                    asm_push 1
-                    asm_op $ EVM.MSTORE
-                    asm_pop 2
-              return (next_dest, next_copy, copy_m'))
-          (0, mem_before, return ()) args
+    foldM
+      ( \(arg_dest, arg_copy, copy_m) arg -> do
+          comp_blarg arg
+          asm_op $ EVM.PUSH1 [fromIntegral arg_copy]
+          asm_push 1
+          asm_op $ EVM.MSTORE
+          asm_pop 2
+          let size = (size_of_type $ LT_BT BT_UInt256)
+          let next_copy = arg_copy + size
+          let next_dest = arg_dest + size
+          let copy_m' = do
+                copy_m
+                asm_op $ EVM.PUSH1 [fromIntegral arg_copy]
+                asm_push 1
+                asm_op $ EVM.MLOAD
+                asm_stack 1 1
+                asm_op $ EVM.PUSH1 [fromIntegral arg_dest]
+                asm_push 1
+                asm_op $ EVM.MSTORE
+                asm_pop 2
+          return (next_dest, next_copy, copy_m')
+      )
+      (0, mem_before, return ())
+      args
   --- copy that block to the beginning of memory
   copy_m_end
 
 comp_store :: Int -> ASMMonad ann ()
 comp_store addr = do
-  asm_op $ EVM.PUSH1 [ fromIntegral addr ]
+  asm_op $ EVM.PUSH1 [fromIntegral addr]
   asm_push 1
   asm_op $ EVM.MSTORE
   asm_pop 2
@@ -698,25 +731,28 @@ abiTag_type (LT_FixedArray bt hm) = abiTag_btype bt ++ "[" ++ show hm ++ "]"
 
 --- FIXME just get first four bytes
 --- https://solidity.readthedocs.io/en/latest/abi-spec.html#function-selector
-abiTag :: AbiTag_Kind -> Int -> [ BLVar ] -> Integer
+abiTag :: AbiTag_Kind -> Int -> [BLVar] -> Integer
 abiTag k i vs = h
-  where label = case k of
-                  AT_Method -> "m"
-                  AT_Evt -> "e"
-        args = map (\(_, (_, t)) -> abiTag_type t) vs
-        args_s = intersperse ',' $ concat args
-        s = label ++ (show i) ++ "(" ++ args_s ++ ")"
-        bs :: B.ByteString
-        bs = bpack s
-        h_bs :: B.ByteString
-        h_bs = convert (hash bs :: Digest Keccak_256)
-        h :: Integer
-        h = B.foldl (\ prev v -> prev * 256 + fromIntegral v) 0 h_bs
+  where
+    label = case k of
+      AT_Method -> "m"
+      AT_Evt -> "e"
+    args = map (\(_, (_, t)) -> abiTag_type t) vs
+    args_s = intersperse ',' $ concat args
+    s = label ++ (show i) ++ "(" ++ args_s ++ ")"
+    bs :: B.ByteString
+    bs = bpack s
+    h_bs :: B.ByteString
+    h_bs = convert (hash bs :: Digest Keccak_256)
+    h :: Integer
+    h = B.foldl (\prev v -> prev * 256 + fromIntegral v) 0 h_bs
 
 tag_offset :: Int
 tag_offset = 0
+
 last_time_offset :: Int
 last_time_offset = tag_offset + 4
+
 arg_start_offset :: Int
 arg_start_offset = last_time_offset + (size_of_type $ LT_BT BT_UInt256)
 
@@ -763,7 +799,7 @@ comp_chandler next_lab (C_Handler _ from_spec _interval (last_i, svs) msg body i
       asm_op $ EVM.EQ
       asm_stack 2 1
       asm_op $ EVM.NOT
-      asm_stack 1 1      
+      asm_stack 1 1
       comp_jump_to_label revert_lab True
   --- check timeout
   comp_cdread last_time_offset
@@ -774,10 +810,9 @@ comp_chandler next_lab (C_Handler _ from_spec _interval (last_i, svs) msg body i
   asm_push 1
   asm_op $ EVM.LT
   asm_stack 2 1
-  if False then --- XXX
-    return ()
-  else
-    asm_op $ EVM.NOT
+  if False --- XXX
+    then return ()
+    else asm_op $ EVM.NOT
   comp_jump_to_label revert_lab True
   --- emit the event
   let msg_length = mem_after_args - mem_after_svs
@@ -794,12 +829,13 @@ comp_chandler next_lab (C_Loop _ _svs _args _inv _body _i) = return next_lab
 
 comp_cloop :: CHandler a -> ASMMonad ann ()
 comp_cloop (C_Handler _ _from_spec _interval _ _msg _body _i) = return ()
-comp_cloop (C_Loop _ svs args _inv body i) = void $ asm_with_label_handler i $ do
-  asm_free_all
-  asm_malloc_args $ svs ++ args
-  comp_ctail (usesCTail body) body $ do
-    end_block_op ("</Loop " ++ show i ++ ">")
-  
+comp_cloop (C_Loop _ svs args _inv body i) = void $
+  asm_with_label_handler i $ do
+    asm_free_all
+    asm_malloc_args $ svs ++ args
+    comp_ctail (usesCTail body) body $ do
+      end_block_op ("</Loop " ++ show i ++ ">")
+
 end_block_op :: String -> ASMMonad ann ()
 end_block_op dbg = asm_op $ EVM.INVALID 0xFE dbg
 
@@ -820,38 +856,43 @@ cp_to_evm (C_Prog _ hs) = assemble $ do
   asm_op $ EVM.RETURN
   asm_pop 2
   end_block_op "</Constructor>"
-  where dis = do
-          halt_lab <- asm_fresh_label $ halt
-          rev_lab <- asm_fresh_label $ revert
-          asm_labels_set halt_lab rev_lab
-          mapM_ comp_cloop hs
-          foldM_ (\next_lab h -> do this_lab <- comp_chandler next_lab h
-                                    return this_lab)
-                 rev_lab (reverse hs)
-          comp_jump_to_handler 1
-          end_block_op "</Dispatch>"
-        halt = do
-          --- current_state = 0x0
-          asm_op $ EVM.PUSH1 [0]
-          asm_push 1
-          asm_op $ EVM.DUP1
-          asm_push 1
-          asm_op $ EVM.SSTORE
-          asm_pop 2
-          --- selfdestruct(msg.sender)
-          asm_op $ EVM.CALLER
-          asm_push 1
-          asm_op $ EVM.SELFDESTRUCT
-          asm_pop 1
-          end_block_op "</HALT>"
-        revert = do
-          asm_op $ EVM.PUSH1 [0]
-          asm_push 1
-          asm_op $ EVM.DUP1
-          asm_push 1
-          asm_op $ EVM.REVERT
-          asm_pop 2
-          end_block_op "</REVERT>"
+  where
+    dis = do
+      halt_lab <- asm_fresh_label $ halt
+      rev_lab <- asm_fresh_label $ revert
+      asm_labels_set halt_lab rev_lab
+      mapM_ comp_cloop hs
+      foldM_
+        ( \next_lab h -> do
+            this_lab <- comp_chandler next_lab h
+            return this_lab
+        )
+        rev_lab
+        (reverse hs)
+      comp_jump_to_handler 1
+      end_block_op "</Dispatch>"
+    halt = do
+      --- current_state = 0x0
+      asm_op $ EVM.PUSH1 [0]
+      asm_push 1
+      asm_op $ EVM.DUP1
+      asm_push 1
+      asm_op $ EVM.SSTORE
+      asm_pop 2
+      --- selfdestruct(msg.sender)
+      asm_op $ EVM.CALLER
+      asm_push 1
+      asm_op $ EVM.SELFDESTRUCT
+      asm_pop 1
+      end_block_op "</HALT>"
+    revert = do
+      asm_op $ EVM.PUSH1 [0]
+      asm_push 1
+      asm_op $ EVM.DUP1
+      asm_push 1
+      asm_op $ EVM.REVERT
+      asm_pop 2
+      end_block_op "</REVERT>"
 
 emit_evm :: FilePath -> BLProgram a -> IO String
 emit_evm evmf (BL_Prog _ _ _ cp) = do
@@ -859,5 +900,6 @@ emit_evm evmf (BL_Prog _ _ _ cp) = do
   writeFile evmf (concat $ intersperse "\n" $ map show bc)
   let hex_bc = trim $ show $ BB.toLazyByteString $ BB.byteStringHex $ B.pack $ EVM.encode bc
   return hex_bc
-  --- FIXME figure out the correct way to get a string
-  where trim = trimQuotes
+  where
+    --- FIXME figure out the correct way to get a string
+    trim = trimQuotes

--- a/hs/src/Reach/Connector/ETH_Solidity.hs
+++ b/hs/src/Reach/Connector/ETH_Solidity.hs
@@ -1,22 +1,21 @@
 module Reach.Connector.ETH_Solidity where
 
-import Data.List (intersperse, foldl', find)
-import Data.Text.Prettyprint.Doc
-import qualified Data.Text as T
+import Data.Aeson
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy.Char8 as B
 import qualified Data.HashMap.Strict as HM
+import Data.List (find, foldl', intersperse)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
-import qualified Data.ByteString.Lazy.Char8 as B
-import qualified Data.ByteString.Char8 as BS
-import System.Process
-import System.Exit
-import Data.Aeson
-import Paths_reach (version)
+import qualified Data.Text as T
+import Data.Text.Prettyprint.Doc
 import Data.Version (showVersion)
-
+import Paths_reach (version)
 import Reach.AST
 import Reach.EmbeddedFiles
 import Reach.Util
+import System.Exit
+import System.Process
 
 {- AST add-ons
  -}
@@ -52,7 +51,7 @@ cmerge m1 m2 = M.unionWith (+) m1 m2
 
 cmerges :: [CCounts] -> CCounts
 cmerges [] = M.empty
-cmerges (m1:ms) = cmerge m1 $ cmerges ms
+cmerges (m1 : ms) = cmerge m1 $ cmerges ms
 
 usesBLArg :: BLArg a -> CCounts
 usesBLArg (BL_Con _ _) = M.empty
@@ -63,29 +62,33 @@ usesCExpr (C_PrimApp _ _ al) = cmerges $ map usesBLArg al
 usesCExpr (C_Digest _ al) = cmerges $ map usesBLArg al
 usesCExpr (C_ArrayRef _ ae ee) = cmerges $ map usesBLArg [ae, ee]
 
-usesCStmt :: CStmt a  -> CCounts
+usesCStmt :: CStmt a -> CCounts
 usesCStmt (C_Claim _ _ a) = usesBLArg a
 usesCStmt (C_Transfer _ _ a) = usesBLArg a
 
 usesBLVars :: [BLVar] -> CCounts
-usesBLVars vs = M.fromList $ map (\v->(v,1)) vs
+usesBLVars vs = M.fromList $ map (\v -> (v, 1)) vs
 
 usesCTail :: CTail a -> CCounts
 usesCTail (C_Halt _) = M.empty
 usesCTail (C_Wait _ _ vs) = usesBLVars vs
-usesCTail (C_If _ ca tt ft) = cmerges [ cs1, cs2, cs3 ]
-  where cs1 = usesBLArg ca
-        cs2 = usesCTail tt
-        cs3 = usesCTail ft
+usesCTail (C_If _ ca tt ft) = cmerges [cs1, cs2, cs3]
+  where
+    cs1 = usesBLArg ca
+    cs2 = usesCTail tt
+    cs3 = usesCTail ft
 usesCTail (C_Let _ _ ce kt) = cmerge cs1 cs2
-  where cs1 = usesCExpr ce
-        cs2 = usesCTail kt
+  where
+    cs1 = usesCExpr ce
+    cs2 = usesCTail kt
 usesCTail (C_Do _ cs kt) = cmerge cs1 cs2
-  where cs1 = usesCStmt cs
-        cs2 = usesCTail kt
+  where
+    cs1 = usesCStmt cs
+    cs2 = usesCTail kt
 usesCTail (C_Jump _ _ vs _ as) = cmerges $ cs1 : cs2
-  where cs1 = usesBLVars vs
-        cs2 = map usesBLArg as
+  where
+    cs1 = usesBLVars vs
+    cs2 = map usesBLArg as
 
 {- Compilation to Solidity
 
@@ -100,6 +103,7 @@ usesCTail (C_Jump _ _ vs _ as) = cmerges $ cs1 : cs2
  -}
 
 type SolRenaming a = M.Map BLVar (Doc a)
+
 type SolInMemory = S.Set BLVar
 
 mustBeMem :: LType -> Bool
@@ -132,13 +136,14 @@ solRawVar (n, _) = pretty $ "v" ++ show n
 
 solVar :: SolInMemory -> SolRenaming a -> BLVar -> Doc a
 solVar sim ρ bv = p
-  where p = case M.lookup bv ρ of
-              Nothing -> bvp
-              Just v -> v
-        bvp = if S.member bv sim then
-                solMemVar bv
-              else
-                solRawVar bv
+  where
+    p = case M.lookup bv ρ of
+      Nothing -> bvp
+      Just v -> v
+    bvp =
+      if S.member bv sim
+        then solMemVar bv
+        else solRawVar bv
 
 solNum :: Show n => n -> Doc a
 solNum i = pretty $ "uint256(" ++ show i ++ ")"
@@ -178,7 +183,7 @@ solApply :: String -> [Doc a] -> Doc a
 solApply f args = pretty f <> parens (hcat $ intersperse (comma <> space) args)
 
 solRequire :: Doc a -> Doc a
-solRequire a = solApply "require" [ a ]
+solRequire a = solApply "require" [a]
 
 solBinOp :: String -> Doc a -> Doc a -> Doc a
 solBinOp o l r = l <+> pretty o <+> r
@@ -196,11 +201,12 @@ solBlockNumber :: Doc a
 solBlockNumber = "uint256(block.number)"
 
 solHash :: [Doc a] -> Doc a
-solHash a = solApply "uint256" [ solApply "keccak256" [ solApply "abi.encodePacked" a ] ]
+solHash a = solApply "uint256" [solApply "keccak256" [solApply "abi.encodePacked" a]]
 
 solHashState :: SolInMemory -> SolRenaming a -> Int -> Bool -> [BLVar] -> Doc a
 solHashState sim ρ i check svs = solHash $ (solNum i) : which_last : (map (solVar sim ρ) svs)
-  where which_last = if check then solLastBlock else solBlockNumber
+  where
+    which_last = if check then solLastBlock else solBlockNumber
 
 solPrimApply :: C_Prim -> [Doc a] -> Doc a
 solPrimApply pr args =
@@ -221,110 +227,127 @@ solPrimApply pr args =
     BIOR -> binOp "|"
     BXOR -> binOp "^"
     IF_THEN_ELSE -> case args of
-                      [ c, t, f ] -> c <+> "?" <+> t <+> ":" <+> f
-                      _ -> impossible $ "emitSol: ITE wrong args"
+      [c, t, f] -> c <+> "?" <+> t <+> ":" <+> f
+      _ -> impossible $ "emitSol: ITE wrong args"
     BYTES_EQ -> binOp "=="
     BALANCE -> "address(this).balance"
     TXN_VALUE -> "msg.value"
-  where binOp op = case args of
-          [ l, r ] -> solBinOp op l r
-          _ -> impossible $ "emitSol: bin op args"
+  where
+    binOp op = case args of
+      [l, r] -> solBinOp op l r
+      _ -> impossible $ "emitSol: bin op args"
 
 solCExpr :: SolInMemory -> SolRenaming a -> CExpr b -> Doc a
 solCExpr sim ρ (C_PrimApp _ pr al) = solPrimApply pr $ map (solArg sim ρ) al
 solCExpr sim ρ (C_Digest _ al) = solHash $ map (solArg sim ρ) al
 solCExpr sim ρ (C_ArrayRef _ ae ee) = ae' <> "[" <> ee' <> "]"
-  where ae' = solArg sim ρ ae
-        ee' = solArg sim ρ ee
-
+  where
+    ae' = solArg sim ρ ae
+    ee' = solArg sim ρ ee
 
 solCStmt :: SolInMemory -> SolRenaming a -> CStmt b -> Doc a
 solCStmt _ _ (C_Claim _ CT_Possible _) = emptyDoc
 solCStmt _ _ (C_Claim _ CT_Assert _) = emptyDoc
 solCStmt sim ρ (C_Claim _ _ a) = (solRequire $ solArg sim ρ a) <> semi <> hardline
-solCStmt sim ρ (C_Transfer _ p a) = solVar sim ρ p <> "." <> solApply "transfer" [ solArg sim ρ a ] <> semi <> hardline
+solCStmt sim ρ (C_Transfer _ p a) = solVar sim ρ p <> "." <> solApply "transfer" [solArg sim ρ a] <> semi <> hardline
 
 solCTail :: Doc a -> SolInMemory -> SolRenaming a -> CCounts -> CTail b -> Doc a
 solCTail emitp sim ρ ccs ct =
   case ct of
     C_Halt _ ->
-      emitp <> vsep [ solSet ("current_state") ("0x0") <> semi,
-                      solApply "selfdestruct" [ "msg.sender" ] <> semi ]
+      emitp
+        <> vsep
+          [ solSet ("current_state") ("0x0") <> semi,
+            solApply "selfdestruct" ["msg.sender"] <> semi
+          ]
     C_Wait _ last_i svs ->
       emitp <> (solSet ("current_state") (solHashState sim ρ last_i False svs)) <> semi
     C_If _ ca tt ft ->
       "if" <+> parens (solArg sim ρ ca) <+> bp tt <> hardline <> "else" <+> bp ft
-      where bp at = solBraces $ solCTail emitp sim ρ ccs at
+      where
+        bp at = solBraces $ solCTail emitp sim ρ ccs at
     C_Let _ bv ce kt ->
       case M.lookup bv ccs of
         Just 0 -> solCTail emitp sim ρ ccs kt
         Just 1 -> solCTail emitp sim ρ' ccs kt
-          where ρ' = M.insert bv (parens (solCExpr sim ρ ce)) ρ
-        _ -> vsep [ solVarDecl bv <+> "=" <+> solCExpr sim ρ ce <> semi,
-                    solCTail emitp sim ρ ccs kt ]
+          where
+            ρ' = M.insert bv (parens (solCExpr sim ρ ce)) ρ
+        _ ->
+          vsep
+            [ solVarDecl bv <+> "=" <+> solCExpr sim ρ ce <> semi,
+              solCTail emitp sim ρ ccs kt
+            ]
     C_Do _ cs kt -> solCStmt sim ρ cs <> (solCTail emitp sim ρ ccs kt)
     C_Jump _ which vs _ as ->
       emitp <> solApply (solLoop_fun which) ((map (solVar sim ρ) vs) ++ (map (solArg sim ρ) as)) <> semi
 
 solFrame :: Int -> SolInMemory -> (Doc a, Doc a)
 solFrame i sim = if null var_decls then (emptyDoc, emptyDoc) else (frame_defp, frame_declp)
-  where framei = "_F" ++ show i
-        frame_declp = (pretty $ framei ++ " memory _f") <> semi
-        frame_defp = pretty ("struct " ++ framei) <+> solBraces (vsep var_decls)
-        var_decls = map mk_var_decl $ S.elems sim
-        mk_var_decl v = solFieldDecl v <> semi
+  where
+    framei = "_F" ++ show i
+    frame_declp = (pretty $ framei ++ " memory _f") <> semi
+    frame_defp = pretty ("struct " ++ framei) <+> solBraces (vsep var_decls)
+    var_decls = map mk_var_decl $ S.elems sim
+    mk_var_decl v = solFieldDecl v <> semi
 
 makeSIM :: CCounts -> [BLVar] -> SolInMemory
 makeSIM ccs vs = S.unions $ map f $ M.toList ccs
-  where f (v, c) =
-          if c <= 1 || elem v vs then
-            S.empty
-          else
-            S.singleton v
+  where
+    f (v, c) =
+      if c <= 1 || elem v vs
+        then S.empty
+        else S.singleton v
 
 solHandler :: CHandler b -> Doc a
-solHandler (C_Handler _ from_spec interval (last_i, svs) msg body i) = vsep [ evtp, frame_defp, funp ]
-  where msg_rs = map solRawVar msg
-        msg_ds = map solArgDecl msg
-        msg_eds = map solFieldDecl msg
-        arg_ds = (solDecl (solType (LT_BT BT_UInt256)) solLastBlock) : map solArgDecl svs ++ msg_ds
-        evts = solMsg_evt i
-        evtp = solEvent evts msg_eds
-        sim0 = makeSIM ccs (svs ++ msg)
-        sim = case from_spec of
-                FS_Join from -> S.insert from sim0
-                _ -> sim0
-        (frame_defp, frame_declp) = solFrame i sim
-        funp = solFunction (solMsg_fun i) arg_ds retp bodyp
-        retp = "external payable"
-        balancep = solPrimApply BALANCE []
-        --- FIXME can stick this anywhere
-        emitp = "emit" <+> solApply evts (balancep : msg_rs) <> semi <> hardline
-        ccs = usesCTail body
-        ρ = M.empty
-        fromp = case from_spec of
-                  FS_Join from -> solVarDecl from <+> "=" <+> "msg.sender" <> semi
-                  FS_From from -> (solRequire $ solEq ("msg.sender") (solVar sim ρ from)) <> semi
-        bodyp = vsep [ (solRequire $ solEq ("current_state") (solHashState sim ρ last_i True svs)) <> semi,
-                       frame_declp, fromp,
-                       timeoutp,
-                       solCTail emitp sim ρ ccs body ]
-        timeoutp = solRequire (solBinOp "&&" int_fromp int_top) <> semi
-          where C_Between from to = interval
-                int_fromp = check True from
-                int_top = check False to
-                check sign mv =
-                  case mv of
-                    [] -> "true"
-                    vs -> solBinOp (if sign then ">=" else "<") solBlockNumber (foldl' (solBinOp "+") solLastBlock (map (solArg sim ρ) vs))
-solHandler (C_Loop _ svs args _inv body i) = vsep [ frame_defp, funp ]
-  where funp = solFunction (solLoop_fun i) arg_ds retp (vsep [ frame_declp, bodyp ])
-        sim = makeSIM ccs (args ++ svs)
-        (frame_defp, frame_declp) = solFrame i sim
-        arg_ds = map solArgDecl svs ++ map solArgDecl args
-        retp = "internal"
-        ccs = usesCTail body
-        bodyp = solCTail "" sim M.empty ccs body
+solHandler (C_Handler _ from_spec interval (last_i, svs) msg body i) = vsep [evtp, frame_defp, funp]
+  where
+    msg_rs = map solRawVar msg
+    msg_ds = map solArgDecl msg
+    msg_eds = map solFieldDecl msg
+    arg_ds = (solDecl (solType (LT_BT BT_UInt256)) solLastBlock) : map solArgDecl svs ++ msg_ds
+    evts = solMsg_evt i
+    evtp = solEvent evts msg_eds
+    sim0 = makeSIM ccs (svs ++ msg)
+    sim = case from_spec of
+      FS_Join from -> S.insert from sim0
+      _ -> sim0
+    (frame_defp, frame_declp) = solFrame i sim
+    funp = solFunction (solMsg_fun i) arg_ds retp bodyp
+    retp = "external payable"
+    balancep = solPrimApply BALANCE []
+    --- FIXME can stick this anywhere
+    emitp = "emit" <+> solApply evts (balancep : msg_rs) <> semi <> hardline
+    ccs = usesCTail body
+    ρ = M.empty
+    fromp = case from_spec of
+      FS_Join from -> solVarDecl from <+> "=" <+> "msg.sender" <> semi
+      FS_From from -> (solRequire $ solEq ("msg.sender") (solVar sim ρ from)) <> semi
+    bodyp =
+      vsep
+        [ (solRequire $ solEq ("current_state") (solHashState sim ρ last_i True svs)) <> semi,
+          frame_declp,
+          fromp,
+          timeoutp,
+          solCTail emitp sim ρ ccs body
+        ]
+    timeoutp = solRequire (solBinOp "&&" int_fromp int_top) <> semi
+      where
+        C_Between from to = interval
+        int_fromp = check True from
+        int_top = check False to
+        check sign mv =
+          case mv of
+            [] -> "true"
+            vs -> solBinOp (if sign then ">=" else "<") solBlockNumber (foldl' (solBinOp "+") solLastBlock (map (solArg sim ρ) vs))
+solHandler (C_Loop _ svs args _inv body i) = vsep [frame_defp, funp]
+  where
+    funp = solFunction (solLoop_fun i) arg_ds retp (vsep [frame_declp, bodyp])
+    sim = makeSIM ccs (args ++ svs)
+    (frame_defp, frame_declp) = solFrame i sim
+    arg_ds = map solArgDecl svs ++ map solArgDecl args
+    retp = "internal"
+    ccs = usesCTail body
+    bodyp = solCTail "" sim M.empty ccs body
 
 solHandlers :: [CHandler b] -> Doc a
 solHandlers hs = vsep $ intersperse emptyDoc $ map solHandler hs
@@ -334,53 +357,67 @@ vsep_with_blank l = vsep $ intersperse emptyDoc l
 
 emit_sol :: BLProgram b -> Doc a
 emit_sol (BL_Prog _ _ _ (C_Prog ca hs)) =
-  vsep_with_blank $ [ preamble, solVersion, solStdLib, ctcp ]
-  where ctcp = solContract "ReachContract is Stdlib"
-               $ ctcbody
-        ctcbody = vsep $ [state_defn, emptyDoc, consp, emptyDoc, solHandlers hs]
-        consp = solApply "constructor" [] <+> "public payable" <+> solBraces consbody
-        consbody = solCTail emptyDoc S.empty M.empty M.empty (C_Wait ca 0 [])
-        state_defn = "uint256 current_state;"
-        preamble = pretty $ "// Automatically generated with Reach " ++ showVersion version
+  vsep_with_blank $ [preamble, solVersion, solStdLib, ctcp]
+  where
+    ctcp =
+      solContract "ReachContract is Stdlib" $
+        ctcbody
+    ctcbody = vsep $ [state_defn, emptyDoc, consp, emptyDoc, solHandlers hs]
+    consp = solApply "constructor" [] <+> "public payable" <+> solBraces consbody
+    consbody = solCTail emptyDoc S.empty M.empty M.empty (C_Wait ca 0 [])
+    state_defn = "uint256 current_state;"
+    preamble = pretty $ "// Automatically generated with Reach " ++ showVersion version
 
 type CompiledSol = (String, String)
+
 data CompiledSolRec = CompiledSolRec
-  { csrAbi :: T.Text
-  , csrCode :: T.Text }
+  { csrAbi :: T.Text,
+    csrCode :: T.Text
+  }
 
 instance FromJSON CompiledSolRec where
-  parseJSON = withObject "CompiledSolRec" $ \ o -> do
+  parseJSON = withObject "CompiledSolRec" $ \o -> do
     ctcs <- o .: "contracts"
     case find (":ReachContract" `T.isSuffixOf`) (HM.keys ctcs) of
-      Just ctcKey-> do
+      Just ctcKey -> do
         ctc <- ctcs .: ctcKey
         abit <- ctc .: "abi"
         codebodyt <- ctc .: "bin"
         return CompiledSolRec {csrAbi = abit, csrCode = codebodyt}
       Nothing -> fail "Expected contracts object to have a key with suffix ':ReachContract'"
 
-
 extract :: Value -> CompiledSol
 extract v = case fromJSON v of
-    Error e -> error e  -- XXX
-    Success CompiledSolRec{csrAbi, csrCode} ->
-      ( T.unpack csrAbi, T.unpack csrCode )
-
+  Error e -> error e -- XXX
+  Success CompiledSolRec {csrAbi, csrCode} ->
+    (T.unpack csrAbi, T.unpack csrCode)
 
 compile_sol :: FilePath -> BLProgram a -> IO CompiledSol
 compile_sol solf blp = do
   writeFile solf (show (emit_sol blp))
-  ( ec, stdout, stderr ) <- readProcessWithExitCode "solc" ["--optimize", "--combined-json", "abi,bin", solf] []
+  (ec, stdout, stderr) <- readProcessWithExitCode "solc" ["--optimize", "--combined-json", "abi,bin", solf] []
   case ec of
     ExitFailure _ ->
-      die $ "solc failed:\n"
-      ++ "STDOUT:\n" ++ stdout ++ "\n"
-      ++ "STDERR:\n" ++ stderr ++ "\n"
+      die $
+        "solc failed:\n"
+          ++ "STDOUT:\n"
+          ++ stdout
+          ++ "\n"
+          ++ "STDERR:\n"
+          ++ stderr
+          ++ "\n"
     ExitSuccess ->
       case (eitherDecode $ B.pack stdout) of
         Right v -> return $ extract v
         Left err ->
-          die $ "solc failed to produce valid output:\n"
-          ++ "STDOUT:\n" ++ stdout ++ "\n"
-          ++ "STDERR:\n" ++ stderr ++ "\n"
-          ++ "Decode:\n" ++ err ++ "\n"
+          die $
+            "solc failed to produce valid output:\n"
+              ++ "STDOUT:\n"
+              ++ stdout
+              ++ "\n"
+              ++ "STDERR:\n"
+              ++ stderr
+              ++ "\n"
+              ++ "Decode:\n"
+              ++ err
+              ++ "\n"

--- a/hs/src/Reach/ConsensusNetworkProgram.hs
+++ b/hs/src/Reach/ConsensusNetworkProgram.hs
@@ -2,29 +2,35 @@ module Reach.ConsensusNetworkProgram where
 
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
-
-import Reach.AST (ConsensusNetwork, CNP_TMap)
-import Reach.Connector.ETH_Solidity
-  ( CompiledSol )
+import Reach.AST (CNP_TMap, ConsensusNetwork)
 import Reach.Connector.ALGO
-  ( CompiledTeal )
+  ( CompiledTeal,
+  )
+import Reach.Connector.ETH_Solidity
+  ( CompiledSol,
+  )
 import Reach.Util
 
 -- ^ A specific program compiled to a given Consensus Network
+
 data ConsensusNetworkProgram
-  = CNP_ETH CompiledSol  -- Or EVM not compiled from Sol
+  = CNP_ETH CompiledSol -- Or EVM not compiled from Sol
   | CNP_ALGO CompiledTeal
 
 type CNP_Map = M.Map ConsensusNetwork ConsensusNetworkProgram
 
 cnpToFieldMap :: CNP_Map -> CNP_TMap
-cnpToFieldMap  = M.mapKeys tshow . fmap cnpToFields where
+cnpToFieldMap = M.mapKeys tshow . fmap cnpToFields where
 
 cnpToFields :: ConsensusNetworkProgram -> M.Map T.Text T.Text
-cnpToFields (CNP_ETH (abi, bc)) = M.fromList
-  [ ("ABI", T.pack abi)
-  , ("Bytecode", "0x" <> T.pack bc) ]
-cnpToFields (CNP_ALGO (tc_lsp, tc_ap, tc_csp)) = M.fromList
-  [ ("LogicSigProgram", T.pack tc_lsp)
-  , ("ApprovalProgram", T.pack tc_ap)
-  , ("ClearStateProgram", T.pack tc_csp) ]
+cnpToFields (CNP_ETH (abi, bc)) =
+  M.fromList
+    [ ("ABI", T.pack abi),
+      ("Bytecode", "0x" <> T.pack bc)
+    ]
+cnpToFields (CNP_ALGO (tc_lsp, tc_ap, tc_csp)) =
+  M.fromList
+    [ ("LogicSigProgram", T.pack tc_lsp),
+      ("ApprovalProgram", T.pack tc_ap),
+      ("ClearStateProgram", T.pack tc_csp)
+    ]

--- a/hs/src/Reach/Parser.hs
+++ b/hs/src/Reach/Parser.hs
@@ -1,5 +1,6 @@
 module Reach.Parser
-  ( readReachFile
-  ) where
+  ( readReachFile,
+  )
+where
 
 import Reach.ParserInternal

--- a/hs/src/Reach/Util.hs
+++ b/hs/src/Reach/Util.hs
@@ -1,12 +1,11 @@
 module Reach.Util where
 
+import Control.Monad
 import Data.ByteString (ByteString)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import GHC.Stack
 import System.Exit
-import Control.Monad
-
 
 -- | A simple substitute for Data.ByteString.Char8.pack that handles unicode
 bpack :: String -> ByteString
@@ -15,7 +14,8 @@ bpack = TE.encodeUtf8 . T.pack
 maybeDie :: IO ExitCode -> IO ()
 maybeDie ma = do
   ec <- ma
-  unless (ec == ExitSuccess)
+  unless
+    (ec == ExitSuccess)
     (do (exitWith ec))
   return ()
 

--- a/hs/src/Reach/VerifySMT.hs
+++ b/hs/src/Reach/VerifySMT.hs
@@ -1,29 +1,31 @@
 module Reach.VerifySMT where
+
 -- XXX clean up function names and params to not refer to z3
 
-import Data.Maybe (catMaybes)
-import qualified Data.Set as S
-import qualified Data.Map as M
-import Data.Char (isDigit)
-import Text.Read (readMaybe)
+--- Maybe use Language.SMTLib2 in future
+
+import Control.Loop
 import Control.Monad
 import Control.Monad.Extra
-import SimpleSMT hiding (not) --- Maybe use Language.SMTLib2 in future
-import System.IO
-import System.Exit
-import Data.Text.Prettyprint.Doc
-import Data.Digest.CRC32
 import qualified Data.ByteString.Char8 as BS
+import Data.Char (isDigit)
+import Data.Digest.CRC32
 import Data.IORef
-import Control.Loop
+import qualified Data.Map as M
+import Data.Maybe (catMaybes)
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
-
+import Data.Text.Prettyprint.Doc
 import Reach.AST
 import Reach.EmbeddedFiles
-import Reach.Util
 import Reach.Pretty ()
+import Reach.Util
+import SimpleSMT hiding (not)
+import System.Exit
+import System.IO
+import Text.Read (readMaybe)
 
 {- Collect Types of IL variables -}
 
@@ -44,8 +46,10 @@ instance CollectTypes (ILTail a) where
   cvs (IL_Let _ _ v _ ct) = cvs v <> cvs ct
   cvs (IL_Do _ _ _ ct) = cvs ct
   cvs (IL_ToConsensus _ (_, _, _, _) mto kt) = cvs kt <> mto_vs
-    where mto_vs = case mto of Nothing -> mempty
-                               Just (_, tt) -> cvs tt
+    where
+      mto_vs = case mto of
+        Nothing -> mempty
+        Just (_, tt) -> cvs tt
   cvs (IL_FromConsensus _ kt) = cvs kt
   cvs (IL_While _ loopvs _ it ct bt kt) = cvs loopvs <> cvs it <> cvs ct <> cvs bt <> cvs kt
   cvs (IL_Continue _ _) = mempty
@@ -54,24 +58,26 @@ instance CollectTypes (ILProgram a) where
   cvs (IL_Prog _ _ _ it) = cvs it
 
 data LetAnn a = LetAnn
-  { la_ann :: a
-  , la_role :: Role ILVar
-  , la_var :: ILVar
-  , la_expr :: ILExpr a
+  { la_ann :: a,
+    la_role :: Role ILVar,
+    la_var :: ILVar,
+    la_expr :: ILExpr a
   }
 
 type AnnMap a = M.Map Int (LetAnn a)
-
 -- ^ Collect Let annotations.
 -- Returns a map of var # to ann
+
 clanns :: ILTail a -> AnnMap a
 clanns (IL_Ret _ _) = mempty
 clanns (IL_If _ _ tt ft) = clanns tt <> clanns ft
 clanns (IL_Let a r v@(i, _) e ct) = M.singleton i (LetAnn a r v e) <> clanns ct
 clanns (IL_Do _ _ _ ct) = clanns ct
 clanns (IL_ToConsensus _ (_, _, _, _) mto kt) = clanns kt <> mto_vs
-    where mto_vs = case mto of Nothing -> mempty
-                               Just (_, tt) -> clanns tt
+  where
+    mto_vs = case mto of
+      Nothing -> mempty
+      Just (_, tt) -> clanns tt
 clanns (IL_FromConsensus _ kt) = clanns kt
 clanns (IL_While _ _loopvs _ it ct bt kt) = clanns it <> clanns ct <> clanns bt <> clanns kt
 clanns (IL_Continue _ _) = mempty
@@ -87,13 +93,13 @@ z3_sortof_bt BT_Address = Atom "Address"
 
 z3_sortof :: LType -> SExpr
 z3_sortof (LT_BT bt) = z3_sortof_bt bt
-z3_sortof (LT_FixedArray bt _hm) = List [ Atom "Array", z3_sortof_bt bt, Atom "Int" ]
+z3_sortof (LT_FixedArray bt _hm) = List [Atom "Array", z3_sortof_bt bt, Atom "Int"]
 
 z3Apply :: String -> [SExpr] -> SExpr
 z3Apply f args = List (Atom f : args)
 
 z3Eq :: SExpr -> SExpr -> SExpr
-z3Eq x y = z3Apply "=" [ x, y ]
+z3Eq x y = z3Apply "=" [x, y]
 
 z3Var :: (S.Set ILVar) -> ILVar -> String
 z3Var primed v@(n, (s, _)) = "v" ++ show n ++ (if False then "_" ++ s else "") ++ (if (S.member v primed) then "p" else "")
@@ -136,32 +142,37 @@ display_fail honest r tk ann a = do
   --- XXX a is dumb, because it has been renamed from what they wrote
   putStrLn $ "\tspecifically: " ++ (showsSExpr a ":")
 
-type ModelMap = M.Map String (String, String)  -- ^ name -> (type, value)
+type ModelMap =
+  -- | name -> (type, value)
+  M.Map String (String, String)
+
 data ModelDefineInfo a = ModelDefineInfo
-  { mdi_name :: String
-  , mdi_type :: String
-  , mdi_value :: String
-  , mdi_sexpr :: Maybe (a, SExpr)
-  , mdi_la :: Maybe (LetAnn a)
-  , mdi_anns :: AnnMap a
-  , mdi_model :: ModelMap
+  { mdi_name :: String,
+    mdi_type :: String,
+    mdi_value :: String,
+    mdi_sexpr :: Maybe (a, SExpr),
+    mdi_la :: Maybe (LetAnn a),
+    mdi_anns :: AnnMap a,
+    mdi_model :: ModelMap
   }
 
 show_value :: String -> String -> Text
 show_value val = \case
   "Int" -> T.pack val
   "Bool" -> T.pack val
-  "Bytes" -> tshow val  -- XXX: prettier show of bytes
+  "Bytes" -> tshow val -- XXX: prettier show of bytes
   "Address" -> tshow val -- XXX: prettier show of address?
   _anything -> tshow val
 
 show_interact :: Show a => ModelDefineInfo a -> Text
-show_interact (ModelDefineInfo{mdi_name, mdi_value, mdi_type, mdi_la}) =
+show_interact (ModelDefineInfo {mdi_name, mdi_value, mdi_type, mdi_la}) =
   -- name <> "\t= " <> val <> showMay "\t-- " ann "" <> "\n" <>
   -- XXX: show more info? more than just interact?
   T.unwords
-    ["... interact [" <> T.pack mdi_name <> "]" <> showMay " (w/ " who ")"
-    , "returns", show_value mdi_value mdi_type <> showMay " (at " ann ")" ]
+    [ "... interact [" <> T.pack mdi_name <> "]" <> showMay " (w/ " who ")",
+      "returns",
+      show_value mdi_value mdi_type <> showMay " (at " ann ")"
+    ]
   where
     who = dispRole =<< (la_role <$> mdi_la)
     dispRole (RolePart (_, (s, _))) = Just $ T.pack s
@@ -169,16 +180,18 @@ show_interact (ModelDefineInfo{mdi_name, mdi_value, mdi_type, mdi_la}) =
     ann = tshow . la_ann <$> mdi_la
     showMay pre (Just x) post = pre <> x <> post
     showMay _pre Nothing _post = ""
-    -- XXX: also show expr with values substituted in from mmap
+
+-- XXX: also show expr with values substituted in from mmap
 
 show_la :: Show a => LetAnn a -> String
-show_la LetAnn{la_ann, la_role, la_var, la_expr} = s where
-  s = unwords ["[", r, ":", v, "@", show la_ann, "]", e]
-  r = case la_role of
-    RolePart (_, (rr, _)) -> rr
-    RoleContract{} -> ""
-  (_, (v, _)) = la_var
-  e = showILExpr la_expr
+show_la LetAnn {la_ann, la_role, la_var, la_expr} = s
+  where
+    s = unwords ["[", r, ":", v, "@", show la_ann, "]", e]
+    r = case la_role of
+      RolePart (_, (rr, _)) -> rr
+      RoleContract {} -> ""
+    (_, (v, _)) = la_var
+    e = showILExpr la_expr
 
 show_sexpr :: SExpr -> String
 show_sexpr sexpr = "= " <> showsSExpr sexpr ""
@@ -186,14 +199,24 @@ show_sexpr sexpr = "= " <> showsSExpr sexpr ""
 show_mdi :: Show a => ModelDefineInfo a -> String
 show_mdi (ModelDefineInfo {mdi_name, mdi_value, mdi_type, mdi_sexpr, mdi_la}) =
   unwords
-    [ mdi_name, ":", mdi_type, "=", mdi_value, maybe "" show_sexpr sexpr,
-      maybe "" show_la mdi_la, maybe "" (("-- " <>) . show) ann]
+    [ mdi_name,
+      ":",
+      mdi_type,
+      "=",
+      mdi_value,
+      maybe "" show_sexpr sexpr,
+      maybe "" show_la mdi_la,
+      maybe "" (("-- " <>) . show) ann
+    ]
   where
     ann = fst <$> mdi_sexpr
     sexpr = snd <$> mdi_sexpr
 
 data Z3Model = Z3Model [Z3Define]
-data Z3Define = Z3Define String Bool String String -- ^ name, hasArgs, type, val
+
+data Z3Define
+  = -- | name, hasArgs, type, val
+    Z3Define String Bool String String
 
 instance Show Z3Model where
   show (Z3Model ds) = unlines $ map show ds
@@ -207,14 +230,14 @@ parse_list_val sexprs@[Atom "ite", _, _, _] = return $ show sexprs -- XXX pretti
 parse_list_val sexprs = fail $ "Don't know how to parse as value: " <> show sexprs
 
 parse_define :: SExpr -> IO Z3Define
-parse_define (List (Atom "define-fun":Atom name:List args:Atom ty:Atom val:[])) =
+parse_define (List (Atom "define-fun" : Atom name : List args : Atom ty : Atom val : [])) =
   return $ Z3Define name (not $ null args) ty val
-parse_define (List (Atom "define-fun":Atom name:List args:Atom ty:List val:[])) =
+parse_define (List (Atom "define-fun" : Atom name : List args : Atom ty : List val : [])) =
   Z3Define name (not $ null args) ty <$> parse_list_val val
 parse_define e = fail $ "invalid define-fun " <> show e
 
 parse_model :: SExpr -> IO Z3Model
-parse_model (List (Atom "model":sexprs)) =
+parse_model (List (Atom "model" : sexprs)) =
   Z3Model <$> mapM parse_define sexprs
 parse_model e = fail $ "invalid model " <> show e
 
@@ -229,81 +252,99 @@ parse_var_int :: String -> IO Int
 parse_var_int s = case readMaybe $ numericPart s of
   Just i -> return i
   Nothing -> fail $ "Expected var to be v${i}, got: " <> s
-  where numericPart = reverse . dropNonDigits . reverse . dropNonDigits
-        dropNonDigits = dropWhile (not . isDigit)
+  where
+    numericPart = reverse . dropNonDigits . reverse . dropNonDigits
+    dropNonDigits = dropWhile (not . isDigit)
 
 displayTheoremFail :: TheoremKind -> Text
-displayTheoremFail = T.unlines . \case
-  TAssert ->
-    [ "Failed an assertion:"
-    , " This program would allow a call to assert() to fail."
-    , " This program is invalid." ]
-  TRequire ->
-    [ "Failed a requirement:"
-    , " This program would allow a call to require() to fail."
-    , " This program is invalid." ]
-  TPossible ->
-    [ "Failed a possibility check:"
-    , " It is impossible for a possible() expression"
-    , " to be true. This program is invalid." ]
-  TBalanceZero ->
-    [ "Failed the token linearity property:"
-    , " This program would allow the contract account's"
-    , " final balance to be nonzero. This program is invalid." ]
-  TBalanceSufficient ->
-    [ "Failed the sufficient balance property:"
-    , " This program would allow the contract account's"
-    , " balance to go negative. This program is invalid." ]
-  TInvariant ->
-    [ "Failed a while loop invariant check:"
-    , " This program would allow an invariant()"
-    , " to be false. This program is invalid." ]
-  TBounds ->
-    [ "Failed bounds check:"
-    , " This program would allow out-of-bounds array indexing."
-    , " This program is invalid." ]
+displayTheoremFail =
+  T.unlines . \case
+    TAssert ->
+      [ "Failed an assertion:",
+        " This program would allow a call to assert() to fail.",
+        " This program is invalid."
+      ]
+    TRequire ->
+      [ "Failed a requirement:",
+        " This program would allow a call to require() to fail.",
+        " This program is invalid."
+      ]
+    TPossible ->
+      [ "Failed a possibility check:",
+        " It is impossible for a possible() expression",
+        " to be true. This program is invalid."
+      ]
+    TBalanceZero ->
+      [ "Failed the token linearity property:",
+        " This program would allow the contract account's",
+        " final balance to be nonzero. This program is invalid."
+      ]
+    TBalanceSufficient ->
+      [ "Failed the sufficient balance property:",
+        " This program would allow the contract account's",
+        " balance to go negative. This program is invalid."
+      ]
+    TInvariant ->
+      [ "Failed a while loop invariant check:",
+        " This program would allow an invariant()",
+        " to be false. This program is invalid."
+      ]
+    TBounds ->
+      [ "Failed bounds check:",
+        " This program would allow out-of-bounds array indexing.",
+        " This program is invalid."
+      ]
 
 displayInteracts :: Show a => [ModelDefineInfo a] -> Text
-displayInteracts = T.unlines . \case
-  [] ->
-    [ "This could happen regardless of user interactions" ]
-  mp_interacts@(_:_) -> do
-    "This could happen if..." : map show_interact mp_interacts
+displayInteracts =
+  T.unlines . \case
+    [] ->
+      ["This could happen regardless of user interactions"]
+    mp_interacts@(_ : _) -> do
+      "This could happen if..." : map show_interact mp_interacts
 
 filterDisplayUnbound :: Show a => [SmtVar a] -> Text
-filterDisplayUnbound = T.pack . concatMap displayOne where
-  displayOne = \case
-    SmtComputedVar{} -> ""
-    SmtOtherVar{} -> ""
-    SmtInputVar name val expr role ann -> s where
-      s = "..." <> ty <> " [" <> name <> "]" <> r
-        <> " returns " <> val <> at <> "\n"
-      ty = case expr of
-        IL_PrimApp _ op _ -> case op of
-          RANDOM -> " random"
-          CP cp -> " " <> show cp <> " [XXX reach error]"
-        IL_Declassify{} -> " declassify"
-        IL_Interact _ m _ _ -> " interact." <> m
-        IL_Digest{} -> " Digest [XXX reach error]"
-        IL_ArrayRef{} -> " ArrayRef [XXX reach error]"
-      r = case role of
-        RolePart (_, (rr, _)) -> " w/" <> rr
-        RoleContract{} -> ""
-      at = " (at " <> show ann <> ")"
+filterDisplayUnbound = T.pack . concatMap displayOne
+  where
+    displayOne = \case
+      SmtComputedVar {} -> ""
+      SmtOtherVar {} -> ""
+      SmtInputVar name val expr role ann -> s
+        where
+          s =
+            "..." <> ty <> " [" <> name <> "]" <> r
+              <> " returns "
+              <> val
+              <> at
+              <> "\n"
+          ty = case expr of
+            IL_PrimApp _ op _ -> case op of
+              RANDOM -> " random"
+              CP cp -> " " <> show cp <> " [XXX reach error]"
+            IL_Declassify {} -> " declassify"
+            IL_Interact _ m _ _ -> " interact." <> m
+            IL_Digest {} -> " Digest [XXX reach error]"
+            IL_ArrayRef {} -> " ArrayRef [XXX reach error]"
+          r = case role of
+            RolePart (_, (rr, _)) -> " w/" <> rr
+            RoleContract {} -> ""
+          at = " (at " <> show ann <> ")"
 
 harvestIdents :: SExpr -> [String]
-harvestIdents (Atom s@(c:_))
+harvestIdents (Atom s@(c : _))
   | isDigit c = []
   | s == "true" || s == "false" = []
   | otherwise = [s]
 harvestIdents (Atom "") = [] -- wat
-harvestIdents (List (_f:xs)) = concatMap harvestIdents xs
+harvestIdents (List (_f : xs)) = concatMap harvestIdents xs
 harvestIdents (List xs) = concatMap harvestIdents xs -- shoudln't happen?
 
 -- ^ all, collected-so-far, current-sexp-to-explore
+
 collectIds :: M.Map String (a, SExpr) -> M.Map String SExpr -> [SExpr] -> M.Map String SExpr
 collectIds _mAll mColl [] = mColl
-collectIds mAll mColl (sx:sxs) = collectIds mAll mColl' sxs' where
+collectIds mAll mColl (sx : sxs) = collectIds mAll mColl' sxs'
+  where
     ids = harvestIdents sx
     newIds = filter (\i -> not $ M.member i mColl) ids
     mCollNew = M.fromList mCollNewList
@@ -312,47 +353,56 @@ collectIds mAll mColl (sx:sxs) = collectIds mAll mColl' sxs' where
     sxs' = sxs ++ sxsNew
     sxsNew = map snd mCollNewList
 
-filterVarInfo :: forall a.
-  M.Map String (ModelDefineInfo a)
-  -> String -> String -> SExpr -> a -> M.Map String (SmtVar a)
-filterVarInfo mdis n0 v0 e0 a0 = go mColl0 [e0] where
-  mColl0 = M.singleton n0 (SmtComputedVar n0 v0 e0 a0)
-  go :: M.Map String (SmtVar a) -> [SExpr] -> M.Map String (SmtVar a)
-  go mColl [] = mColl
-  go mColl (sx:sxs) = go mColl' sxs' where
-    mColl' = mColl <> mCollNew
-    mCollNew = M.fromList mCollNewList
-    mCollNewList = map (\i -> (,) i (discoverVar i)) newIds
-    newIds = filter (\i -> not $ M.member i mColl) ids
-    ids = harvestIdents sx
-    discoverVar :: String -> SmtVar a
-    discoverVar v = case M.lookup v mdis of
-      Just mdi@ModelDefineInfo{mdi_name, mdi_value, mdi_sexpr, mdi_la} ->
-        case mdi_sexpr of
-          Just (ann, sexpr) ->
-            SmtComputedVar mdi_name mdi_value sexpr mann where
-              mann = maybe ann id (la_ann <$> mdi_la)
-          Nothing -> case mdi_la of
-            Just LetAnn{la_ann, la_expr, la_role} ->
-              SmtInputVar mdi_name mdi_value la_expr la_role la_ann
-            Nothing ->
-              SmtOtherVar mdi_name mdi_value (Just mdi)
-      -- XXX value should be optional for this constructor?
-      Nothing -> SmtOtherVar v "UNKNOWN" Nothing
-    sxsNew = catMaybes $ map (harvestSExpr . snd) mCollNewList
-    sxs' = sxs ++ sxsNew
+filterVarInfo ::
+  forall a.
+  M.Map String (ModelDefineInfo a) ->
+  String ->
+  String ->
+  SExpr ->
+  a ->
+  M.Map String (SmtVar a)
+filterVarInfo mdis n0 v0 e0 a0 = go mColl0 [e0]
+  where
+    mColl0 = M.singleton n0 (SmtComputedVar n0 v0 e0 a0)
+    go :: M.Map String (SmtVar a) -> [SExpr] -> M.Map String (SmtVar a)
+    go mColl [] = mColl
+    go mColl (sx : sxs) = go mColl' sxs'
+      where
+        mColl' = mColl <> mCollNew
+        mCollNew = M.fromList mCollNewList
+        mCollNewList = map (\i -> (,) i (discoverVar i)) newIds
+        newIds = filter (\i -> not $ M.member i mColl) ids
+        ids = harvestIdents sx
+        discoverVar :: String -> SmtVar a
+        discoverVar v = case M.lookup v mdis of
+          Just mdi@ModelDefineInfo {mdi_name, mdi_value, mdi_sexpr, mdi_la} ->
+            case mdi_sexpr of
+              Just (ann, sexpr) ->
+                SmtComputedVar mdi_name mdi_value sexpr mann
+                where
+                  mann = maybe ann id (la_ann <$> mdi_la)
+              Nothing -> case mdi_la of
+                Just LetAnn {la_ann, la_expr, la_role} ->
+                  SmtInputVar mdi_name mdi_value la_expr la_role la_ann
+                Nothing ->
+                  SmtOtherVar mdi_name mdi_value (Just mdi)
+          -- XXX value should be optional for this constructor?
+          Nothing -> SmtOtherVar v "UNKNOWN" Nothing
+        sxsNew = catMaybes $ map (harvestSExpr . snd) mCollNewList
+        sxs' = sxs ++ sxsNew
 
 harvestSExpr :: SmtVar ann -> Maybe SExpr
 harvestSExpr = \case
   SmtComputedVar _ _ sexpr _ -> Just sexpr
-  SmtInputVar{} -> Nothing
-  SmtOtherVar{} -> Nothing
+  SmtInputVar {} -> Nothing
+  SmtOtherVar {} -> Nothing
 
 data SmtVar ann
   = SmtComputedVar String String SExpr ann
   | SmtInputVar String String (ILExpr ann) (Role ILVar) ann
   | SmtOtherVar String String (Maybe (ModelDefineInfo ann))
-  -- name, value, etc
+
+-- name, value, etc
 
 showILExpr :: ILExpr ann -> String
 showILExpr = show . pretty
@@ -363,22 +413,29 @@ showSmtVar = \case
   SmtComputedVar n v sexpr ann ->
     "... " <> n <> " = " <> v <> " = " <> showsSExpr sexpr ("  -- " <> show ann)
   SmtInputVar n v expr _role ann ->
-    "... " <> n <> " = " <> v <> " = " <> showILExpr expr <> "  -- "  <> show ann
+    "... " <> n <> " = " <> v <> " = " <> showILExpr expr <> "  -- " <> show ann
   SmtOtherVar n v Nothing ->
     "... " <> n <> " = " <> v <> " -- XXX reachc error, no info on var"
   SmtOtherVar n v (Just _mdi) ->
     "... " <> n <> " = " <> v <> " -- XXX reachc error, bad info on var"
 
-
 varNameToInt :: String -> Maybe Int
-varNameToInt ('v':s) = case reverse s of
-  ('p':s') -> readMaybe (reverse s')
+varNameToInt ('v' : s) = case reverse s of
+  ('p' : s') -> readMaybe (reverse s')
   _ -> readMaybe s
 varNameToInt _ = Nothing
 
-
-display_model :: Show ann =>
-  AssnMem ann -> AnnMap ann -> Bool -> rolet -> TheoremKind -> ann -> SExpr -> SExpr -> IO ()
+display_model ::
+  Show ann =>
+  AssnMem ann ->
+  AnnMap ann ->
+  Bool ->
+  rolet ->
+  TheoremKind ->
+  ann ->
+  SExpr ->
+  SExpr ->
+  IO ()
 display_model mem anns _honest _who tk ann a m = do
   mp <- parse_model_map m
   memm <- readIORef mem
@@ -414,18 +471,19 @@ display_model mem anns _honest _who tk ann a m = do
     --   isInteract mdi = (fst . snd . la_var <$> mdi_la mdi) == Just "Interact"
     --   isV mdi = take 1 (mdi_name mdi) == "v"
     --   notP mdi = take 1 (reverse $ mdi_name mdi) /= "p"
-    enrich mp memm (name, (ty, val)) = ModelDefineInfo {..} where
-      mdi_name = name
-      mdi_type = ty
-      mdi_value = val
-      mdi_sexpr = M.lookup name memm
-      mdi_la = varNameToInt name >>= flip M.lookup anns
-      mdi_anns = anns
-      mdi_model = mp
+    enrich mp memm (name, (ty, val)) = ModelDefineInfo {..}
+      where
+        mdi_name = name
+        mdi_type = ty
+        mdi_value = val
+        mdi_sexpr = M.lookup name memm
+        mdi_la = varNameToInt name >>= flip M.lookup anns
+        mdi_anns = anns
+        mdi_model = mp
 
 z3_verify1 :: Show rolet => Show ann => Solver -> AssnMem ann -> AnnMap ann -> (Bool, rolet, TheoremKind, ann) -> SExpr -> IO VerifyResult
 z3_verify1 z3 mem anns (honest, who, tk, ann) a = inNewScope z3 $ do
-  assert z3 (z3Apply "not" [ a ])
+  assert z3 (z3Apply "not" [a])
   r <- check z3
   case r of
     -- XXX unknown should be treated like sat, but with no model
@@ -436,7 +494,7 @@ z3_verify1 z3 mem anns (honest, who, tk, ann) a = inNewScope z3 $ do
       --- xxx minimize model to assigned (i.e. inputs)
       --- xxx relate inputs back to program text
       --- xxx relate inputs forward to this assertion
-      m <- command z3 $ List [ Atom "get-model" ]
+      m <- command z3 $ List [Atom "get-model"]
       display_model mem anns honest who tk ann a m
       return $ VR 0 1
 
@@ -452,9 +510,9 @@ z3_sat1 z3 (honest, who, tk, ann) a = inNewScope z3 $ do
       uc <- getUnsatCore z3
       mapM_ putStrLn uc
       return $ VR 0 1
-
 -- ^ v = rhs. lhs must be a var. Returns the (= v rhs) sexpr
-z3VarAssign :: Solver -> AssnMem ann -> ann -> String ->  SExpr -> IO SExpr
+
+z3VarAssign :: Solver -> AssnMem ann -> ann -> String -> SExpr -> IO SExpr
 z3VarAssign z3 mem h v rhs = do
   let lhs = Atom v
   rememberAssignment mem h v rhs
@@ -476,7 +534,7 @@ z3_declare z3 v bt = do
 z3_assert_declare_bt :: Solver -> SExpr -> BaseType -> IO ()
 z3_assert_declare_bt z3 vs bt =
   case bt of
-    BT_UInt256 -> assert z3 (z3Apply "<=" [ Atom "0", vs ])
+    BT_UInt256 -> assert z3 (z3Apply "<=" [Atom "0", vs])
     _ -> mempty
 
 z3_assert_declare :: Solver -> SExpr -> LType -> IO ()
@@ -484,9 +542,13 @@ z3_assert_declare z3 vs lty =
   case lty of
     LT_BT bt -> z3_assert_declare_bt z3 vs bt
     LT_FixedArray bt hm ->
-      forLoop 0 (< hm) (+1) h
-      where h i = z3_assert_declare_bt z3
-                  (List [ Atom "select", vs, Atom (show i)]) bt
+      forLoop 0 (< hm) (+ 1) h
+      where
+        h i =
+          z3_assert_declare_bt
+            z3
+            (List [Atom "select", vs, Atom (show i)])
+            bt
 
 z3_assert_eq_chk :: Show ann => Solver -> AssnMem ann -> ann -> String -> SExpr -> IO ()
 z3_assert_eq_chk z3 mem h v rhs = do
@@ -494,12 +556,12 @@ z3_assert_eq_chk z3 mem h v rhs = do
   z3_chk z3 h e
 
 z3_chk :: Show ann => Solver -> ann -> SExpr -> IO ()
-z3_chk z3 h e = check z3 >>= \case
-  -- XXX unknown should be treated like unsat
-  Unknown -> impossible $ show h ++ ": Z3 assert_chk: Unknown"
-  Sat -> mempty
-  Unsat -> error $ show h ++ ": Unreachable code with addition of assumption: " ++ show e
-  
+z3_chk z3 h e =
+  check z3 >>= \case
+    -- XXX unknown should be treated like unsat
+    Unknown -> impossible $ show h ++ ": Z3 assert_chk: Unknown"
+    Sat -> mempty
+    Unsat -> error $ show h ++ ": Unreachable code with addition of assumption: " ++ show e
 
 z3_assert_chk :: Show ann => Solver -> ann -> SExpr -> IO ()
 z3_assert_chk z3 h e = do
@@ -549,9 +611,10 @@ z3CPrim cbi cp =
     TXN_VALUE -> \case
       [] -> z3TxnValueRef cbi
       _ -> impossible "XXX TXN_VALUE with nonempty [SExpr]"
-  where app n = z3Apply n
-
+  where
+    app n = z3Apply n
 -- ^ Assignment memory
+
 type AssnMem a = IORef (M.Map String (a, SExpr))
 
 -- it doesn't respect push/pop, but should work anyway
@@ -578,9 +641,13 @@ data TheoremKind
   | TBounds
   deriving (Show)
 
-type Theorem = (Bool, (Role ILVar), TheoremKind) -- ^ honest, who, what
+type Theorem =
+  -- | honest, who, what
+  (Bool, (Role ILVar), TheoremKind)
 
-data VerifyResult = VR Int Int  -- ^ # succeeded, # failed
+data VerifyResult
+  = -- | # succeeded, # failed
+    VR Int Int
 
 instance Semigroup VerifyResult where
   (VR s1 f1) <> (VR s2 f2) = VR (s1 + s2) (f1 + f2)
@@ -592,7 +659,7 @@ emit_z3_con :: Constant -> SExpr
 emit_z3_con (Con_I i) = Atom $ show i
 emit_z3_con (Con_B True) = Atom "true"
 emit_z3_con (Con_B False) = Atom "false"
-emit_z3_con (Con_BS bs) = z3Apply "bytes-literal" [ Atom (show $ crc32 bs) ]
+emit_z3_con (Con_BS bs) = z3Apply "bytes-literal" [Atom (show $ crc32 bs)]
 
 emit_z3_arg :: (S.Set ILVar) -> ILArg a -> SExpr
 emit_z3_arg _ (IL_Con _ c) = emit_z3_con c
@@ -611,66 +678,77 @@ z3_expr z3 mem anns (honest, who) primed cbi out how = case how of
   IL_PrimApp h pr al -> do
     z3PrimEq z3 mem h primed cbi pr alt out
     return mempty
-    where alt = map (emit_z3_arg primed) al
+    where
+      alt = map (emit_z3_arg primed) al
   IL_Interact _ _ _ _ -> return mempty
   IL_Digest h al -> do
-    z3_assert_eq_chk z3 mem h (z3Var primed out) (z3Apply "digest" [ z3DigestCombine primed al ])
+    z3_assert_eq_chk z3 mem h (z3Var primed out) (z3Apply "digest" [z3DigestCombine primed al])
     return mempty
   IL_ArrayRef h ae ee -> do
     let hm = case ilarg_type ae of
-               LT_FixedArray _ x -> x
-               _ -> impossible $ "IL_ArrayRef called with no Array"
-    z3_assert_eq_chk z3 mem h (z3Var primed out) (z3Apply "select" [ (emit_z3_arg primed ae), (emit_z3_arg primed ee) ])
-    z3_verify1 z3 mem anns (honest, who, TBounds, h) (z3CPrim cbi PLT [ (emit_z3_arg primed ee), (emit_z3_con $ Con_I hm) ])
+          LT_FixedArray _ x -> x
+          _ -> impossible $ "IL_ArrayRef called with no Array"
+    z3_assert_eq_chk z3 mem h (z3Var primed out) (z3Apply "select" [(emit_z3_arg primed ae), (emit_z3_arg primed ee)])
+    z3_verify1 z3 mem anns (honest, who, TBounds, h) (z3CPrim cbi PLT [(emit_z3_arg primed ee), (emit_z3_con $ Con_I hm)])
 
 z3DigestCombine :: Show a => (S.Set ILVar) -> [ILArg a] -> SExpr
 z3DigestCombine primed ys =
   case ys of
     [] -> z3Apply "bytes0" []
-    [ x ] -> convert1 x
-    (x : xs) -> z3Apply "msg-cat" [ convert1 x , z3DigestCombine primed xs ]
-  where convert1 a = z3Apply (toBytes a) [ emit_z3_arg primed a ]
-        toBytes (IL_Var _ (_, (_, bt))) = "toBytes_" ++ s
-          where s = case z3_sortof bt of
-                  Atom a -> a
-                  _ -> error "Expected an Atom" -- XXX
-        toBytes (IL_Con _ c) = "toBytes_" ++ s
-          where s= case c of
-                     Con_I _ -> "Int"
-                     Con_B _ -> "Bool"
-                     Con_BS _ -> "Bytes"
-
+    [x] -> convert1 x
+    (x : xs) -> z3Apply "msg-cat" [convert1 x, z3DigestCombine primed xs]
+  where
+    convert1 a = z3Apply (toBytes a) [emit_z3_arg primed a]
+    toBytes (IL_Var _ (_, (_, bt))) = "toBytes_" ++ s
+      where
+        s = case z3_sortof bt of
+          Atom a -> a
+          _ -> error "Expected an Atom" -- XXX
+    toBytes (IL_Con _ c) = "toBytes_" ++ s
+      where
+        s = case c of
+          Con_I _ -> "Int"
+          Con_B _ -> "Bool"
+          Con_BS _ -> "Bytes"
 -- ^ Returns (next cbi, result)
+
 z3_stmt :: Show rolet => Show a => Solver -> AssnMem a -> AnnMap a -> Bool -> rolet -> (S.Set ILVar) -> Int -> ILStmt a -> IO (Int, VerifyResult)
 z3_stmt z3 mem anns honest r primed cbi how =
   case how of
-    IL_Transfer h _who amount -> do vr <- z3_verify1 z3 mem anns (honest, r, TBalanceSufficient, h) (z3Apply "<=" [ amountt, cbit ])
-                                    z3_define z3 mem h cb' (LT_BT BT_UInt256) (z3Apply "-" [ cbit, amountt ])
-                                    return (cbi', vr)
-      where cbi' = cbi + 1
-            cbit = z3CTCBalanceRef cbi
-            cb' = z3CTCBalance cbi'
-            amountt = emit_z3_arg primed amount
-    IL_Claim h CT_Possible a -> do vr <- z3_sat1 z3 (honest, r, TPossible, h) at
-                                   return ( cbi, vr )
-      where at = emit_z3_arg primed a
-    IL_Claim h ct a -> do vr <- this_check
-                          assert z3 at
-                          return ( cbi, vr )
-      where at = emit_z3_arg primed a
-            this_check = case mct of
-              Just tk -> z3_verify1 z3 mem anns (honest, r, tk, h) at
-              Nothing -> return mempty
-            mct = case ct of
-              CT_Assert -> Just TAssert
-              CT_Assume -> Nothing
-              CT_Require | honest -> Just TRequire
-              CT_Require -> Nothing
-              CT_Possible -> impossible $ "CT_Possible in previous case"
+    IL_Transfer h _who amount -> do
+      vr <- z3_verify1 z3 mem anns (honest, r, TBalanceSufficient, h) (z3Apply "<=" [amountt, cbit])
+      z3_define z3 mem h cb' (LT_BT BT_UInt256) (z3Apply "-" [cbit, amountt])
+      return (cbi', vr)
+      where
+        cbi' = cbi + 1
+        cbit = z3CTCBalanceRef cbi
+        cb' = z3CTCBalance cbi'
+        amountt = emit_z3_arg primed amount
+    IL_Claim h CT_Possible a -> do
+      vr <- z3_sat1 z3 (honest, r, TPossible, h) at
+      return (cbi, vr)
+      where
+        at = emit_z3_arg primed a
+    IL_Claim h ct a -> do
+      vr <- this_check
+      assert z3 at
+      return (cbi, vr)
+      where
+        at = emit_z3_arg primed a
+        this_check = case mct of
+          Just tk -> z3_verify1 z3 mem anns (honest, r, tk, h) at
+          Nothing -> return mempty
+        mct = case ct of
+          CT_Assert -> Just TAssert
+          CT_Assume -> Nothing
+          CT_Require | honest -> Just TRequire
+          CT_Require -> Nothing
+          CT_Possible -> impossible $ "CT_Possible in previous case"
 
 data VerifyCtxt a
   = VC_Top
-  | VC_AssignCheckInv Bool [ILVar] (ILTail a)  -- ^ shouldPrime, loop vars, inv tail
+  | -- | shouldPrime, loop vars, inv tail
+    VC_AssignCheckInv Bool [ILVar] (ILTail a)
   | VC_CheckRet
   | VC_WhileBody_AssumeNotUntil [ILVar] (ILTail a) (ILTail a) (VerifyCtxt a)
   | VC_WhileBody_AssumeInv [ILVar] (ILTail a) (ILTail a) (VerifyCtxt a)
@@ -692,124 +770,133 @@ z3_it_top z3 mem anns it_top (honest, me) = inNewScope z3 $ do
   z3_declare z3 cb0 (LT_BT BT_UInt256)
   void $ z3VarAssign z3 mem top_ann cb0 zero
   meta_iter Nothing VC_Top it_top
-  where zero = emit_z3_con (Con_I 0)
-        cb0 = z3CTCBalance 0
-        meta_iter :: Maybe Int -> VerifyCtxt a -> ILTail a -> IO VerifyResult
-        meta_iter m_prev_cbi ctxt it = do
-          putStrLn $ "...checking " ++ take 32 (show ctxt)
-          let (init_cbi, init_cbim) =
-                case m_prev_cbi of
-                  Nothing -> (0, mempty)
-                  Just prev_cbi ->
-                    (cbi', z3_declare z3 cb'v (LT_BT BT_UInt256))
-                    where cbi' = prev_cbi + 1
-                          cb'v = z3CTCBalance cbi'
-          inNewScope z3 $ do init_cbim
-                             iter (S.empty) init_cbi ctxt it
-        top_ann = case it_top of
-          IL_Ret h _ -> h
-          IL_If h _ _ _ -> h
-          IL_Let h _ _ _ _ -> h
-          IL_Do h _ _ _ -> h
-          IL_ToConsensus h _ _ _ -> h
-          IL_FromConsensus h _ -> h
-          IL_While h _ _ _ _ _ _ -> h
-          IL_Continue h _ -> h
-        iter :: (S.Set ILVar) -> Int -> VerifyCtxt a -> ILTail a -> IO VerifyResult
-        iter primed cbi ctxt it = case it of
-          IL_Ret h al -> do
-            case ctxt of
-              VC_Top -> do
-                let cbi_balance = z3Eq (z3CTCBalanceRef cbi) zero
-                z3_verify1 z3 mem anns (honest, me, TBalanceZero, h) cbi_balance
-              VC_AssignCheckInv should_prime loopvs invt -> do
-                let invt_vs = extract_invariant_variables invt
-                let primed' = if should_prime then S.unions [primed, S.fromList loopvs, S.fromList invt_vs] else primed
-                mapM_ (\(loopv, a) ->
-                         z3_assert_eq_chk z3 mem h (z3Var primed' loopv) (emit_z3_arg primed a))
-                      (zip loopvs al)
-                iter primed' cbi VC_CheckRet invt
-              VC_CheckRet -> do
-                a <- case al of
-                  [ x ] -> return x
-                  _ -> fail "Expected [ILArg] to have exactly one element"  -- XXX
-                z3_verify1 z3 mem anns (honest, me, TInvariant, h) (emit_z3_arg primed a)
-              VC_WhileBody_AssumeNotUntil loopvs invt bodyt kctxt -> do
-                a <- case al of
-                  [ x ] -> return x
-                  _ -> fail "Expected [ILArg] to have exactly one element"  -- XXX
-                z3_assert_chk z3 h (z3Apply "not" [ emit_z3_arg primed a ])
-                iter primed cbi (VC_WhileBody_AssumeInv loopvs invt bodyt kctxt) invt
-              VC_WhileBody_AssumeInv loopvs invt bodyt kctxt -> do
-                a <- case al of
-                  [ x ] -> return x
-                  _ -> fail "Expected [ILArg] to have exactly one element"  -- XXX
-                z3_assert_chk z3 h (emit_z3_arg primed a)
-                iter primed cbi (VC_WhileBody_Eval loopvs invt kctxt) bodyt
-              VC_WhileBody_Eval _ _ kctxt ->
-                iter primed cbi kctxt it
-              VC_WhileTail_AssumeUntil invt ki -> do
-                a <- case al of
-                  [ x ] -> return x
-                  _ -> fail "Expected [ILArg] to have exactly one element"  -- XXX
-                z3_assert_chk z3 h (emit_z3_arg primed a)
-                iter primed cbi (VC_WhileTail_AssumeInv ki) invt
-              VC_WhileTail_AssumeInv (kctxt, kt) -> do
-                a <- case al of
-                  [ x ] -> return x
-                  _ -> fail "Expected [ILArg] to have exactly one element"  -- XXX
-                z3_assert_chk z3 h (emit_z3_arg primed a)
-                iter primed cbi kctxt kt
-          IL_If h ca tt ft -> do
-            mconcatMapM (inNewScope z3 . f) (zip [True, False] [tt, ft])
-            where ca' = emit_z3_arg primed ca
-                  f (v, kt) = do z3_assert_chk z3 h (z3Eq ca' cav)
-                                 iter primed cbi ctxt kt
-                    where cav = emit_z3_con (Con_B v)
-          IL_Let _ who what how kt ->
-            do vr <- if (honest || role_me me who) then z3_expr z3 mem anns (honest, who) primed cbi what how else return mempty
-               vr' <- iter primed cbi ctxt kt
-               return $ vr <> vr'
-          IL_Do _ who how kt ->
-            if (honest || role_me me who) then
-              do (cbi', vr) <- z3_stmt z3 mem anns honest me primed cbi how
-                 vr' <- iter primed cbi' ctxt kt
-                 return $ vr <> vr'
-            else
-              iter primed cbi ctxt kt
-          IL_ToConsensus h (_ok_ij, _who, _msg, amount) mto kt ->
-            mconcatMapM (inNewScope z3) [timeout, notimeout]
+  where
+    zero = emit_z3_con (Con_I 0)
+    cb0 = z3CTCBalance 0
+    meta_iter :: Maybe Int -> VerifyCtxt a -> ILTail a -> IO VerifyResult
+    meta_iter m_prev_cbi ctxt it = do
+      putStrLn $ "...checking " ++ take 32 (show ctxt)
+      let (init_cbi, init_cbim) =
+            case m_prev_cbi of
+              Nothing -> (0, mempty)
+              Just prev_cbi ->
+                (cbi', z3_declare z3 cb'v (LT_BT BT_UInt256))
+                where
+                  cbi' = prev_cbi + 1
+                  cb'v = z3CTCBalance cbi'
+      inNewScope z3 $ do
+        init_cbim
+        iter (S.empty) init_cbi ctxt it
+    top_ann = case it_top of
+      IL_Ret h _ -> h
+      IL_If h _ _ _ -> h
+      IL_Let h _ _ _ _ -> h
+      IL_Do h _ _ _ -> h
+      IL_ToConsensus h _ _ _ -> h
+      IL_FromConsensus h _ -> h
+      IL_While h _ _ _ _ _ _ -> h
+      IL_Continue h _ -> h
+    iter :: (S.Set ILVar) -> Int -> VerifyCtxt a -> ILTail a -> IO VerifyResult
+    iter primed cbi ctxt it = case it of
+      IL_Ret h al -> do
+        case ctxt of
+          VC_Top -> do
+            let cbi_balance = z3Eq (z3CTCBalanceRef cbi) zero
+            z3_verify1 z3 mem anns (honest, me, TBalanceZero, h) cbi_balance
+          VC_AssignCheckInv should_prime loopvs invt -> do
+            let invt_vs = extract_invariant_variables invt
+            let primed' = if should_prime then S.unions [primed, S.fromList loopvs, S.fromList invt_vs] else primed
+            mapM_
+              ( \(loopv, a) ->
+                  z3_assert_eq_chk z3 mem h (z3Var primed' loopv) (emit_z3_arg primed a)
+              )
+              (zip loopvs al)
+            iter primed' cbi VC_CheckRet invt
+          VC_CheckRet -> do
+            a <- case al of
+              [x] -> return x
+              _ -> fail "Expected [ILArg] to have exactly one element" -- XXX
+            z3_verify1 z3 mem anns (honest, me, TInvariant, h) (emit_z3_arg primed a)
+          VC_WhileBody_AssumeNotUntil loopvs invt bodyt kctxt -> do
+            a <- case al of
+              [x] -> return x
+              _ -> fail "Expected [ILArg] to have exactly one element" -- XXX
+            z3_assert_chk z3 h (z3Apply "not" [emit_z3_arg primed a])
+            iter primed cbi (VC_WhileBody_AssumeInv loopvs invt bodyt kctxt) invt
+          VC_WhileBody_AssumeInv loopvs invt bodyt kctxt -> do
+            a <- case al of
+              [x] -> return x
+              _ -> fail "Expected [ILArg] to have exactly one element" -- XXX
+            z3_assert_chk z3 h (emit_z3_arg primed a)
+            iter primed cbi (VC_WhileBody_Eval loopvs invt kctxt) bodyt
+          VC_WhileBody_Eval _ _ kctxt ->
+            iter primed cbi kctxt it
+          VC_WhileTail_AssumeUntil invt ki -> do
+            a <- case al of
+              [x] -> return x
+              _ -> fail "Expected [ILArg] to have exactly one element" -- XXX
+            z3_assert_chk z3 h (emit_z3_arg primed a)
+            iter primed cbi (VC_WhileTail_AssumeInv ki) invt
+          VC_WhileTail_AssumeInv (kctxt, kt) -> do
+            a <- case al of
+              [x] -> return x
+              _ -> fail "Expected [ILArg] to have exactly one element" -- XXX
+            z3_assert_chk z3 h (emit_z3_arg primed a)
+            iter primed cbi kctxt kt
+      IL_If h ca tt ft -> do
+        mconcatMapM (inNewScope z3 . f) (zip [True, False] [tt, ft])
+        where
+          ca' = emit_z3_arg primed ca
+          f (v, kt) = do
+            z3_assert_chk z3 h (z3Eq ca' cav)
+            iter primed cbi ctxt kt
             where
-              timeout = case mto of
-                          Nothing -> mempty
-                          Just (_da, tt) -> do
-                            iter primed cbi ctxt tt
-              notimeout = do
-                z3_declare z3 pvv (LT_BT BT_UInt256)
-                z3_define z3 mem h cb'v (LT_BT BT_UInt256) (z3Apply "+" [cbr, pvr])
-                case honest of
-                  True -> z3_assert_eq_chk z3 mem h pvv amountt
-                  False -> z3_assert_chk z3 h thisc
-                iter primed cbi' ctxt kt
-              cbi' = cbi + 1
-              cb'v = z3CTCBalance cbi'
-              cbr = z3CTCBalanceRef cbi
-              amountt = emit_z3_arg primed amount
-              pvv = z3TxnValue cbi'
-              pvr = z3TxnValueRef cbi'
-              thisc = z3Apply "<=" [ zero, pvr ]
-          IL_FromConsensus _ kt -> iter primed cbi ctxt kt
-          IL_While x loopvs initas untilt invt bodyt kt -> do
-            vr_body <- meta_iter (Just cbi) (VC_WhileBody_AssumeNotUntil loopvs invt bodyt ctxt) untilt
-            vr_tail <- meta_iter (Just cbi) (VC_WhileTail_AssumeUntil invt (ctxt, kt)) untilt
-            vr_pre <- iter primed cbi (VC_AssignCheckInv False loopvs invt) (IL_Ret x initas)
-            return $ vr_pre <> vr_body <> vr_tail
-          IL_Continue x newas ->
-            case ctxt of
-              VC_WhileBody_Eval loopvs invt _kctxt ->
-                iter primed cbi (VC_AssignCheckInv True loopvs invt) (IL_Ret x newas)
-              _ ->
-                impossible $ "VerifyZ3 IL_Continue must only occur inside While"
+              cav = emit_z3_con (Con_B v)
+      IL_Let _ who what how kt ->
+        do
+          vr <- if (honest || role_me me who) then z3_expr z3 mem anns (honest, who) primed cbi what how else return mempty
+          vr' <- iter primed cbi ctxt kt
+          return $ vr <> vr'
+      IL_Do _ who how kt ->
+        if (honest || role_me me who)
+          then do
+            (cbi', vr) <- z3_stmt z3 mem anns honest me primed cbi how
+            vr' <- iter primed cbi' ctxt kt
+            return $ vr <> vr'
+          else iter primed cbi ctxt kt
+      IL_ToConsensus h (_ok_ij, _who, _msg, amount) mto kt ->
+        mconcatMapM (inNewScope z3) [timeout, notimeout]
+        where
+          timeout = case mto of
+            Nothing -> mempty
+            Just (_da, tt) -> do
+              iter primed cbi ctxt tt
+          notimeout = do
+            z3_declare z3 pvv (LT_BT BT_UInt256)
+            z3_define z3 mem h cb'v (LT_BT BT_UInt256) (z3Apply "+" [cbr, pvr])
+            case honest of
+              True -> z3_assert_eq_chk z3 mem h pvv amountt
+              False -> z3_assert_chk z3 h thisc
+            iter primed cbi' ctxt kt
+          cbi' = cbi + 1
+          cb'v = z3CTCBalance cbi'
+          cbr = z3CTCBalanceRef cbi
+          amountt = emit_z3_arg primed amount
+          pvv = z3TxnValue cbi'
+          pvr = z3TxnValueRef cbi'
+          thisc = z3Apply "<=" [zero, pvr]
+      IL_FromConsensus _ kt -> iter primed cbi ctxt kt
+      IL_While x loopvs initas untilt invt bodyt kt -> do
+        vr_body <- meta_iter (Just cbi) (VC_WhileBody_AssumeNotUntil loopvs invt bodyt ctxt) untilt
+        vr_tail <- meta_iter (Just cbi) (VC_WhileTail_AssumeUntil invt (ctxt, kt)) untilt
+        vr_pre <- iter primed cbi (VC_AssignCheckInv False loopvs invt) (IL_Ret x initas)
+        return $ vr_pre <> vr_body <> vr_tail
+      IL_Continue x newas ->
+        case ctxt of
+          VC_WhileBody_Eval loopvs invt _kctxt ->
+            iter primed cbi (VC_AssignCheckInv True loopvs invt) (IL_Ret x newas)
+          _ ->
+            impossible $ "VerifyZ3 IL_Continue must only occur inside While"
 
 z3StdLib :: String
 z3StdLib = BS.unpack z3_runtime_smt2
@@ -821,15 +908,18 @@ _verify_z3 z3 tp = do
   mem <- newIORef mempty
   VR ss fs <- mconcatMapM (z3_it_top z3 mem anns it) (liftM2 (,) [True, False] ps)
   putStr $ "Checked " ++ (show $ ss + fs) ++ " theorems;"
-  (if ( fs == 0 ) then
-      do putStrLn $ " No failures!"
-         return ExitSuccess
-   else
-      do putStrLn $ " " ++ show fs ++ " failures. :'("
-         return $ ExitFailure 1)
-  where IL_Prog _ _ ipi it = tp
-        ps = RoleContract : (map RolePart $ S.toList ipi)
-        anns = clanns it
+  ( if (fs == 0)
+      then do
+        putStrLn $ " No failures!"
+        return ExitSuccess
+      else do
+        putStrLn $ " " ++ show fs ++ " failures. :'("
+        return $ ExitFailure 1
+    )
+  where
+    IL_Prog _ _ ipi it = tp
+    ps = RoleContract : (map RolePart $ S.toList ipi)
+    anns = clanns it
 
 newFileLogger :: FilePath -> IO (IO (), Logger)
 newFileLogger p = do
@@ -847,24 +937,28 @@ newFileLogger p = do
       logMessage m' = do
         let (which, m) = splitAt (length send_tag) m'
         let short_which = if which == send_tag then "+" else "-"
-        if (which == recv_tag && m == " success") then
-          return ()
-        else if (m == " (push 1 )") then do
-          printTab
-          hPutStrLn logh $ "(push"
-          hFlush logh
-          logTab
-        else if (m == " (pop 1 )") then do
-          logUntab
-          printTab
-          hPutStrLn logh $ ")"
-          hFlush logh
-        else do
-          printTab
-          hPutStrLn logh $ "(" ++ short_which ++ m ++ ")"
-          hFlush logh
+        if (which == recv_tag && m == " success")
+          then return ()
+          else
+            if (m == " (push 1 )")
+              then do
+                printTab
+                hPutStrLn logh $ "(push"
+                hFlush logh
+                logTab
+              else
+                if (m == " (pop 1 )")
+                  then do
+                    logUntab
+                    printTab
+                    hPutStrLn logh $ ")"
+                    hFlush logh
+                  else do
+                    printTab
+                    hPutStrLn logh $ "(" ++ short_which ++ m ++ ")"
+                    hFlush logh
       close = hClose logh
-  return (close, Logger { .. })
+  return (close, Logger {..})
 
 verify_smt :: Show a => (Maybe Logger -> IO Solver) -> FilePath -> ILProgram a -> IO ()
 verify_smt mkSolver logp tp = do

--- a/hs/src/Reach/VerifyYices.hs
+++ b/hs/src/Reach/VerifyYices.hs
@@ -5,5 +5,6 @@ import Reach.VerifySMT
 import SimpleSMT
 
 verify_yices :: Show a => FilePath -> ILProgram a -> IO ()
-verify_yices = verify_smt mkSolver where
-  mkSolver = newSolver "yices-smt2" []
+verify_yices = verify_smt mkSolver
+  where
+    mkSolver = newSolver "yices-smt2" []

--- a/hs/src/Reach/VerifyZ3.hs
+++ b/hs/src/Reach/VerifyZ3.hs
@@ -5,5 +5,6 @@ import Reach.VerifySMT
 import SimpleSMT
 
 verify_z3 :: Show a => FilePath -> ILProgram a -> IO ()
-verify_z3 = verify_smt mkSolver where
-  mkSolver = newSolver "z3" ["-smt2", "-in"]
+verify_z3 = verify_smt mkSolver
+  where
+    mkSolver = newSolver "z3" ["-smt2", "-in"]

--- a/hs/test/Main.hs
+++ b/hs/test/Main.hs
@@ -1,19 +1,28 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module Main where
 
 import Control.DeepSeq
 import Control.Exception
+import qualified Data.ByteString.Lazy as LB
 import Data.Functor.Identity
 import Data.List (isPrefixOf, (\\))
 import Data.Proxy
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.Text.IO as TIO
 import Data.Typeable
 import Generics.Deriving
 import Language.JavaScript.Parser.SrcLocation
+import Reach.Compiler (CompileErr, Verifier (Z3), compile)
+import Reach.CompilerTool
+import Reach.ParserInternal
+import Reach.Util
 import System.Directory
 import System.Environment
 import System.Exit
-import System.IO.Silently
 import System.FilePath
+import System.IO.Silently
 import System.Process
 import Test.Hspec
 import Test.SmallCheck.Series
@@ -23,24 +32,16 @@ import Test.Tasty.Hspec
 import Test.Tasty.Runners.AntXML
 import Test.Tasty.Runners.Html
 
-import Reach.ParserInternal
-import Reach.Compiler (CompileErr, compile, Verifier(Z3))
-import Reach.CompilerTool
-import Reach.Util
-
-import qualified Data.ByteString.Lazy as LB
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
-import qualified Data.Text.IO as TIO
-
-
 instance NFData TP where
   rnf (TP _) = ()
+
 instance NFData TokenPosn where
   rnf (TokenPn _ _ _) = ()
 
 class (Generic a, Typeable a, ConNames (Rep a), Serial Identity a) => ReachErr a
+
 instance ReachErr ParseErr
+
 instance ReachErr CompileErr
 
 try_hard :: NFData a => Exception e => IO a -> IO (Either e a)
@@ -64,21 +65,24 @@ dropExcess = id -- dropDefines . dropHypotheticalInteracts . dropMoreInfo
 
 test_compile :: FilePath -> IO ()
 test_compile n = do
-  opts <- makeCompilerOpts $ CompilerToolOpts
-    { cto_outputDir = "test.out"
-    , cto_source = n
-    , cto_expCon = False
-    , cto_expComp = False
-    , cto_verifier = Z3
-    }
+  opts <-
+    makeCompilerOpts $
+      CompilerToolOpts
+        { cto_outputDir = "test.out",
+          cto_source = n,
+          cto_expCon = False,
+          cto_expComp = False,
+          cto_verifier = Z3
+        }
   silence $ compile opts
 
 errExampleBs :: (Show a, NFData a) => (FilePath -> IO a) -> FilePath -> IO LB.ByteString
-errExampleBs k fp = withCurrentDirectory dir (try_hard (k fpRel)) >>= \case
-  Right r ->
-    fail $ "expected a failure, but got: " ++ show r
-  Left (ErrorCall e) ->
-    return $ LB.fromStrict $ bpack e
+errExampleBs k fp =
+  withCurrentDirectory dir (try_hard (k fpRel)) >>= \case
+    Right r ->
+      fail $ "expected a failure, but got: " ++ show r
+    Left (ErrorCall e) ->
+      return $ LB.fromStrict $ bpack e
   where
     dir = takeDirectory fp
     fpRel = takeFileName fp
@@ -103,8 +107,11 @@ test_compile_vererr pf = do
   (_, Just hout, Just herr, hP) <- do
     -- TODO: a better way of running the compiler and capturing stdout/stderr
     unsetEnv "REACHC_VERIFIER"
-    createProcess (proc "stack" ["exec", "--", "reachc", "-o", "test.out", rdest]){ std_out = CreatePipe,
-                                                                                    std_err = CreatePipe }
+    createProcess
+      (proc "stack" ["exec", "--", "reachc", "-o", "test.out", rdest])
+        { std_out = CreatePipe,
+          std_err = CreatePipe
+        }
   outT <- TIO.hGetContents hout
   err <- LB.hGetContents herr
   -- strip out the defines
@@ -115,14 +122,12 @@ test_compile_vererr pf = do
   removeFile rdest
   return (out, err)
 
-
 stderroutExampleBs :: (FilePath -> IO (LB.ByteString, LB.ByteString)) -> FilePath -> IO LB.ByteString
 stderroutExampleBs k fp = do
   (out, err) <- k fp
   let tag t x = "<" <> t <> ">\n" <> x <> "\n</" <> t <> ">\n"
   let res = (tag "out" out) <> (tag "err" err)
   return res
-
 
 stderroutExample :: String -> (FilePath -> IO (LB.ByteString, LB.ByteString)) -> FilePath -> TestTree
 stderroutExample ext k fp = do
@@ -139,17 +144,21 @@ compileErrExample = errExample ".txt" test_compile
 verifyErrExample :: FilePath -> TestTree
 verifyErrExample = stderroutExample ".out" test_compile_vererr
 
-
 -- It is dumb that both testSpec and it require descriptive strings
 testNotEmpty :: String -> [a] -> IO TestTree
-testNotEmpty label xs = testSpec label $ it "is not empty" $ case xs of
-  [] -> expectationFailure "... it is empty =["
-  (_:_) -> pure ()
+testNotEmpty label xs = testSpec label $
+  it "is not empty" $ case xs of
+    [] -> expectationFailure "... it is empty =["
+    (_ : _) -> pure ()
 
 testExamplesCover ::
-  forall err proxy. (ReachErr err) =>
-  proxy err -> [FilePath] -> IO TestTree
-testExamplesCover p sources = testSpec label t where
+  forall err proxy.
+  (ReachErr err) =>
+  proxy err ->
+  [FilePath] ->
+  IO TestTree
+testExamplesCover p sources = testSpec label t
+  where
     label = "Examples covering " <> ty
     ty = show $ typeRep p
     constrs = listSeries 1 :: [err]
@@ -158,8 +167,13 @@ testExamplesCover p sources = testSpec label t where
       let missing = cNames \\ map takeBaseName sources
       missing `shouldBe` []
 
-testsFor :: ReachErr err =>
-  proxy err -> (FilePath -> TestTree) -> String -> FilePath -> IO TestTree
+testsFor ::
+  ReachErr err =>
+  proxy err ->
+  (FilePath -> TestTree) ->
+  String ->
+  FilePath ->
+  IO TestTree
 testsFor p mkTest ext subdir = do
   (sources, gTests) <- goldenTests' mkTest ext subdir
   testCov <- testExamplesCover p sources
@@ -185,19 +199,21 @@ goldenTests mkTest ext subdir = do
 
 main :: IO ()
 main = do
-  parseTests <- testsFor (Proxy @ParseErr) parseErrExample ".rsh" "parse-errors"
-  compileTests <- testsFor (Proxy @CompileErr) compileErrExample ".rsh" "compile-errors"
+  parseTests <- testsFor (Proxy :: Proxy ParseErr) parseErrExample ".rsh" "parse-errors"
+  compileTests <- testsFor (Proxy :: Proxy CompileErr) compileErrExample ".rsh" "compile-errors"
   verifyTests <- goldenTests verifyErrExample ".patch" "verification-errors"
   args <- getArgs
-  let
-    -- Note: antXMLRunner isn't very polite when you leave off --xml
-    theMain = case any ("--xml" `isPrefixOf`) args of
-      True -> defaultMainWithIngredients (htmlRunner:antXMLRunner:defaultIngredients)
-      False -> defaultMainWithIngredients (htmlRunner:defaultIngredients)
-    -- Note: The tests get current dir mixed up if run in parallel
-    theArgs = "--num-threads=1":args
-  withArgs theArgs $ theMain $ testGroup "tests"
-    [ parseTests
-    , compileTests
-    , verifyTests
-    ]
+  let -- Note: antXMLRunner isn't very polite when you leave off --xml
+      theMain = case any ("--xml" `isPrefixOf`) args of
+        True -> defaultMainWithIngredients (htmlRunner : antXMLRunner : defaultIngredients)
+        False -> defaultMainWithIngredients (htmlRunner : defaultIngredients)
+      -- Note: The tests get current dir mixed up if run in parallel
+      theArgs = "--num-threads=1" : args
+  withArgs theArgs $
+    theMain $
+      testGroup
+        "tests"
+        [ parseTests,
+          compileTests,
+          verifyTests
+        ]


### PR DESCRIPTION
Not a real PR, just a demo of what the code looks like when run thru [`ormolu`](https://github.com/tweag/ormolu#readme).

Be warned that `stack build ormolu` takes a while to build because it uses `ghc-lib-parser` which is huge.

Ormolu has no config.

Overall it looks like the main thing it does compared to our style is it pushes more things onto a new line

* where bindings are pushed to the line after `where`
* multiline bindings are pushed to the line after `=`
* case branches are pushed to the line after `of`

Also

* it uses comma suffix style, rather than "Haskelly" comma prefix style.
* it lumps all imports together and alphabetizes

I have no strong feelings about any of these style choices, I just like to have an autoformatter that keeps the code looking consistent so that I don't have to think about it.