### PR TITLE
Extend Standard Library

### DIFF
--- a/docs-src/ref-programs.scrbl
+++ b/docs-src/ref-programs.scrbl
@@ -1302,7 +1302,7 @@ except that index @reachin{idx} is replaced with @reachin{val}.
 
 Both may be abbreviated as @reachin{expr.set(idx, val)} where @reachin{expr} evaluates to a tuple or an array.
 
-@subsubsection{Array group operations: @tt{Array.iota}, @tt{Array.concat} & @tt{.concat}, @tt{Array.empty}, @tt{Array.zip} & @tt{.zip}, @tt{Array.map} & @tt{.map}, @tt{Array.reduce} & @tt{.reduce}, @tt{Array.forEach} & @tt{.forEach}, and @tt{Array.replicate} }
+@subsubsection{Array group operations: @tt{Array.iota}, @tt{Array.concat} & @tt{.concat}, @tt{Array.empty}, @tt{Array.zip} & @tt{.zip}, @tt{Array.map} & @tt{.map}, @tt{Array.reduce} & @tt{.reduce}, @tt{Array.forEach} & @tt{.forEach}, @tt{Array.replicate}, @tt{Array.all} & @tt{.all}, @tt{Array.any} & @tt{.any}, @tt{Array.or} & @tt{.or}, @tt{Array.and} & @tt{.and}, @tt{Array.includes} & @tt{.includes}, @tt{Array.indexOf} & @tt{.indexOf}, @tt{Array.findIndex} & @tt{.findIndex}, @tt{Array.count} & @tt{.count}, @tt{Array.min} & @tt{.min}, @tt{Array.max} & @tt{.max}, and @tt{Array.sum} & @tt{.sum} }
 
 @(mint-define! '("iota"))
 @reach{
@@ -1379,6 +1379,91 @@ For example, @reachin{Array.iota(4).reduce(Array.iota(4), 0, (x, y, z) => (z + x
 
 @index{Array.forEach} @reachin{Array.forEach(arr, f)} iterates the function @reachin{f} over the elements of the array @reachin{arr}, discarding the result.
 This may be abbreviated as @reachin{arr.forEach(f)}.
+
+@(mint-define! '("all"))
+@reach{
+  Array.all(arr, f)
+  arr.all(f) }
+
+@index{Array.all} @reachin{Array.all(arr, f)} determines whether the predicate, @tt{f}, is satisfied
+by every element of the array, @tt{arr}.
+
+@(mint-define! '("any"))
+@reach{
+  Array.any(arr, f)
+  arr.any(f) }
+
+@index{Array.any} @reachin{Array.any(arr, f)} determines whether the predicate, @tt{f}, is satisfied
+by at least one element of the array, @tt{arr}.
+
+@(mint-define! '("or"))
+@reach{
+  Array.or(arr)
+  arr.or() }
+
+@index{Array.or} @reachin{Array.or(arr)} returns the disjunction of an array of @reachin{Bool}s.
+
+@(mint-define! '("and"))
+@reach{
+  Array.and(arr)
+  arr.and() }
+
+@index{Array.and} @reachin{Array.and(arr)} returns the conjunction of an array of @reachin{Bool}s.
+
+@(mint-define! '("includes"))
+@reach{
+  Array.includes(arr, x)
+  arr.includes(x) }
+
+@index{Array.includes} @reachin{Array.includes(arr, x)} determines whether the array includes
+the element, @tt{x}.
+
+@(mint-define! '("indexOf"))
+@reach{
+  Array.indexOf(arr, x)
+  arr.indexOf(x) }
+
+@index{Array.indexOf} @reachin{Array.indexOf(arr, x)} returns the index of the first element
+in the given array that is equal to @tt{x}. The return value is of type @reachin{Maybe(UInt)}. If
+the value is not present in the array, @reachin{None} is returned.
+
+@(mint-define! '("findIndex"))
+@reach{
+  Array.findIndex(arr, f)
+  arr.findIndex(f) }
+
+@index{Array.findIndex} @reachin{Array.findIndex(arr, f)} returns the index of the first element
+in the given array that satisfies the predicate @tt{f}. The return value is of type @reachin{Maybe(UInt)}. If
+no value satisfies the prediate in the array, @reachin{None} is returned.
+
+@(mint-define! '("count"))
+@reach{
+  Array.count(arr, f)
+  arr.count(f) }
+
+@index{Array.count} @reachin{Array.count(arr, f)} returns the number of elements that
+satisfy the predicate, @tt{f}, in @tt{arr}.
+
+@(mint-define! '("min"))
+@reach{
+  Array.min(arr)
+  arr.min() }
+
+@index{Array.min} @reachin{Array.min(arr)} returns the lowest number in an array of @tt{UInt}s.
+
+@(mint-define! '("max"))
+@reach{
+  Array.max(arr)
+  arr.max() }
+
+@index{Array.max} @reachin{Array.max(arr)} returns the largest number in an array of @tt{UInt}s.
+
+@(mint-define! '("sum"))
+@reach{
+  Array.sum(arr)
+  arr.sum() }
+
+@index{Array.sum} @reachin{Array.sum(arr)} returns the sum of an array of @tt{UInt}s.
 
 @subsubsection[#:tag "ref-programs-objects"]{Objects}
 
@@ -1658,3 +1743,10 @@ The @deftech{balance} primitive returns the balance of the @tech{contract} @tech
  hasRandom }
 
 @index{hasRandom} A @tech{participant interact interface} which specifies @litchar{random} as a function that takes no arguments and returns an unsigned integer of @tech{bit width} bits.
+
+@(mint-define! '("compose"))
+@reach{
+ compose(f, g) }
+
+@index{compose} Creates a new function that applies it's argument to @tt{g}, then pipes the result to the function @tt{f}.
+The argument type of @tt{f} must be the return type of @tt{g}.

--- a/docs-src/ref-programs.scrbl
+++ b/docs-src/ref-programs.scrbl
@@ -1434,15 +1434,15 @@ the value is not present in the array, @reachin{None} is returned.
 
 @index{Array.findIndex} @reachin{Array.findIndex(arr, f)} returns the index of the first element
 in the given array that satisfies the predicate @tt{f}. The return value is of type @reachin{Maybe(UInt)}. If
-no value satisfies the prediate in the array, @reachin{None} is returned.
+no value in the array satisfies the predicate, @reachin{None} is returned.
 
 @(mint-define! '("count"))
 @reach{
   Array.count(arr, f)
   arr.count(f) }
 
-@index{Array.count} @reachin{Array.count(arr, f)} returns the number of elements that
-satisfy the predicate, @tt{f}, in @tt{arr}.
+@index{Array.count} @reachin{Array.count(arr, f)} returns the number of elements in @tt{arr} that
+satisfy the predicate, @tt{f}.
 
 @(mint-define! '("min"))
 @reach{
@@ -1579,6 +1579,45 @@ As a special case, when the type of a variant is @reachin{Null}, the @reachin{VA
 This means it is a function that returns a @reachin{Data} type specialized to a particular type in the @reachin{Some} variant.
 
 @reachin{Maybe} instances can be conveniently consumed by @reachin{fromMaybe(mValue, onNone, onSome)}, where @reachin{onNone} is a function of no arguments which is called when @reachin{mValue} is @reachin{None}, @reachin{onSome} is a function of on argument which is called with the value when @reachin{mValue} is @reachin{Some}, and @reachin{mValue} is a @tech{data instance} of @reachin{Maybe}.
+
+@subsubsection{@tt{Either}}
+
+@reachin{Either} is defined by
+@reach{
+  export const Either = (A, B) => Data({Left: A, Right: B}); }
+
+@reachin{Either} can be used to represent values with two possible types.
+
+Similar to @tt{Maybe}, @tt{Either} may be used to represent values that are correct or erroneous.
+A successful result is stored, by convention, in @tt{Right}. Unlike @tt{None}, @tt{Left} may
+carry additional information about the error.
+
+@(mint-define! '("either"))
+@reach{
+  either(e, onLeft, onRight) }
+
+@index{either} @reachin{either(e, onLeft, onRight)} For an @tt{Either} value, @tt{e}, @tt{either}
+will either apply the function @tt{onLeft} or @tt{onRight} to the appropriate variant value.
+
+@(mint-define! '("isLeft") '("isRight") '("fromLeft") '("fromRight"))
+@reach{
+  const e = Either(UInt, Bool);
+  const l = e.Left(1);
+  const r = e.Right(true);
+  isLeft(l);  // true
+  isRight(l); // false
+  const x = fromLeft(l, 0);      // x = 1
+  const y = fromRight(l, false); // y = false }
+
+@index{isLeft} @reachin{isLeft} is a convenience method that determines whether the variant is @tt{Left}.
+
+@index{isRight} @reachin{isRight} is a convenience method that determines whether the variant is @tt{Right}.
+
+@index{fromLeft} @reachin{fromLeft(e, default)} is a convenience method that returns the value in @tt{Left},
+or @tt{default} if the variant is @tt{Right}.
+
+@index{fromRight} @reachin{fromRight(e, default)} is a convenience method that returns the value in @tt{Right},
+or @tt{default} if the variant is @tt{Left}.
 
 @subsubsection{@tt{match}}
 

--- a/hs/rsh/stdlib.rsh
+++ b/hs/rsh/stdlib.rsh
@@ -64,6 +64,32 @@ export function closeTo(Who, after) {
 
 export const fail = () => assume(false);
 
+export const Either = (A, B) => Data({
+  Left: A,
+  Right: B });
+
+export const either = (e, l, r) =>
+  e.match({
+    Left: lv => { return l(lv); },
+    Right: rv => { return r(rv); }
+  });
+
+export const isLeft = e => e.match({
+  Left: (_) => { return true; },
+  Right: (_) => { return false; } });
+
+export const isRight = e => e.match({
+  Left: (_) => { return false; },
+  Right: (_) => { return true; } });
+
+export const fromLeft = (e, d) => e.match({
+  Left: (v) => { return v; },
+  Right: (_) => { return d; } });
+
+export const fromRight = (e, d) => e.match({
+  Left: (_) => { return d; },
+  Right: (v) => { return v; } });
+
 // Standard library functions that should be hidden in some way, like
 // SLV_HaskellFunction FIXME
 
@@ -79,3 +105,76 @@ export const Array_forEach =
   (arr, f) => arr.reduce(null, (acc, xe) => f(xe));
 export const Array_forEach1 =
   (arr) => (f) => Array_forEach(arr, f);
+
+export const Array_min =
+  (arr) => arr.reduce(UInt.max, (acc, x) => (x < acc) ? x : acc);
+export const Array_min1 = (arr) => () => Array_min(arr);
+
+export const Array_max =
+  (arr) => arr.reduce(0, (acc, x) => (x > acc) ? x : acc);
+export const Array_max1 = (arr) => () => Array_max(arr);
+
+export const Array_any =
+  (arr, f) => arr.reduce(false, (acc, x) =>
+    acc ? acc : f(x));
+export const Array_any1 = (arr) => (f) => Array_any(arr, f);
+
+export const Array_all =
+  (arr, f) => arr.reduce(true, (acc, x) =>
+    acc ? f(x) : false);
+export const Array_all1 = (arr) => (f) => Array_all(arr, f);
+
+export const Array_or =
+  (arr) => Array_any(arr, x => x);
+export const Array_or1 = (arr) => () => Array_or(arr);
+
+export const Array_and =
+  (arr) => Array_all(arr, x => x);
+export const Array_and1 = (arr) => () => Array_and(arr);
+
+export const Array_sum =
+  (arr) => arr.reduce(0, (acc, x) => acc + x);
+export const Array_sum1 = (arr) => () => Array_sum(arr);
+
+export const Array_includes =
+  (arr, x) => arr.reduce(false, (acc, e) =>
+    acc ? acc : (x == e) ? true : false);
+export const Array_includes1 =
+  (arr) => (x) => Array_includes(arr, x);
+
+export const Array_indexOfAux =
+  (arr, f) => {
+    const init = [Maybe(UInt).None(), 0];
+    const [res, _] =
+      arr.reduce(init, (acc, e) => {
+        const [foundIdx, idx] = acc;
+        return foundIdx.match({
+          Some: (_) => { return acc; },
+          None: () => {
+            return f(e)
+              ? [Maybe(UInt).Some(idx), idx]
+              : [foundIdx, idx + 1]; }
+        });
+      });
+    return res;
+  };
+export const Array_indexOf =
+  (arr, x) => Array_indexOfAux(arr, (el) => { return el == x; });
+export const Array_indexOf1 =
+  (arr) => (x) => Array_indexOf(arr, x);
+
+export const Array_findIndex =
+  (arr, f) => Array_indexOfAux(arr, f);
+export const Array_findIndex1 =
+  (arr) => (f) => Array_findIndex(arr, f);
+
+export const Array_count =
+  (arr, f) => arr.reduce(0, (acc, x) =>
+    f(x) ? acc + 1 : acc);
+export const Array_count1 =
+  (arr) => (f) => Array_count(arr, f);
+
+export const compose =
+  (f, g) => (v) => f(g(v));
+
+

--- a/hs/src/Reach/Optimize.hs
+++ b/hs/src/Reach/Optimize.hs
@@ -177,7 +177,7 @@ opt_m mkk opt_k = \case
   LL_LocalIf at c t f k ->
     mkk <$> (LL_LocalIf at <$> opt_a c <*> (newScope $ opt_l t) <*> (newScope $ opt_l f) <*> opt_k k)
   LL_LocalSwitch at ov csm k ->
-    mkk <$> (LL_LocalSwitch at ov <$> mapM cm1 csm <*> opt_k k)
+    mkk <$> (LL_LocalSwitch at <$> opt_v ov <*> mapM cm1 csm <*> opt_k k)
     where
       cm1 (mov', l) = (,) <$> pure mov' <*> (newScope $ opt_l l)
   LL_ArrayMap at ans x0 a f k -> do
@@ -199,7 +199,7 @@ opt_n = \case
   LLC_If at c t f ->
     LLC_If at <$> opt_a c <*> (newScope $ opt_n t) <*> (newScope $ opt_n f)
   LLC_Switch at ov csm ->
-    LLC_Switch at ov <$> mapM cm1 csm
+    LLC_Switch at <$> opt_v ov <*> mapM cm1 csm
     where
       cm1 (mov', n) = (,) <$> pure mov' <*> (newScope $ opt_n n)
   LLC_While at asn inv cond body k ->

--- a/hs/test-examples/features/array_stdlib.rsh
+++ b/hs/test-examples/features/array_stdlib.rsh
@@ -1,0 +1,23 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {}]],
+    (A) => {
+      A.only(() => {
+        const a = Array.iota(5);
+        assert(a.sum() == 10);
+        assert(a.min() == 0);
+        assert(a.max() == 4);
+        assert(a.count(x => x < 3) == 3);
+        assert(Array.any(a, x => x < 2));
+        assert(!Array.all(a, x => x < 2));
+        assert(a.findIndex(x => x == 2) == Maybe(UInt).Some(2));
+        assert(a.indexOf(15) == Maybe(UInt).None());
+        assert(Array.and(array(Bool, [true, true])));
+        assert(Array.or(array(Bool, [true, false])));
+        assert(a.includes(2));
+        assert(!a.includes(322));
+      });
+    });

--- a/hs/test-examples/features/array_stdlib.txt
+++ b/hs/test-examples/features/array_stdlib.txt
@@ -1,0 +1,6 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying with mode = VM_Honest
+  Verifying with mode = VM_Dishonest RoleContract
+  Verifying with mode = VM_Dishonest (RolePart "A")
+Checked 27 theorems; No failures!

--- a/hs/test-examples/features/either_stdlib.rsh
+++ b/hs/test-examples/features/either_stdlib.rsh
@@ -1,0 +1,27 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [['A', {
+      showBool: Fun([Bool], Null),
+      showInt: Fun([UInt], Null),
+    }]],
+    (A) => {
+      const e = Either(UInt, Bool);
+      A.only(() => {
+        const l = e.Left(5);
+        const r = e.Right(false);
+        either(l, interact.showInt, interact.showBool);
+        either(r, interact.showInt, interact.showBool);
+        assert(isLeft(l));
+        assert(!isLeft(r));
+        assert(isRight(r));
+        assert(!isRight(l));
+        assert(fromLeft(l, 0) == 5);
+        assert(fromLeft(r, 0) == 0);
+        assert(fromRight(r, true) == false);
+        assert(fromRight(l, true));
+      });
+    });
+

--- a/hs/test-examples/features/either_stdlib.txt
+++ b/hs/test-examples/features/either_stdlib.txt
@@ -1,0 +1,6 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying with mode = VM_Honest
+  Verifying with mode = VM_Dishonest RoleContract
+  Verifying with mode = VM_Dishonest (RolePart "A")
+Checked 19 theorems; No failures!


### PR DESCRIPTION
* Add an `Either` data type and some functions to the standard library. 
    * Either
      * either
      * isLeft
      * isRight
      * fromLeft
      * fromRight
    * Array
      * min
      * max
      * all
      * any
      * or
      * and
      * sum
      * includes
      * indexOf
      * findIndex
      * count
    * compose (function composition)
* Update `evalAsEnv` to handle `Array/Data/Tuple` that come from the interaction interface. 
* Fix an issue with the optimizer where it wasn't optimizing the variable that `switch` destructures.

I had some difficulty finding things that were useful to the language as it is, so if I missed anything let me know.