### PR TITLE
Provide Reach Stack Trace In Error Messages

### DIFF
--- a/hs/src/Reach/AST.hs
+++ b/hs/src/Reach/AST.hs
@@ -63,6 +63,9 @@ expect_throw mCtx src ce =
       [] -> ""
       ctx -> "\nTrace:\n" <> intercalate "\n" (topOfStackTrace ctx)
 
+expect_thrown :: Show a => HasCallStack => SrcLoc -> a -> b
+expect_thrown = expect_throw Nothing
+
 topOfStackTrace :: [SLCtxtFrame] -> [String]
 topOfStackTrace stack
   | length stackMsgs > 10 = take 10 stackMsgs <> ["  ..."]

--- a/hs/src/Reach/Backend/JS.hs
+++ b/hs/src/Reach/Backend/JS.hs
@@ -188,7 +188,7 @@ jsExpr ctxt = \case
   DLE_Arg _ a ->
     jsArg a
   DLE_Impossible at msg ->
-    expect_throw Nothing at msg
+    expect_thrown at msg
   DLE_PrimOp _ p as ->
     jsPrimApply ctxt p $ map jsArg as
   DLE_ArrayRef _ aa ia ->

--- a/hs/src/Reach/Backend/JS.hs
+++ b/hs/src/Reach/Backend/JS.hs
@@ -188,7 +188,7 @@ jsExpr ctxt = \case
   DLE_Arg _ a ->
     jsArg a
   DLE_Impossible at msg ->
-    expect_throw at msg
+    expect_throw Nothing at msg
   DLE_PrimOp _ p as ->
     jsPrimApply ctxt p $ map jsArg as
   DLE_ArrayRef _ aa ia ->

--- a/hs/src/Reach/Connector/ALGO.hs
+++ b/hs/src/Reach/Connector/ALGO.hs
@@ -597,7 +597,7 @@ doArrayRef at aa frombs ie = do
 ce :: DLExpr -> App ()
 ce = \case
   DLE_Arg _ a -> ca a
-  DLE_Impossible at msg -> expect_throw Nothing at msg
+  DLE_Impossible at msg -> expect_thrown at msg
   DLE_PrimOp _ p args -> cprim p args
   DLE_ArrayRef at aa ia -> doArrayRef at aa True (Left ia)
   DLE_ArraySet at aa ia va -> do

--- a/hs/src/Reach/Connector/ALGO.hs
+++ b/hs/src/Reach/Connector/ALGO.hs
@@ -597,7 +597,7 @@ doArrayRef at aa frombs ie = do
 ce :: DLExpr -> App ()
 ce = \case
   DLE_Arg _ a -> ca a
-  DLE_Impossible at msg -> expect_throw at msg
+  DLE_Impossible at msg -> expect_throw Nothing at msg
   DLE_PrimOp _ p args -> cprim p args
   DLE_ArrayRef at aa ia -> doArrayRef at aa True (Left ia)
   DLE_ArraySet at aa ia va -> do

--- a/hs/src/Reach/Connector/ETH_Solidity.hs
+++ b/hs/src/Reach/Connector/ETH_Solidity.hs
@@ -339,7 +339,7 @@ solPrimApply ctxt = \case
 solExpr :: SolCtxt -> Doc -> DLExpr -> Doc
 solExpr ctxt sp = \case
   DLE_Arg _ a -> solArg ctxt a <> sp
-  DLE_Impossible at msg -> expect_throw at msg
+  DLE_Impossible at msg -> expect_throw Nothing at msg
   DLE_PrimOp _ p args ->
     (solPrimApply ctxt p $ map (solArg ctxt) args) <> sp
   DLE_ArrayRef _ ae ie ->

--- a/hs/src/Reach/Connector/ETH_Solidity.hs
+++ b/hs/src/Reach/Connector/ETH_Solidity.hs
@@ -339,7 +339,7 @@ solPrimApply ctxt = \case
 solExpr :: SolCtxt -> Doc -> DLExpr -> Doc
 solExpr ctxt sp = \case
   DLE_Arg _ a -> solArg ctxt a <> sp
-  DLE_Impossible at msg -> expect_throw Nothing at msg
+  DLE_Impossible at msg -> expect_thrown at msg
   DLE_PrimOp _ p args ->
     (solPrimApply ctxt p $ map (solArg ctxt) args) <> sp
   DLE_ArrayRef _ ae ie ->

--- a/hs/src/Reach/EPP.hs
+++ b/hs/src/Reach/EPP.hs
@@ -355,7 +355,7 @@ epp_n st n =
       let this_loop = fromMaybe (impossible "no loop") $ pst_loop_num st
       let loop_svs = fromMaybe (impossible "no loop") $ pst_loop_svs st
       when (this_loop == pst_prev_handler st) $
-        expect_throw at Err_ContinueDomination
+        expect_throw Nothing at Err_ContinueDomination
       let asn_cs = counts asn
       let cons_cs' = asn_cs <> counts loop_svs
       let ct' = CT_Jump at this_loop loop_svs asn

--- a/hs/src/Reach/EPP.hs
+++ b/hs/src/Reach/EPP.hs
@@ -355,7 +355,7 @@ epp_n st n =
       let this_loop = fromMaybe (impossible "no loop") $ pst_loop_num st
       let loop_svs = fromMaybe (impossible "no loop") $ pst_loop_svs st
       when (this_loop == pst_prev_handler st) $
-        expect_throw Nothing at Err_ContinueDomination
+        expect_thrown at Err_ContinueDomination
       let asn_cs = counts asn
       let cons_cs' = asn_cs <> counts loop_svs
       let ct' = CT_Jump at this_loop loop_svs asn

--- a/hs/src/Reach/Parser.hs
+++ b/hs/src/Reach/Parser.hs
@@ -85,17 +85,17 @@ parseIdent at = \case
   JSIdentName a ident ->
     (srcloc_jsa ident a at, ident)
   JSIdentNone ->
-    expect_throw Nothing at $ Err_Parse_JSIdentNone
+    expect_thrown at $ Err_Parse_JSIdentNone
 
 jse_expect_id :: HasCallStack => SrcLoc -> JSExpression -> String
 jse_expect_id at = \case
   (JSIdentifier _ x) -> x
-  j -> expect_throw Nothing at (Err_Parse_ExpectIdentifier j)
+  j -> expect_thrown at (Err_Parse_ExpectIdentifier j)
 
 jso_expect_id :: HasCallStack => SrcLoc -> JSObjectProperty -> String
 jso_expect_id at = \case
   JSPropertyIdentRef _ x -> x
-  j -> expect_throw Nothing at $ Err_Parse_ExpectIdentifierProp j
+  j -> expect_thrown at $ Err_Parse_ExpectIdentifierProp j
 
 parseJSFormals :: SrcLoc -> JSCommaList JSExpression -> [JSExpression]
 parseJSFormals _at jsformals = jscl_flatten jsformals
@@ -105,7 +105,7 @@ jsArrowFormalsToFunFormals at = \case
   JSUnparenthesizedArrowParameter (JSIdentName a x) ->
     JSLOne (JSIdentifier a x)
   JSUnparenthesizedArrowParameter JSIdentNone ->
-    expect_throw Nothing at Err_Parser_Arrow_NoFormals
+    expect_thrown at Err_Parser_Arrow_NoFormals
   JSParenthesizedArrowParameterList _ l _ -> l
 
 parseJSArrowFormals :: SrcLoc -> JSArrowParameterList -> [JSExpression]
@@ -119,7 +119,7 @@ jsCallLike at = \case
   JSMemberExpression rator _ rands _ ->
     (rator, jscl_flatten rands)
   e ->
-    expect_throw Nothing at $ Err_Parse_NotCallLike e
+    expect_thrown at $ Err_Parse_NotCallLike e
 
 readJsExpr :: HasCallStack => String -> JSExpression
 readJsExpr s =
@@ -186,7 +186,7 @@ gatherDeps_ast at fmr = \case
   JSAstModule mis _ ->
     mapM (gatherDeps_mi at fmr) mis
   j ->
-    expect_throw Nothing at (Err_Parse_NotModule j)
+    expect_thrown at (Err_Parse_NotModule j)
 
 updatePartialAvoidCycles :: Ord a => SrcLoc -> IORef (BundleMap a b) -> Maybe a -> [a] -> (() -> IO a) -> (a -> c) -> (a -> ParserError) -> (a -> IO b) -> IO c
 updatePartialAvoidCycles at fmr mfrom def_a get_key ret_key err_key proc_key = do
@@ -206,7 +206,7 @@ updatePartialAvoidCycles at fmr mfrom def_a get_key ret_key err_key proc_key = d
       writeIORef fmr (dm'', fm'')
       return res
     Just Nothing ->
-      expect_throw Nothing at $ err_key key
+      expect_thrown at $ err_key key
     Just (Just _) ->
       return res
 
@@ -247,9 +247,9 @@ gatherDeps_file gctxt at fmr src_rel =
       reRel <- makeRelativeToCurrentDirectory src_abs
       when (gctxt == GatherNotTop) $ do
         when (isAbsolute src_rel) $ do
-          expect_throw Nothing at (Err_Parse_ImportAbsolute src_rel)
+          expect_thrown at (Err_Parse_ImportAbsolute src_rel)
         when ("../" `isPrefixOf` reRel) $ do
-          expect_throw Nothing at (Err_Parse_ImportDotDot src_rel)
+          expect_thrown at (Err_Parse_ImportDotDot src_rel)
       return $ ReachSourceFile src_abs
     ret_key (ReachSourceFile x) = x
     ret_key (ReachStdLib) = no_stdlib

--- a/hs/src/Reach/Parser.hs
+++ b/hs/src/Reach/Parser.hs
@@ -85,17 +85,17 @@ parseIdent at = \case
   JSIdentName a ident ->
     (srcloc_jsa ident a at, ident)
   JSIdentNone ->
-    expect_throw at $ Err_Parse_JSIdentNone
+    expect_throw Nothing at $ Err_Parse_JSIdentNone
 
 jse_expect_id :: HasCallStack => SrcLoc -> JSExpression -> String
 jse_expect_id at = \case
   (JSIdentifier _ x) -> x
-  j -> expect_throw at (Err_Parse_ExpectIdentifier j)
+  j -> expect_throw Nothing at (Err_Parse_ExpectIdentifier j)
 
 jso_expect_id :: HasCallStack => SrcLoc -> JSObjectProperty -> String
 jso_expect_id at = \case
   JSPropertyIdentRef _ x -> x
-  j -> expect_throw at $ Err_Parse_ExpectIdentifierProp j
+  j -> expect_throw Nothing at $ Err_Parse_ExpectIdentifierProp j
 
 parseJSFormals :: SrcLoc -> JSCommaList JSExpression -> [JSExpression]
 parseJSFormals _at jsformals = jscl_flatten jsformals
@@ -105,7 +105,7 @@ jsArrowFormalsToFunFormals at = \case
   JSUnparenthesizedArrowParameter (JSIdentName a x) ->
     JSLOne (JSIdentifier a x)
   JSUnparenthesizedArrowParameter JSIdentNone ->
-    expect_throw at Err_Parser_Arrow_NoFormals
+    expect_throw Nothing at Err_Parser_Arrow_NoFormals
   JSParenthesizedArrowParameterList _ l _ -> l
 
 parseJSArrowFormals :: SrcLoc -> JSArrowParameterList -> [JSExpression]
@@ -119,7 +119,7 @@ jsCallLike at = \case
   JSMemberExpression rator _ rands _ ->
     (rator, jscl_flatten rands)
   e ->
-    expect_throw at $ Err_Parse_NotCallLike e
+    expect_throw Nothing at $ Err_Parse_NotCallLike e
 
 readJsExpr :: HasCallStack => String -> JSExpression
 readJsExpr s =
@@ -186,7 +186,7 @@ gatherDeps_ast at fmr = \case
   JSAstModule mis _ ->
     mapM (gatherDeps_mi at fmr) mis
   j ->
-    expect_throw at (Err_Parse_NotModule j)
+    expect_throw Nothing at (Err_Parse_NotModule j)
 
 updatePartialAvoidCycles :: Ord a => SrcLoc -> IORef (BundleMap a b) -> Maybe a -> [a] -> (() -> IO a) -> (a -> c) -> (a -> ParserError) -> (a -> IO b) -> IO c
 updatePartialAvoidCycles at fmr mfrom def_a get_key ret_key err_key proc_key = do
@@ -206,7 +206,7 @@ updatePartialAvoidCycles at fmr mfrom def_a get_key ret_key err_key proc_key = d
       writeIORef fmr (dm'', fm'')
       return res
     Just Nothing ->
-      expect_throw at $ err_key key
+      expect_throw Nothing at $ err_key key
     Just (Just _) ->
       return res
 
@@ -247,9 +247,9 @@ gatherDeps_file gctxt at fmr src_rel =
       reRel <- makeRelativeToCurrentDirectory src_abs
       when (gctxt == GatherNotTop) $ do
         when (isAbsolute src_rel) $ do
-          expect_throw at (Err_Parse_ImportAbsolute src_rel)
+          expect_throw Nothing at (Err_Parse_ImportAbsolute src_rel)
         when ("../" `isPrefixOf` reRel) $ do
-          expect_throw at (Err_Parse_ImportDotDot src_rel)
+          expect_throw Nothing at (Err_Parse_ImportDotDot src_rel)
       return $ ReachSourceFile src_abs
     ret_key (ReachSourceFile x) = x
     ret_key (ReachStdLib) = no_stdlib

--- a/hs/src/Reach/Type.hs
+++ b/hs/src/Reach/Type.hs
@@ -53,7 +53,7 @@ checkIntLiteral :: SrcLoc -> Integer -> Integer -> Integer -> Integer
 checkIntLiteral at rmin x rmax =
   case rmin <= x && x <= rmax of
     True -> x
-    False -> expect_throw at $ Err_Type_IntLiteralRange rmin x rmax
+    False -> expect_throw Nothing at $ Err_Type_IntLiteralRange rmin x rmax
 
 typeMeet :: SrcLoc -> (SrcLoc, SLType) -> (SrcLoc, SLType) -> SLType
 typeMeet _ (_, T_Bytes xz) (_, T_Bytes yz) =
@@ -63,13 +63,13 @@ typeMeet top_at x@(_, xt) y@(_, yt) =
   case xt == yt of
     True -> xt
     False ->
-      expect_throw top_at $ Err_TypeMeets_Mismatch top_at x y
+      expect_throw Nothing top_at $ Err_TypeMeets_Mismatch top_at x y
 
 typeMeets :: SrcLoc -> [(SrcLoc, SLType)] -> SLType
 typeMeets top_at l =
   case l of
     [] ->
-      expect_throw top_at $ Err_TypeMeets_None
+      expect_throw Nothing top_at $ Err_TypeMeets_None
     [(_, xt)] -> xt
     [x, y] -> typeMeet top_at x y
     x : more -> typeMeet top_at x $ (top_at, typeMeets top_at more)
@@ -197,7 +197,7 @@ typeOf :: HasCallStack => SrcLoc -> SLVal -> (SLType, DLArg)
 typeOf at v =
   case typeOfM at v of
     Just x -> x
-    Nothing -> expect_throw at $ Err_Type_None v
+    Nothing -> expect_throw Nothing at $ Err_Type_None v
 
 typeCheck :: SrcLoc -> TypeEnv s -> SLType -> SLVal -> ST s DLArg
 typeCheck at env ty val = typeCheck_help at env ty val val_ty res
@@ -214,9 +214,9 @@ typeChecks at env ts vs =
       ds' <- typeChecks at env ts' vs'
       return $ d : ds'
     ((_ : _), _) ->
-      expect_throw at $ Err_Type_TooFewArguments ts
+      expect_throw Nothing at $ Err_Type_TooFewArguments ts
     (_, (_ : _)) ->
-      expect_throw at $ Err_Type_TooManyArguments vs
+      expect_throw Nothing at $ Err_Type_TooManyArguments vs
 
 checkAndConvert_i :: SrcLoc -> TypeEnv s -> SLType -> [SLVal] -> ST s (SLType, [DLArg])
 checkAndConvert_i at env t args =
@@ -230,7 +230,7 @@ checkAndConvert_i at env t args =
       (vrng, dargs) <- checkAndConvert_i at env' ft args
       rng <- typeSubst at env' vrng
       return (rng, dargs)
-    _ -> expect_throw at $ Err_Type_NotApplicable t
+    _ -> expect_throw Nothing at $ Err_Type_NotApplicable t
 
 checkAndConvert :: SrcLoc -> SLType -> [SLVal] -> (SLType, [DLArg])
 checkAndConvert at t args = runST $ checkAndConvert_i at mempty t args

--- a/hs/src/Reach/Type.hs
+++ b/hs/src/Reach/Type.hs
@@ -53,7 +53,7 @@ checkIntLiteral :: SrcLoc -> Integer -> Integer -> Integer -> Integer
 checkIntLiteral at rmin x rmax =
   case rmin <= x && x <= rmax of
     True -> x
-    False -> expect_throw Nothing at $ Err_Type_IntLiteralRange rmin x rmax
+    False -> expect_thrown at $ Err_Type_IntLiteralRange rmin x rmax
 
 typeMeet :: SrcLoc -> (SrcLoc, SLType) -> (SrcLoc, SLType) -> SLType
 typeMeet _ (_, T_Bytes xz) (_, T_Bytes yz) =
@@ -63,13 +63,13 @@ typeMeet top_at x@(_, xt) y@(_, yt) =
   case xt == yt of
     True -> xt
     False ->
-      expect_throw Nothing top_at $ Err_TypeMeets_Mismatch top_at x y
+      expect_thrown top_at $ Err_TypeMeets_Mismatch top_at x y
 
 typeMeets :: SrcLoc -> [(SrcLoc, SLType)] -> SLType
 typeMeets top_at l =
   case l of
     [] ->
-      expect_throw Nothing top_at $ Err_TypeMeets_None
+      expect_thrown top_at $ Err_TypeMeets_None
     [(_, xt)] -> xt
     [x, y] -> typeMeet top_at x y
     x : more -> typeMeet top_at x $ (top_at, typeMeets top_at more)
@@ -197,7 +197,7 @@ typeOf :: HasCallStack => SrcLoc -> SLVal -> (SLType, DLArg)
 typeOf at v =
   case typeOfM at v of
     Just x -> x
-    Nothing -> expect_throw Nothing at $ Err_Type_None v
+    Nothing -> expect_thrown at $ Err_Type_None v
 
 typeCheck :: SrcLoc -> TypeEnv s -> SLType -> SLVal -> ST s DLArg
 typeCheck at env ty val = typeCheck_help at env ty val val_ty res
@@ -214,9 +214,9 @@ typeChecks at env ts vs =
       ds' <- typeChecks at env ts' vs'
       return $ d : ds'
     ((_ : _), _) ->
-      expect_throw Nothing at $ Err_Type_TooFewArguments ts
+      expect_thrown at $ Err_Type_TooFewArguments ts
     (_, (_ : _)) ->
-      expect_throw Nothing at $ Err_Type_TooManyArguments vs
+      expect_thrown at $ Err_Type_TooManyArguments vs
 
 checkAndConvert_i :: SrcLoc -> TypeEnv s -> SLType -> [SLVal] -> ST s (SLType, [DLArg])
 checkAndConvert_i at env t args =
@@ -230,7 +230,7 @@ checkAndConvert_i at env t args =
       (vrng, dargs) <- checkAndConvert_i at env' ft args
       rng <- typeSubst at env' vrng
       return (rng, dargs)
-    _ -> expect_throw Nothing at $ Err_Type_NotApplicable t
+    _ -> expect_thrown at $ Err_Type_NotApplicable t
 
 checkAndConvert :: SrcLoc -> SLType -> [SLVal] -> (SLType, [DLArg])
 checkAndConvert at t args = runST $ checkAndConvert_i at mempty t args

--- a/hs/test-examples/keywords/UInt.txt
+++ b/hs/test-examples/keywords/UInt.txt
@@ -1,1 +1,3 @@
 reachc: error: ./UInt.rsh:9:9:const: Invalid name shadowing. Identifier 'UInt' is already bound at <builtin>. It cannot be bound again at ./UInt.rsh:9:15:id
+Trace:
+  at "function" (./UInt.rsh:10:9:after expr stmt semicolon)

--- a/hs/test-examples/keywords/interact.txt
+++ b/hs/test-examples/keywords/interact.txt
@@ -1,1 +1,3 @@
 reachc: error: ./interact.rsh:9:9:const: Invalid name shadowing. Identifier 'interact' is already bound at ./interact.rsh:6:12:obj. It cannot be bound again at ./interact.rsh:9:15:id
+Trace:
+  at "function" (./interact.rsh:10:9:after expr stmt semicolon)

--- a/hs/test-examples/nl-eval-errors/Err_Block_IllegalJS.txt
+++ b/hs/test-examples/nl-eval-errors/Err_Block_IllegalJS.txt
@@ -1,1 +1,3 @@
 reachc: error: ./Err_Block_IllegalJS.rsh:5:3:throw: Invalid statement
+Trace:
+  at "function" (./Err_Block_IllegalJS.rsh:9:27:application)

--- a/hs/test-examples/nl-eval-errors/Err_ExpectedPrivate.txt
+++ b/hs/test-examples/nl-eval-errors/Err_ExpectedPrivate.txt
@@ -1,1 +1,3 @@
 reachc: error: ./Err_ExpectedPrivate.rsh:8:27:application: Invalid declassify. Expected to declassify something private, but this uint256 is public.
+Trace:
+  at "function" (./Err_ExpectedPrivate.rsh:9:7:after expr stmt semicolon)

--- a/hs/test-examples/nl-eval-errors/Err_Invalid_Statement.txt
+++ b/hs/test-examples/nl-eval-errors/Err_Invalid_Statement.txt
@@ -1,1 +1,3 @@
-reachc: error: reach standard library:80:8:application: Invalid use of statement: each/only (./Err_Invalid_Statement.rsh:10:13:application). Did you mean to wrap it in a thunk?
+reachc: error: ./Err_Invalid_Statement.rsh:10:13:application: Invalid use of statement: each/only. Did you mean to wrap it in a thunk?
+Trace:
+  at "function" (./Err_Invalid_Statement.rsh:9:14:application)

--- a/hs/test-examples/nl-eval-errors/Err_Obj_IllegalComputedField__interact.txt
+++ b/hs/test-examples/nl-eval-errors/Err_Obj_IllegalComputedField__interact.txt
@@ -1,1 +1,3 @@
 reachc: error: ./Err_Obj_IllegalComputedField__interact.rsh:9:20:computed field name: Invalid computed field name. It must be computable at compile time.
+Trace:
+  at "function" (./Err_Obj_IllegalComputedField__interact.rsh:10:7:after expr stmt semicolon)

--- a/hs/test-examples/nl-eval-errors/Err_RecursionDepthLimit.txt
+++ b/hs/test-examples/nl-eval-errors/Err_RecursionDepthLimit.txt
@@ -1,1 +1,13 @@
 reachc: error: ./Err_RecursionDepthLimit.rsh:4:23:application: recursion depth limit exceeded, more than 65536 calls; who would need more than that many?
+Trace:
+  at "function" (./Err_RecursionDepthLimit.rsh:4:23:application)
+  at "function" (./Err_RecursionDepthLimit.rsh:4:23:application)
+  at "function" (./Err_RecursionDepthLimit.rsh:4:23:application)
+  at "function" (./Err_RecursionDepthLimit.rsh:4:23:application)
+  at "function" (./Err_RecursionDepthLimit.rsh:4:23:application)
+  at "function" (./Err_RecursionDepthLimit.rsh:4:23:application)
+  at "function" (./Err_RecursionDepthLimit.rsh:4:23:application)
+  at "function" (./Err_RecursionDepthLimit.rsh:4:23:application)
+  at "function" (./Err_RecursionDepthLimit.rsh:4:23:application)
+  at "function" (./Err_RecursionDepthLimit.rsh:4:23:application)
+  ...

--- a/hs/test-examples/nl-eval-errors/Err_Switch_DoubleCase.txt
+++ b/hs/test-examples/nl-eval-errors/Err_Switch_DoubleCase.txt
@@ -1,1 +1,4 @@
 reachc: error: ./Err_Switch_DoubleCase.rsh:11:24:block: switch contains duplicate case, None at ./Err_Switch_DoubleCase.rsh:14:9:case; first defined at ./Err_Switch_DoubleCase.rsh:13:9:case
+Trace:
+  at "function" (./Err_Switch_DoubleCase.rsh:15:35:application)
+  at "function" (./Err_Switch_DoubleCase.rsh:16:7:after expr stmt semicolon)

--- a/hs/test-examples/nl-eval-errors/Err_Switch_ExtraCases.txt
+++ b/hs/test-examples/nl-eval-errors/Err_Switch_ExtraCases.txt
@@ -1,1 +1,4 @@
 reachc: error: ./Err_Switch_ExtraCases.rsh:12:9:switch: switch contains extra cases: ["Mone"]
+Trace:
+  at "function" (./Err_Switch_ExtraCases.rsh:15:35:application)
+  at "function" (./Err_Switch_ExtraCases.rsh:16:7:after expr stmt semicolon)

--- a/hs/test-examples/nl-eval-errors/Err_Switch_MissingCases.txt
+++ b/hs/test-examples/nl-eval-errors/Err_Switch_MissingCases.txt
@@ -1,1 +1,4 @@
 reachc: error: ./Err_Switch_MissingCases.rsh:12:9:switch: switch missing cases: ["None"]
+Trace:
+  at "function" (./Err_Switch_MissingCases.rsh:13:35:application)
+  at "function" (./Err_Switch_MissingCases.rsh:14:7:after expr stmt semicolon)

--- a/hs/test-examples/non-features/part_field.txt
+++ b/hs/test-examples/non-features/part_field.txt
@@ -1,1 +1,3 @@
 reachc: error: ./part_field.rsh:8:26:dot: wager is not a field of A's interaction interface. Did you mean: ["getWager"]
+Trace:
+  at "function" (./part_field.rsh:9:7:after expr stmt semicolon)

--- a/hs/test-examples/non-features/template_literals.txt
+++ b/hs/test-examples/non-features/template_literals.txt
@@ -1,1 +1,3 @@
 reachc: error: ./template_literals.rsh:9:9:const: Invalid Reach expression syntax: JSTemplateLiteral
+Trace:
+  at "function" (./template_literals.rsh:10:9:after expr stmt semicolon)

--- a/hs/test-examples/non-features/with.txt
+++ b/hs/test-examples/non-features/with.txt
@@ -1,1 +1,3 @@
 reachc: error: ./with.rsh:10:7:with: Invalid statement
+Trace:
+  at "function" (./with.rsh:11:33:after expr stmt semicolon)


### PR DESCRIPTION
## Purpose
Provide a stack trace, if applicable, to errors that occur during evaluation. Currently, I have it in a format that mimics Node's stack trace to be more familiar to JS devs. 

### Notes
Currently, we convert function declarations to anonymous functions so everything will pretty much say "function". Maybe we want to update this in the future to record the declared function name, and in cases of `const x = () =>`, we could somehow connect that the function is bound to `x`. The latter is probably the most common way to declare functions, so treating the function as truly anonymous seems like it's losing meaningful info. Thoughts?
