### PR TITLE
Ensure Keywords Never Appear As Variables

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+hs/test-examples/keywords/*

--- a/hs/src/Reach/AST.hs
+++ b/hs/src/Reach/AST.hs
@@ -215,6 +215,7 @@ data SLVal
   | SLV_Participant SrcLoc SLPart (Maybe SLVar) (Maybe DLVar)
   | SLV_Prim SLPrimitive
   | SLV_Form SLForm
+  | SLV_Kwd SLKwd
   deriving (Eq, Generic, NFData, Show)
 
 isLiteralArray :: SLVal -> Bool
@@ -250,6 +251,91 @@ data SLForm
       , slfpr_muntil :: Maybe JSExpression
       , slfpr_cases :: [ (JSExpression, JSExpression) ] }
   deriving (Eq, Generic, NFData, Show)
+
+data SLKwd
+  = SLK_As
+  | SLK_Async
+  | SLK_Await
+  | SLK_Break
+  | SLK_Case
+  | SLK_Catch
+  | SLK_Class
+  | SLK_Const
+  | SLK_Continue
+  | SLK_Debugger
+  | SLK_Default
+  | SLK_Delete
+  | SLK_Do
+  | SLK_Else
+  | SLK_Enum
+  | SLK_Export
+  | SLK_Extends
+  | SLK_For
+  | SLK_From
+  | SLK_Function
+  | SLK_If
+  | SLK_In
+  | SLK_Import
+  | SLK_InstanceOf
+  | SLK_Let
+  | SLK_New
+  | SLK_Of
+  | SLK_Return
+  | SLK_Static
+  | SLK_Switch
+  | SLK_This
+  | SLK_Throw
+  | SLK_Try
+  | SLK_Typeof
+  | SLK_Var
+  | SLK_While
+  | SLK_With
+  | SLK_Yield
+  deriving (Enum, Eq, Generic, NFData)
+
+instance Show SLKwd where
+  show = \case
+    SLK_As -> "as"
+    SLK_Async -> "async"
+    SLK_Await -> "await"
+    SLK_Break -> "break"
+    SLK_Case -> "case"
+    SLK_Catch -> "catch"
+    SLK_Class -> "class"
+    SLK_Const -> "const"
+    SLK_Continue -> "continue"
+    SLK_Debugger -> "debugger"
+    SLK_Default -> "default"
+    SLK_Delete -> "delete"
+    SLK_Do -> "do"
+    SLK_Else -> "else"
+    SLK_Enum -> "enum"
+    SLK_Export -> "export"
+    SLK_Extends -> "extends"
+    SLK_For -> "for"
+    SLK_From -> "from"
+    SLK_Function -> "function"
+    SLK_If -> "if"
+    SLK_In -> "in"
+    SLK_Import -> "import"
+    SLK_InstanceOf -> "instanceof"
+    SLK_Let -> "let"
+    SLK_New -> "new"
+    SLK_Of -> "of"
+    SLK_Return -> "return"
+    SLK_Static -> "static"
+    SLK_Switch -> "switch"
+    SLK_This -> "this"
+    SLK_Throw -> "throw"
+    SLK_Try -> "try"
+    SLK_Typeof -> "typeof"
+    SLK_Var -> "var"
+    SLK_While -> "while"
+    SLK_With -> "with"
+    SLK_Yield -> "yield"
+
+allKeywords :: [SLKwd]
+allKeywords = enumFrom $ toEnum 0
 
 data PrimOp
   = ADD

--- a/hs/src/Reach/AST.hs
+++ b/hs/src/Reach/AST.hs
@@ -14,6 +14,7 @@ import Language.JavaScript.Parser
 import Reach.JSOrphans ()
 import Reach.UnsafeUtil
 import Reach.Util
+import Generics.Deriving (conNameOf)
 
 --- Source Information
 data ReachSource
@@ -253,86 +254,48 @@ data SLForm
   deriving (Eq, Generic, NFData, Show)
 
 data SLKwd
-  = SLK_As
-  | SLK_Async
-  | SLK_Await
-  | SLK_Break
-  | SLK_Case
-  | SLK_Catch
-  | SLK_Class
-  | SLK_Const
-  | SLK_Continue
-  | SLK_Debugger
-  | SLK_Default
-  | SLK_Delete
-  | SLK_Do
-  | SLK_Else
-  | SLK_Enum
-  | SLK_Export
-  | SLK_Extends
-  | SLK_For
-  | SLK_From
-  | SLK_Function
-  | SLK_If
-  | SLK_In
-  | SLK_Import
-  | SLK_InstanceOf
-  | SLK_Let
-  | SLK_New
-  | SLK_Of
-  | SLK_Return
-  | SLK_Static
-  | SLK_Switch
-  | SLK_This
-  | SLK_Throw
-  | SLK_Try
-  | SLK_Typeof
-  | SLK_Var
-  | SLK_While
-  | SLK_With
-  | SLK_Yield
+  = SLK_as
+  | SLK_async
+  | SLK_await
+  | SLK_break
+  | SLK_case
+  | SLK_catch
+  | SLK_class
+  | SLK_const
+  | SLK_continue
+  | SLK_debugger
+  | SLK_default
+  | SLK_delete
+  | SLK_do
+  | SLK_else
+  | SLK_enum
+  | SLK_export
+  | SLK_extends
+  | SLK_for
+  | SLK_from
+  | SLK_function
+  | SLK_if
+  | SLK_in
+  | SLK_import
+  | SLK_instanceOf
+  | SLK_let
+  | SLK_new
+  | SLK_of
+  | SLK_return
+  | SLK_static
+  | SLK_switch
+  | SLK_this
+  | SLK_throw
+  | SLK_try
+  | SLK_typeof
+  | SLK_var
+  | SLK_while
+  | SLK_with
+  | SLK_yield
   deriving (Bounded, Enum, Eq, Generic, NFData)
 
 instance Show SLKwd where
-  show = \case
-    SLK_As -> "as"
-    SLK_Async -> "async"
-    SLK_Await -> "await"
-    SLK_Break -> "break"
-    SLK_Case -> "case"
-    SLK_Catch -> "catch"
-    SLK_Class -> "class"
-    SLK_Const -> "const"
-    SLK_Continue -> "continue"
-    SLK_Debugger -> "debugger"
-    SLK_Default -> "default"
-    SLK_Delete -> "delete"
-    SLK_Do -> "do"
-    SLK_Else -> "else"
-    SLK_Enum -> "enum"
-    SLK_Export -> "export"
-    SLK_Extends -> "extends"
-    SLK_For -> "for"
-    SLK_From -> "from"
-    SLK_Function -> "function"
-    SLK_If -> "if"
-    SLK_In -> "in"
-    SLK_Import -> "import"
-    SLK_InstanceOf -> "instanceof"
-    SLK_Let -> "let"
-    SLK_New -> "new"
-    SLK_Of -> "of"
-    SLK_Return -> "return"
-    SLK_Static -> "static"
-    SLK_Switch -> "switch"
-    SLK_This -> "this"
-    SLK_Throw -> "throw"
-    SLK_Try -> "try"
-    SLK_Typeof -> "typeof"
-    SLK_Var -> "var"
-    SLK_While -> "while"
-    SLK_With -> "with"
-    SLK_Yield -> "yield"
+  show k = drop 4 $ conNameOf k
 
 allKeywords :: [SLKwd]
 allKeywords = enumFrom minBound

--- a/hs/src/Reach/AST.hs
+++ b/hs/src/Reach/AST.hs
@@ -291,7 +291,7 @@ data SLKwd
   | SLK_While
   | SLK_With
   | SLK_Yield
-  deriving (Enum, Eq, Generic, NFData)
+  deriving (Bounded, Enum, Eq, Generic, NFData)
 
 instance Show SLKwd where
   show = \case
@@ -335,7 +335,7 @@ instance Show SLKwd where
     SLK_Yield -> "yield"
 
 allKeywords :: [SLKwd]
-allKeywords = enumFrom $ toEnum 0
+allKeywords = enumFrom minBound
 
 data PrimOp
   = ADD

--- a/hs/src/Reach/Eval.hs
+++ b/hs/src/Reach/Eval.hs
@@ -516,7 +516,7 @@ base_env =
       )
     ]
     -- Add language keywords to env to prevent variables from using names.
-    ++ map (\ t -> (show t, SLV_Kwd t)) allKeywords
+    <> map (\ t -> (show t, SLV_Kwd t)) allKeywords
 
 jsClo :: HasCallStack => SrcLoc -> String -> String -> (M.Map SLVar SLVal) -> SLVal
 jsClo at name js env_ = SLV_Clo at (Just name) args body cloenv

--- a/hs/src/Reach/Eval.hs
+++ b/hs/src/Reach/Eval.hs
@@ -457,7 +457,11 @@ env_lookup at x env =
   case M.lookup x env of
     Just v -> v
     Nothing ->
-      expect_throw at (Err_Eval_UnboundId x $ M.keys env)
+      expect_throw at (Err_Eval_UnboundId x $ M.keys $ M.filter (not . isKwd) env)
+
+isKwd :: SLSSVal -> Bool
+isKwd (SLSSVal _ _ (SLV_Kwd _)) = True
+isKwd _ = False
 
 m_fromList_public_builtin :: [(SLVar, SLVal)] -> SLEnv
 m_fromList_public_builtin = m_fromList_public srcloc_builtin

--- a/hs/src/Reach/Pretty.hs
+++ b/hs/src/Reach/Pretty.hs
@@ -53,6 +53,10 @@ instance Pretty SLVal where
       "<participant: " <> pretty who <> ">"
     SLV_Prim {} -> "<primitive>"
     SLV_Form {} -> "<form>"
+    SLV_Kwd k -> pretty k
+
+instance Pretty SLKwd where
+  pretty = viaShow
 
 instance Pretty FluidVar where
   pretty FV_balance = "balance"

--- a/hs/src/Reach/Type.hs
+++ b/hs/src/Reach/Type.hs
@@ -186,6 +186,7 @@ slToDL _at v =
         _ -> return $ DLA_Interact who m t
     SLV_Prim _ -> Nothing
     SLV_Form _ -> Nothing
+    SLV_Kwd _ -> Nothing
 
 typeOfM :: HasCallStack => SrcLoc -> SLVal -> Maybe (SLType, DLArg)
 typeOfM at v = do

--- a/hs/src/Reach/Verify/SMT.hs
+++ b/hs/src/Reach/Verify/SMT.hs
@@ -215,7 +215,7 @@ smtPrimOp _ctxt p dargs =
     ADDRESS_EQ -> app "="
     SELF_ADDRESS ->
       case dargs of
-        [ DLA_Literal (DLL_Bytes pn) ] -> const $ Atom $ smtAddress pn
+        [DLA_Literal (DLL_Bytes pn)] -> const $ Atom $ smtAddress pn
         se -> impossible $ "self address " <> show se
   where
     cant = impossible $ "Int doesn't support " ++ show p
@@ -926,8 +926,8 @@ _verify_smt mc vst smt lp = do
           _ ->
             pathAddUnbound_v ctxt Nothing at (smtInteract ctxt who v) it O_Interact
   let definePIE (who, InteractEnv iem) = do
-       pathAddUnbound_v ctxt Nothing at (smtAddress who) T_Address O_BuiltIn
-       mapM_ (defineIE who) $ M.toList iem
+        pathAddUnbound_v ctxt Nothing at (smtAddress who) T_Address O_BuiltIn
+        mapM_ (defineIE who) $ M.toList iem
   mapM_ definePIE $ M.toList pies_m
   let smt_s_top mode = do
         putStrLn $ "  Verifying with mode = " ++ show mode

--- a/hs/test-examples/keywords/UInt.rsh
+++ b/hs/test-examples/keywords/UInt.rsh
@@ -1,0 +1,11 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {}]],
+    (A) => {
+      A.only(() => {
+        const UInt = 5;
+      });
+    });

--- a/hs/test-examples/keywords/UInt.txt
+++ b/hs/test-examples/keywords/UInt.txt
@@ -1,0 +1,1 @@
+reachc: error: ./UInt.rsh:9:9:const: Invalid name shadowing. Identifier 'UInt' is already bound at <builtin>. It cannot be bound again at ./UInt.rsh:9:15:id

--- a/hs/test-examples/keywords/case.rsh
+++ b/hs/test-examples/keywords/case.rsh
@@ -1,0 +1,9 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {}]],
+    (A) => {
+      const case = 5;
+    });

--- a/hs/test-examples/keywords/case.txt
+++ b/hs/test-examples/keywords/case.txt
@@ -1,0 +1,1 @@
+reachc: Unexpected token, CaseToken at ./case.rsh:8:13

--- a/hs/test-examples/keywords/commit.rsh
+++ b/hs/test-examples/keywords/commit.rsh
@@ -1,0 +1,9 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {}]],
+    (A) => {
+      const commit = 5;
+    });

--- a/hs/test-examples/keywords/commit.txt
+++ b/hs/test-examples/keywords/commit.txt
@@ -1,0 +1,1 @@
+reachc: error: ./commit.rsh:8:7:const: Invalid name shadowing. Identifier 'commit' is already bound at <builtin>. It cannot be bound again at ./commit.rsh:8:13:id

--- a/hs/test-examples/keywords/const.rsh
+++ b/hs/test-examples/keywords/const.rsh
@@ -1,0 +1,9 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {}]],
+    (A) => {
+      const const = 5;
+    });

--- a/hs/test-examples/keywords/const.txt
+++ b/hs/test-examples/keywords/const.txt
@@ -1,0 +1,1 @@
+reachc: Unexpected token, ConstToken at ./const.rsh:8:13

--- a/hs/test-examples/keywords/continue.rsh
+++ b/hs/test-examples/keywords/continue.rsh
@@ -1,0 +1,9 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {}]],
+    (A) => {
+      const continue = 5;
+    });

--- a/hs/test-examples/keywords/continue.txt
+++ b/hs/test-examples/keywords/continue.txt
@@ -1,0 +1,1 @@
+reachc: Unexpected token, ContinueToken at ./continue.rsh:8:13

--- a/hs/test-examples/keywords/else.rsh
+++ b/hs/test-examples/keywords/else.rsh
@@ -1,0 +1,9 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {}]],
+    (A) => {
+      const else = 5;
+    });

--- a/hs/test-examples/keywords/else.txt
+++ b/hs/test-examples/keywords/else.txt
@@ -1,0 +1,1 @@
+reachc: Unexpected token, ElseToken at ./else.rsh:8:13

--- a/hs/test-examples/keywords/if.rsh
+++ b/hs/test-examples/keywords/if.rsh
@@ -1,0 +1,9 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {}]],
+    (A) => {
+      const if = 5;
+    });

--- a/hs/test-examples/keywords/if.txt
+++ b/hs/test-examples/keywords/if.txt
@@ -1,1 +1,1 @@
-reachc: Unexpected token, IfToken at ./else.rsh:8:13
+reachc: Unexpected token, IfToken at ./if.rsh:8:13

--- a/hs/test-examples/keywords/if.txt
+++ b/hs/test-examples/keywords/if.txt
@@ -1,0 +1,1 @@
+reachc: Unexpected token, IfToken at ./else.rsh:8:13

--- a/hs/test-examples/keywords/interact.rsh
+++ b/hs/test-examples/keywords/interact.rsh
@@ -1,0 +1,11 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {}]],
+    (A) => {
+      A.only(() => {
+        const interact = 5;
+      });
+    });

--- a/hs/test-examples/keywords/interact.txt
+++ b/hs/test-examples/keywords/interact.txt
@@ -1,0 +1,1 @@
+reachc: error: ./interact.rsh:9:9:const: Invalid name shadowing. Identifier 'interact' is already bound at ./interact.rsh:6:12:obj. It cannot be bound again at ./interact.rsh:9:15:id

--- a/hs/test-examples/keywords/interact_nonlocal.rsh
+++ b/hs/test-examples/keywords/interact_nonlocal.rsh
@@ -1,0 +1,9 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {}]],
+    (A) => {
+      const interact = 5;
+    });

--- a/hs/test-examples/keywords/interact_nonlocal.txt
+++ b/hs/test-examples/keywords/interact_nonlocal.txt
@@ -1,0 +1,1 @@
+reachc: error: ./interact_nonlocal.rsh:8:7:const: Invalid name shadowing. Identifier 'interact' is already bound at ./interact_nonlocal.rsh:6:12:obj. It cannot be bound again at ./interact_nonlocal.rsh:8:13:id

--- a/hs/test-examples/keywords/interact_w_commit.rsh
+++ b/hs/test-examples/keywords/interact_w_commit.rsh
@@ -1,0 +1,19 @@
+'reach 0.1';
+
+const I = {
+  // Can't use shadow stdlib functions within objects
+  commit: Fun([], UInt)
+};
+
+export const main =
+  Reach.App(
+    {},
+    [['A', I]],
+    (A) => {
+      A.only(() => {
+        const x = declassify(interact.commit());
+      });
+      A.publish(x);
+      commit();
+      exit();
+    });

--- a/hs/test-examples/keywords/interact_w_commit.txt
+++ b/hs/test-examples/keywords/interact_w_commit.txt
@@ -1,0 +1,1 @@
+reachc: error: ./interact_w_commit.rsh:5:3:field: Invalid name shadowing. Identifier 'commit' is already bound at <builtin>. It cannot be bound again at ./interact_w_commit.rsh:5:9:property binding

--- a/hs/test-examples/keywords/interact_w_function.rsh
+++ b/hs/test-examples/keywords/interact_w_function.rsh
@@ -1,0 +1,12 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {
+      // Can't shadow keywords within objects
+      function: Fun([], Null)
+    }]],
+    (A) => {
+      exit();
+    });

--- a/hs/test-examples/keywords/interact_w_function.txt
+++ b/hs/test-examples/keywords/interact_w_function.txt
@@ -1,0 +1,1 @@
+reachc: error: ./interact_w_function.rsh:8:7:field: Invalid name shadowing. Identifier 'function' is already bound at <builtin>. It cannot be bound again at ./interact_w_function.rsh:8:15:property binding

--- a/hs/test-examples/keywords/return.rsh
+++ b/hs/test-examples/keywords/return.rsh
@@ -1,0 +1,9 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {}]],
+    (A) => {
+      const return = 5;
+    });

--- a/hs/test-examples/keywords/return.txt
+++ b/hs/test-examples/keywords/return.txt
@@ -1,0 +1,1 @@
+reachc: Unexpected token, ReturnToken at ./return.rsh:8:13

--- a/hs/test-examples/keywords/switch.rsh
+++ b/hs/test-examples/keywords/switch.rsh
@@ -1,0 +1,9 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {}]],
+    (A) => {
+      const switch = 5;
+    });

--- a/hs/test-examples/keywords/switch.txt
+++ b/hs/test-examples/keywords/switch.txt
@@ -1,0 +1,1 @@
+reachc: Unexpected token, SwitchToken at ./switch.rsh:8:13

--- a/hs/test-examples/keywords/typeof.rsh
+++ b/hs/test-examples/keywords/typeof.rsh
@@ -1,0 +1,9 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {}]],
+    (A) => {
+      const typeof = 5;
+    });

--- a/hs/test-examples/keywords/typeof.txt
+++ b/hs/test-examples/keywords/typeof.txt
@@ -1,1 +1,1 @@
-reachc: Unexpected token, TypeOfToken at ./typeof.rsh:8:13
+reachc: Unexpected token, TypeofToken at ./typeof.rsh:8:13

--- a/hs/test-examples/keywords/typeof.txt
+++ b/hs/test-examples/keywords/typeof.txt
@@ -1,0 +1,1 @@
+reachc: Unexpected token, TypeOfToken at ./typeof.rsh:8:13

--- a/hs/test-examples/keywords/unknowable.rsh
+++ b/hs/test-examples/keywords/unknowable.rsh
@@ -1,0 +1,9 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {}]],
+    (A) => {
+      const unknowable = 5;
+    });

--- a/hs/test-examples/keywords/unknowable.txt
+++ b/hs/test-examples/keywords/unknowable.txt
@@ -1,0 +1,1 @@
+reachc: error: ./unknowable.rsh:8:7:const: Invalid name shadowing. Identifier 'unknowable' is already bound at <builtin>. It cannot be bound again at ./unknowable.rsh:8:13:id

--- a/hs/test-examples/keywords/while.rsh
+++ b/hs/test-examples/keywords/while.rsh
@@ -1,0 +1,9 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {}]],
+    (A) => {
+      const while = 5;
+    });

--- a/hs/test-examples/keywords/while.txt
+++ b/hs/test-examples/keywords/while.txt
@@ -1,0 +1,1 @@
+reachc: Unexpected token, WhileToken at ./while.rsh:8:13

--- a/hs/test/Reach/Test_Compiler.hs
+++ b/hs/test/Reach/Test_Compiler.hs
@@ -2,6 +2,7 @@ module Reach.Test_Compiler
   ( test_examples
   , test_language_non_features
   , test_language_features
+  , test_language_keywords
   )
 where
 
@@ -13,6 +14,9 @@ test_language_features = goldenTests compileTestSuccess ".rsh" "features"
 
 test_language_non_features :: IO TestTree
 test_language_non_features = goldenTests compileTestFail ".rsh" "non-features"
+
+test_language_keywords :: IO TestTree
+test_language_keywords = goldenTests compileTestFail ".rsh" "keywords"
 
 test_examples :: IO TestTree
 test_examples = goldenTests compileTestAny ".rsh" "../../examples/"


### PR DESCRIPTION
## Ticket(s)
[Ensure Keywords Never Appear As Variables](https://trello.com/c/Q7TtEzLj)

## Purpose
Create a new `SLVal` constructor to represent keywords. These should be added to the `base_env` to prevent these words from being used as variables.

The Javascript parser will throw errors if keywords are used as variables. Using built-in Reach expressions as variable names will result in an identifier shadow exception. However, it was possible to use keywords or primitives as property names in objects. I added keywords to the `base_env` and updated `evalPropertyName` to prevent this from happening.

I `eslint-ignore`'d the directory of keyword examples as they are mostly malformed Javascript.