### PR TITLE
Add CLI option to output error messages as JSON

### DIFF
--- a/hs/app/reachc/Main.hs
+++ b/hs/app/reachc/Main.hs
@@ -2,21 +2,13 @@ module Main (main) where
 
 import Control.Exception
 import Control.Monad
-import Options.Applicative
+import Reach.CommandLine
 import Reach.CompilerTool
 import Reach.Report
 import Reach.Version
 import System.Environment
 import System.Exit
 import System.FilePath
-
-data CompilerToolArgs = CompilerToolArgs
-  { cta_intermediateFiles :: Bool
-  , cta_disableReporting :: Bool
-  , cta_outputDir :: Maybe FilePath
-  , cta_source :: FilePath
-  , cta_tops :: [String]
-  }
 
 data CompilerToolEnv = CompilerToolEnv
   { cte_REACHC_ID :: Maybe String
@@ -36,31 +28,6 @@ makeCompilerToolOpts CompilerToolArgs {..} CompilerToolEnv {} =
     }
   where
     defaultOutputDir = takeDirectory cta_source </> "build"
-
-compiler :: Parser CompilerToolArgs
-compiler =
-  CompilerToolArgs
-    <$> switch (long "intermediate-files")
-    <*> switch (long "disable-reporting")
-    <*> optional
-      (strOption
-         (long "output"
-            <> short 'o'
-            <> metavar "DIR"
-            <> help "Directory for output files"
-            <> showDefault))
-    <*> strArgument ((metavar "SOURCE") <> value ("index.rsh"))
-    <*> many (strArgument (metavar "EXPORTS..."))
-
-getCompilerArgs :: String -> IO CompilerToolArgs
-getCompilerArgs versionCliDisp = do
-  let opts =
-        info
-          (compiler <**> helper)
-          (fullDesc
-             <> progDesc "verify and compile an Reach program"
-             <> header versionCliDisp)
-  execParser opts
 
 getCompilerEnv :: IO CompilerToolEnv
 getCompilerEnv = do

--- a/hs/src/Reach/AST/Base.hs
+++ b/hs/src/Reach/AST/Base.hs
@@ -56,6 +56,14 @@ instance Show SrcLoc where
         Nothing -> []
         Just (TokenPn _ l c) -> [show l, show c]
 
+data ImpossibleError
+  = Err_Impossible String
+  deriving (Eq, Generic, ErrorMessageForJson, ErrorSuggestions)
+
+instance Show ImpossibleError where
+  show = \case
+    Err_Impossible msg -> msg
+
 data CompilationError =
   CompilationError {
     ce_suggestions :: [String],

--- a/hs/src/Reach/AST/Base.hs
+++ b/hs/src/Reach/AST/Base.hs
@@ -79,10 +79,10 @@ srcloc_line_col _ = []
 expect_throw :: (Show a, ErrorMessageForJson a, ErrorSuggestions a) => HasCallStack => Maybe ([SLCtxtFrame]) -> SrcLoc -> a -> b
 expect_throw mCtx src ce =
   case unsafeIsErrorFormatJson of
-    True -> error $ map w2c $ LB.unpack $ encode $ CompilationError {
+    True -> error $ "error: " ++ (map w2c $ LB.unpack $ encode $ CompilationError {
       ce_suggestions = errorSuggestions ce,
       ce_errorMessage = errorMessageForJson ce,
-      ce_position = srcloc_line_col src }
+      ce_position = srcloc_line_col src })
     False ->
       error . T.unpack . unsafeRedactAbs . T.pack $
       "error: " ++ (show src) ++ ": " ++ (take 512 $ show ce)

--- a/hs/src/Reach/Backend/JS.hs
+++ b/hs/src/Reach/Backend/JS.hs
@@ -18,17 +18,6 @@ import Reach.Type
 import Reach.UnsafeUtil
 import Reach.Util
 import Reach.Version
-import Generics.Deriving (Generic)
-
-
-data JsError
-  = Err_Impossible String
-  deriving (Eq, Generic, ErrorMessageForJson, ErrorSuggestions)
-
-instance Show JsError where
-  show = \case
-    Err_Impossible msg -> msg
-
 
 --- Pretty helpers
 

--- a/hs/src/Reach/Backend/JS.hs
+++ b/hs/src/Reach/Backend/JS.hs
@@ -18,6 +18,17 @@ import Reach.Type
 import Reach.UnsafeUtil
 import Reach.Util
 import Reach.Version
+import Generics.Deriving (Generic)
+
+
+data JsError
+  = Err_Impossible String
+  deriving (Eq, Generic, ErrorMessageForJson, ErrorSuggestions)
+
+instance Show JsError where
+  show = \case
+    Err_Impossible msg -> msg
+
 
 --- Pretty helpers
 
@@ -199,7 +210,7 @@ jsExpr ctxt = \case
   DLE_LArg _ la ->
     jsLargeArg la
   DLE_Impossible at msg ->
-    expect_thrown at msg
+    expect_thrown at $ Err_Impossible msg
   DLE_PrimOp _ p as ->
     jsPrimApply ctxt p $ map jsArg as
   DLE_ArrayRef _ aa ia ->

--- a/hs/src/Reach/CommandLine.hs
+++ b/hs/src/Reach/CommandLine.hs
@@ -1,0 +1,39 @@
+module Reach.CommandLine (CompilerToolArgs (..), compiler, getCompilerArgs)  where
+
+import Options.Applicative
+
+
+data CompilerToolArgs = CompilerToolArgs
+  { cta_intermediateFiles :: Bool
+  , cta_disableReporting :: Bool
+  , cta_errorFormatJson :: Bool
+  , cta_outputDir :: Maybe FilePath
+  , cta_source :: FilePath
+  , cta_tops :: [String]
+  }
+
+compiler :: Parser CompilerToolArgs
+compiler =
+  CompilerToolArgs
+    <$> switch (long "intermediate-files")
+    <*> switch (long "disable-reporting")
+    <*> switch (long "error-format-json")
+    <*> optional
+      (strOption
+         (long "output"
+            <> short 'o'
+            <> metavar "DIR"
+            <> help "Directory for output files"
+            <> showDefault))
+    <*> strArgument ((metavar "SOURCE") <> value ("index.rsh"))
+    <*> many (strArgument (metavar "EXPORTS..."))
+
+getCompilerArgs :: String -> IO CompilerToolArgs
+getCompilerArgs versionCliDisp = do
+  let opts =
+        info
+          (compiler <**> helper)
+          (fullDesc
+             <> progDesc "verify and compile an Reach program"
+             <> header versionCliDisp)
+  execParser opts

--- a/hs/src/Reach/Connector/ALGO.hs
+++ b/hs/src/Reach/Connector/ALGO.hs
@@ -32,8 +32,17 @@ import Reach.UnsafeUtil
 import Reach.Util
 import Safe (atMay)
 import Text.Read
+import Generics.Deriving (Generic)
 
 -- General tools that could be elsewhere
+
+data AlgoError
+  = Err_Impossible String
+  deriving (Eq, Generic, ErrorMessageForJson, ErrorSuggestions)
+
+instance Show AlgoError where
+  show = \case
+    Err_Impossible msg -> msg
 
 aarray :: [Aeson.Value] -> Aeson.Value
 aarray = Aeson.Array . Vector.fromList
@@ -599,7 +608,7 @@ ce :: DLExpr -> App ()
 ce = \case
   DLE_Arg _ a -> ca a
   DLE_LArg _ a -> cla a
-  DLE_Impossible at msg -> expect_thrown at msg
+  DLE_Impossible at msg -> expect_thrown at $ Err_Impossible msg
   DLE_PrimOp _ p args -> cprim p args
   DLE_ArrayRef at aa ia -> doArrayRef at aa True (Left ia)
   DLE_ArraySet at aa ia va -> do

--- a/hs/src/Reach/Connector/ALGO.hs
+++ b/hs/src/Reach/Connector/ALGO.hs
@@ -32,17 +32,8 @@ import Reach.UnsafeUtil
 import Reach.Util
 import Safe (atMay)
 import Text.Read
-import Generics.Deriving (Generic)
 
 -- General tools that could be elsewhere
-
-data AlgoError
-  = Err_Impossible String
-  deriving (Eq, Generic, ErrorMessageForJson, ErrorSuggestions)
-
-instance Show AlgoError where
-  show = \case
-    Err_Impossible msg -> msg
 
 aarray :: [Aeson.Value] -> Aeson.Value
 aarray = Aeson.Array . Vector.fromList

--- a/hs/src/Reach/Connector/ETH_Solidity.hs
+++ b/hs/src/Reach/Connector/ETH_Solidity.hs
@@ -33,6 +33,16 @@ import System.Exit
 import System.FilePath
 import System.IO.Temp
 import System.Process
+import Generics.Deriving (Generic)
+
+
+data EthError
+  = Err_Impossible String
+  deriving (Eq, Generic, ErrorMessageForJson, ErrorSuggestions)
+
+instance Show EthError where
+  show = \case
+    Err_Impossible msg -> msg
 
 --- Debugging tools
 
@@ -346,7 +356,7 @@ solExpr ctxt sp = \case
   DLE_Arg _ a -> solArg ctxt a <> sp
   DLE_LArg {} ->
     impossible "large arg"
-  DLE_Impossible at msg -> expect_thrown at msg
+  DLE_Impossible at msg -> expect_thrown at $ Err_Impossible msg
   DLE_PrimOp _ p args ->
     (solPrimApply ctxt p $ map (solArg ctxt) args) <> sp
   DLE_ArrayRef _ ae ie ->

--- a/hs/src/Reach/Connector/ETH_Solidity.hs
+++ b/hs/src/Reach/Connector/ETH_Solidity.hs
@@ -33,16 +33,6 @@ import System.Exit
 import System.FilePath
 import System.IO.Temp
 import System.Process
-import Generics.Deriving (Generic)
-
-
-data EthError
-  = Err_Impossible String
-  deriving (Eq, Generic, ErrorMessageForJson, ErrorSuggestions)
-
-instance Show EthError where
-  show = \case
-    Err_Impossible msg -> msg
 
 --- Debugging tools
 

--- a/hs/src/Reach/EPP.hs
+++ b/hs/src/Reach/EPP.hs
@@ -22,7 +22,7 @@ import Reach.Util
 
 data EPPError
   = Err_ContinueDomination
-  deriving (Eq, Generic)
+  deriving (Eq, Generic, ErrorMessageForJson, ErrorSuggestions)
 
 instance Show EPPError where
   show Err_ContinueDomination =

--- a/hs/src/Reach/Eval.hs
+++ b/hs/src/Reach/Eval.hs
@@ -156,8 +156,8 @@ displaySecurityLevel :: SecurityLevel -> String
 displaySecurityLevel Secret = "secret"
 displaySecurityLevel Public = "public"
 
-didYouMeanList :: String -> [String] -> Int -> [String]
-didYouMeanList invalidStr validOptions maxClosest =
+getErrorSuggestions :: String -> [String] -> Int -> [String]
+getErrorSuggestions invalidStr validOptions maxClosest =
   take maxClosest $ sortBy (comparing distance) validOptions
   where
     distance = restrictedDamerauLevenshteinDistance defaultEditCosts invalidStr
@@ -168,7 +168,7 @@ didYouMean invalidStr validOptions maxClosest =
   [] -> ""
   _  -> ". Did you mean: " <> show options
   where
-    options = didYouMeanList invalidStr validOptions maxClosest
+    options = getErrorSuggestions invalidStr validOptions maxClosest
 
 showDiff :: Eq b => a -> a -> (a -> b) -> (b -> b -> String) -> String
 showDiff x y f s =
@@ -233,9 +233,9 @@ instance ErrorMessageForJson EvalError where
 
 instance ErrorSuggestions EvalError where
   errorSuggestions = \case
-    Err_App_InvalidOption opt opts -> didYouMeanList opt opts 5
-    Err_Dot_InvalidField _ ks k -> didYouMeanList k ks 5
-    Err_Eval_UnboundId _ slvar slvars -> didYouMeanList slvar slvars 5
+    Err_App_InvalidOption opt opts -> getErrorSuggestions opt opts 5
+    Err_Dot_InvalidField _ ks k -> getErrorSuggestions k ks 5
+    Err_Eval_UnboundId _ slvar slvars -> getErrorSuggestions slvar slvars 5
     _ -> []
 
 -- TODO more hints on why invalid syntax is invalid

--- a/hs/src/Reach/Parser.hs
+++ b/hs/src/Reach/Parser.hs
@@ -50,7 +50,7 @@ data ParserError
   | Err_Parse_NotModule JSAST
   | Err_Parse_NotCallLike JSExpression
   | Err_Parse_JSIdentNone
-  deriving (Generic, Eq)
+  deriving (Generic, Eq, ErrorMessageForJson, ErrorSuggestions)
 
 --- FIXME implement a custom show that is useful
 instance Show ParserError where

--- a/hs/src/Reach/Type.hs
+++ b/hs/src/Reach/Type.hs
@@ -35,7 +35,7 @@ data TypeError
   | Err_Type_TooFewArguments [SLType]
   | Err_Type_TooManyArguments [SLVal]
   | Err_Type_IntLiteralRange Integer Integer Integer
-  deriving (Eq, Generic)
+  deriving (Eq, Generic, ErrorMessageForJson, ErrorSuggestions)
 
 instance Show TypeError where
   show (Err_Type_None val) =

--- a/hs/src/Reach/UnsafeUtil.hs
+++ b/hs/src/Reach/UnsafeUtil.hs
@@ -3,13 +3,14 @@
 -- For advice on writing unsafe functions, see:
 -- http://hackage.haskell.org/package/base/docs/System-IO-Unsafe.html
 
-module Reach.UnsafeUtil (unsafeRedactAbs, unsafeRedactAbsStr) where
+module Reach.UnsafeUtil (unsafeRedactAbs, unsafeRedactAbsStr, unsafeIsErrorFormatJson) where
 
 import Data.Text (Text)
 import qualified Data.Text as T
 import Reach.Util
 import System.Directory
 import System.IO.Unsafe
+import Reach.CommandLine (getCompilerArgs, CompilerToolArgs(cta_errorFormatJson))
 
 -- | s/${pwd}/./g
 unsafeRedactAbs :: Text -> Text
@@ -20,3 +21,10 @@ unsafeRedactAbs s = unsafePerformIO $ do
 
 unsafeRedactAbsStr :: String -> String
 unsafeRedactAbsStr = T.unpack . unsafeRedactAbs . T.pack
+
+unsafeIsErrorFormatJson :: Bool
+unsafeIsErrorFormatJson = unsafePerformIO $ do
+  args <- getCompilerArgs ""
+  return $ cta_errorFormatJson args
+{-# NOINLINE unsafeIsErrorFormatJson #-}
+


### PR DESCRIPTION
Displaying error messages as JSON simplifies the LSP implementation a great detail.