### PR TITLE
Add Lookup Context To `env_lookup`

### DIFF
--- a/examples/abstract-simul/index.txt
+++ b/examples/abstract-simul/index.txt
@@ -1,1 +1,1 @@
-reachc: error: <top level>: Invalid unbound identifier: main. Did you mean: ["rps","rental"]
+reachc: error: <top level>: Expected the following identifier to be declared: "main"

--- a/examples/rental/index.txt
+++ b/examples/rental/index.txt
@@ -1,1 +1,1 @@
-reachc: error: <top level>: Invalid unbound identifier: main. Did you mean: ["fair","l_first","t_first"]
+reachc: error: <top level>: Expected the following identifier to be declared: "main"

--- a/hs/test-examples/nl-eval-errors/Err_Eval_UnboundId.txt
+++ b/hs/test-examples/nl-eval-errors/Err_Eval_UnboundId.txt
@@ -1,1 +1,1 @@
-reachc: error: ./Err_Eval_UnboundId.rsh:9:12:id ref: Invalid unbound identifier: alfa. Did you mean: ["alpha","Data","add","and","array"]
+reachc: error: ./Err_Eval_UnboundId.rsh:9:12:id ref: Invalid unbound identifier in expression: alfa. Did you mean: ["alpha","Data","add","and","array"]

--- a/hs/test-examples/nl-eval-errors/Err_Export_Missing.txt
+++ b/hs/test-examples/nl-eval-errors/Err_Export_Missing.txt
@@ -1,1 +1,1 @@
-reachc: error: ./Err_Export_Missing.rsh:8:1:export: Invalid unbound identifier: x. Did you mean: ["eq","ge","gt","le","lt"]
+reachc: error: ./Err_Export_Missing.rsh:8:1:export: Invalid unbound identifier in module export: x. Did you mean: ["eq","ge","gt","le","lt"]

--- a/hs/test-examples/nl-eval-errors/Err_Import_Missing.txt
+++ b/hs/test-examples/nl-eval-errors/Err_Import_Missing.txt
@@ -1,1 +1,1 @@
-reachc: error: ./Err_Import_Missing.rsh:4:1:import: Invalid unbound identifier: whoops. Did you mean: ["blah"]
+reachc: error: ./Err_Import_Missing.rsh:4:1:import: Invalid unbound identifier in module import: whoops. Did you mean: ["blah"]

--- a/hs/test-examples/nl-eval-errors/missing_export.txt
+++ b/hs/test-examples/nl-eval-errors/missing_export.txt
@@ -1,1 +1,1 @@
-reachc: error: ./missing_export.rsh:3:1:import: Invalid unbound identifier: blag. Did you mean: ["blah"]
+reachc: error: ./missing_export.rsh:3:1:import: Invalid unbound identifier in module import: blag. Did you mean: ["blah"]

--- a/hs/test-examples/nl-eval-errors/sample_lib.txt
+++ b/hs/test-examples/nl-eval-errors/sample_lib.txt
@@ -1,1 +1,1 @@
-reachc: error: <top level>: Invalid unbound identifier: main. Did you mean: ["blah"]
+reachc: error: <top level>: Expected the following identifier to be declared: "main"


### PR DESCRIPTION
# Ticket(s)
[Add some more context to env_lookup to see why it is being looked up](https://trello.com/c/uhxLtO7y)

# Purpose
* Add `LookupCtx` datatype
* Update `env_lookup` and `Err_Eval_UnboundId` to accept `LookupCtx` param.

There are two use cases for `env_lookup`:
* When a user wants to reference an id. e.g. `switch (y) { ... }`, `3 + a`.
* When the compiler wants to ensure an id exists. e.g. `main`. In the future, we might only care about a default export and this won't be needed.

I looked into abstracting object property lookups into this function, but I think it would be too much overhaul compared to the added benefits.