### PR TITLE
sltype, typechecks and is maybe not wrong anymore

### DIFF
--- a/examples/tut-4-attack/index-bad.txt
+++ b/examples/tut-4-attack/index-bad.txt
@@ -20,7 +20,7 @@ Verification failed:
   //    ^ would be [0, 1]
   assert(0 == (((interact_Alice_wager + interact_Alice_wager) - (v51[0] * interact_Alice_wager)) - (v51[1] * interact_Alice_wager)));
 
-Verifying with mode = VM_Dishonest RoleContract
+  Verifying with mode = VM_Dishonest RoleContract
 Verification failed:
   in VM_Dishonest RoleContract mode
   of theorem TClaim CT_Assert

--- a/examples/tut-4-attack/index-bad.txt
+++ b/examples/tut-4-attack/index-bad.txt
@@ -20,7 +20,7 @@ Verification failed:
   //    ^ would be [0, 1]
   assert(0 == (((interact_Alice_wager + interact_Alice_wager) - (v51[0] * interact_Alice_wager)) - (v51[1] * interact_Alice_wager)));
 
-  Verifying with mode = VM_Dishonest RoleContract
+Verifying with mode = VM_Dishonest RoleContract
 Verification failed:
   in VM_Dishonest RoleContract mode
   of theorem TClaim CT_Assert

--- a/hs/src/Reach/AST/DLBase.hs
+++ b/hs/src/Reach/AST/DLBase.hs
@@ -14,8 +14,31 @@ data DeployMode
   | DM_firstMsg
   deriving (Eq, Generic, NFData, Show)
 
+-- DL types only describe data, and explicitly do not describe functions
+data DLType
+  = T_Null
+  | T_Bool
+  | T_UInt
+  | T_Bytes Integer
+  | T_Digest
+  | T_Address
+  | T_Array DLType Integer
+  | T_Tuple [DLType]
+  | T_Object (M.Map SLVar DLType)
+  | T_Data (M.Map SLVar DLType)
+  deriving (Eq, Generic, NFData, Ord)
+
+instance Show DLType where
+  show = show . dt2st
+
+-- Interact types can only be value types or first-order functions
+data IType
+  = IT_Val DLType
+  | IT_Fun [DLType] DLType
+  deriving (Eq, Generic, NFData, Show)
+
 newtype InteractEnv
-  = InteractEnv (M.Map SLVar SLType)
+  = InteractEnv (M.Map SLVar IType)
   deriving (Eq, Generic, Show)
   deriving newtype (Monoid, NFData, Semigroup)
 
@@ -44,6 +67,45 @@ data DLVar = DLVar SrcLoc String DLType Int
 
 instance Eq DLVar where
   (DLVar _ _ _ x) == (DLVar _ _ _ y) = x == y
+
+-- XXX better error message for stuff like Array<Fun> or Array<Forall>
+-- that can't exist in DL-land
+st2dt :: SLType -> DLType
+st2dt = \case
+  ST_Null -> T_Null
+  ST_Bool -> T_Bool
+  ST_UInt -> T_UInt
+  ST_Bytes i -> T_Bytes i
+  ST_Digest -> T_Digest
+  ST_Address -> T_Address
+  ST_Array ty i -> T_Array (st2dt ty) i
+  ST_Tuple tys -> T_Tuple (map st2dt tys)
+  ST_Object tyMap -> T_Object (M.map st2dt tyMap)
+  ST_Data tyMap -> T_Data (M.map st2dt tyMap)
+  -- XXX consider using Maybe so that callers have to handle the error case
+  ST_Fun {} -> error "ST_Fun not a dt"
+  ST_Forall {} -> error "ST_Forall not a dt"
+  ST_Var {} -> error "ST_Var not a dt"
+  ST_Type {} -> error "ST_Type not a dt"
+
+dt2st :: DLType -> SLType
+dt2st = \case
+  T_Null -> ST_Null
+  T_Bool -> ST_Bool
+  T_UInt -> ST_UInt
+  T_Bytes i -> ST_Bytes i
+  T_Digest -> ST_Digest
+  T_Address -> ST_Address
+  T_Array ty i -> ST_Array (dt2st ty) i
+  T_Tuple tys -> ST_Tuple (map dt2st tys)
+  T_Object tyMap -> ST_Object (M.map dt2st tyMap)
+  T_Data tyMap -> ST_Data (M.map dt2st tyMap)
+
+-- XXX improve error messages
+st2it :: SLType -> IType
+st2it t = case t of
+  ST_Fun dom rng -> IT_Fun (map st2dt dom) (st2dt rng)
+  _ -> IT_Val (st2dt t)
 
 dvdelete :: DLVar -> [DLVar] -> [DLVar]
 dvdelete x = filter (x /=)
@@ -217,3 +279,18 @@ data DLinTail a
 data DLinBlock a
   = DLinBlock SrcLoc [SLCtxtFrame] (DLinTail a) DLArg
   deriving (Eq, Show)
+
+data FluidVar
+  = FV_balance
+  | FV_thisConsensusTime
+  | FV_lastConsensusTime
+  deriving (Eq, Generic, NFData, Ord, Show, Bounded, Enum)
+
+fluidVarType :: FluidVar -> DLType
+fluidVarType = \case
+  FV_balance -> T_UInt
+  FV_thisConsensusTime -> T_UInt
+  FV_lastConsensusTime -> T_UInt
+
+allFluidVars :: [FluidVar]
+allFluidVars = enumFrom minBound

--- a/hs/src/Reach/AST/DLBase.hs
+++ b/hs/src/Reach/AST/DLBase.hs
@@ -15,7 +15,7 @@ data DeployMode
   deriving (Eq, Generic, NFData, Show)
 
 newtype InteractEnv
-  = InteractEnv (M.Map SLVar DLType)
+  = InteractEnv (M.Map SLVar SLType)
   deriving (Eq, Generic, Show)
   deriving newtype (Monoid, NFData, Semigroup)
 

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -17,8 +17,8 @@ import Reach.Util
 
 infixr 9 -->
 
-(-->) :: [DLType] -> DLType -> DLType
-dom --> rng = T_Fun dom rng
+(-->) :: [SLType] -> SLType -> SLType
+dom --> rng = ST_Fun dom rng
 
 type SLPartEnvs = M.Map SLPart SLEnv
 
@@ -31,14 +31,14 @@ data SLVal
   | SLV_Bool SrcLoc Bool
   | SLV_Int SrcLoc Integer
   | SLV_Bytes SrcLoc B.ByteString
-  | SLV_Array SrcLoc DLType [SLVal]
+  | SLV_Array SrcLoc SLType [SLVal]
   | SLV_Tuple SrcLoc [SLVal]
   | SLV_Object SrcLoc (Maybe String) SLEnv
   | SLV_Clo SrcLoc (Maybe SLVar) [JSExpression] JSBlock SLCloEnv
-  | SLV_Data SrcLoc (M.Map SLVar DLType) SLVar SLVal
+  | SLV_Data SrcLoc (M.Map SLVar SLType) SLVar SLVal
   | SLV_DLC DLConstant
   | SLV_DLVar DLVar
-  | SLV_Type DLType
+  | SLV_Type SLType
   | SLV_Connector T.Text
   | -- I really want to remove these two Maybes, but it is hard.
     -- The DLVar is needed so that inside of an `only`, we can read off the
@@ -174,26 +174,26 @@ instance Show SLKwd where
 allKeywords :: [SLKwd]
 allKeywords = enumFrom minBound
 
-primOpType :: PrimOp -> DLType
+primOpType :: PrimOp -> SLType
 primOpType SELF_ADDRESS = impossible "self address"
-primOpType ADD = [T_UInt, T_UInt] --> T_UInt
-primOpType SUB = [T_UInt, T_UInt] --> T_UInt
-primOpType MUL = [T_UInt, T_UInt] --> T_UInt
-primOpType DIV = [T_UInt, T_UInt] --> T_UInt
-primOpType MOD = [T_UInt, T_UInt] --> T_UInt
-primOpType PLT = [T_UInt, T_UInt] --> T_Bool
-primOpType PLE = [T_UInt, T_UInt] --> T_Bool
-primOpType PEQ = T_Forall "a" ([T_Var "a", T_Var "a"] --> T_Bool)
-primOpType PGE = [T_UInt, T_UInt] --> T_Bool
-primOpType PGT = [T_UInt, T_UInt] --> T_Bool
-primOpType IF_THEN_ELSE = T_Forall "b" (T_Forall "a" ([T_Var "b", T_Var "a", T_Var "a"] --> T_Var "a"))
-primOpType DIGEST_EQ = ([T_Digest, T_Digest] --> T_Bool)
-primOpType ADDRESS_EQ = ([T_Address, T_Address] --> T_Bool)
-primOpType LSH = [T_UInt, T_UInt] --> T_UInt
-primOpType RSH = [T_UInt, T_UInt] --> T_UInt
-primOpType BAND = [T_UInt, T_UInt] --> T_UInt
-primOpType BIOR = [T_UInt, T_UInt] --> T_UInt
-primOpType BXOR = [T_UInt, T_UInt] --> T_UInt
+primOpType ADD = [ST_UInt, ST_UInt] --> ST_UInt
+primOpType SUB = [ST_UInt, ST_UInt] --> ST_UInt
+primOpType MUL = [ST_UInt, ST_UInt] --> ST_UInt
+primOpType DIV = [ST_UInt, ST_UInt] --> ST_UInt
+primOpType MOD = [ST_UInt, ST_UInt] --> ST_UInt
+primOpType PLT = [ST_UInt, ST_UInt] --> ST_Bool
+primOpType PLE = [ST_UInt, ST_UInt] --> ST_Bool
+primOpType PEQ = ST_Forall "a" ([ST_Var "a", ST_Var "a"] --> ST_Bool)
+primOpType PGE = [ST_UInt, ST_UInt] --> ST_Bool
+primOpType PGT = [ST_UInt, ST_UInt] --> ST_Bool
+primOpType IF_THEN_ELSE = ST_Forall "b" (ST_Forall "a" ([ST_Var "b", ST_Var "a", ST_Var "a"] --> ST_Var "a"))
+primOpType DIGEST_EQ = ([ST_Digest, ST_Digest] --> ST_Bool)
+primOpType ADDRESS_EQ = ([ST_Address, ST_Address] --> ST_Bool)
+primOpType LSH = [ST_UInt, ST_UInt] --> ST_UInt
+primOpType RSH = [ST_UInt, ST_UInt] --> ST_UInt
+primOpType BAND = [ST_UInt, ST_UInt] --> ST_UInt
+primOpType BIOR = [ST_UInt, ST_UInt] --> ST_UInt
+primOpType BXOR = [ST_UInt, ST_UInt] --> ST_UInt
 
 data SLPrimitive
   = SLPrim_makeEnum
@@ -202,14 +202,14 @@ data SLPrimitive
   | SLPrim_commit
   | SLPrim_committed
   | SLPrim_claim ClaimType
-  | SLPrim_interact SrcLoc SLPart String DLType
+  | SLPrim_interact SrcLoc SLPart String SLType
   | SLPrim_is_type
   | SLPrim_type_eq
   | SLPrim_typeOf
   | SLPrim_Fun
   | SLPrim_Bytes
   | SLPrim_Data
-  | SLPrim_Data_variant (M.Map SLVar DLType) SLVar DLType
+  | SLPrim_Data_variant (M.Map SLVar SLType) SLVar SLType
   | SLPrim_data_match
   | SLPrim_Array
   | SLPrim_Array_iota

--- a/hs/src/Reach/Backend/JS.hs
+++ b/hs/src/Reach/Backend/JS.hs
@@ -93,14 +93,10 @@ jsContract = \case
   T_Bytes sz -> jsApply "stdlib.T_Bytes" [jsCon $ DLL_Int sb sz]
   T_Digest -> "stdlib.T_Digest"
   T_Address -> "stdlib.T_Address"
-  T_Fun {} -> impossible "fun dl"
   T_Array t sz -> jsApply ("stdlib.T_Array") $ [jsContract t, jsCon (DLL_Int sb sz)]
   T_Tuple as -> jsApply ("stdlib.T_Tuple") $ [jsArray $ map jsContract as]
   T_Object m -> jsApply ("stdlib.T_Object") [jsObject $ M.map jsContract m]
   T_Data m -> jsApply ("stdlib.T_Data") [jsObject $ M.map jsContract m]
-  T_Forall {} -> impossible "forall dl"
-  T_Var {} -> impossible "var dl"
-  T_Type {} -> impossible "type dl"
 
 jsProtect :: Doc -> DLType -> Doc -> Doc
 jsProtect ai how what =

--- a/hs/src/Reach/CollectTypes.hs
+++ b/hs/src/Reach/CollectTypes.hs
@@ -49,14 +49,31 @@ instance CollectsTypes DLType where
         T_Bytes _ -> mempty
         T_Digest -> mempty
         T_Address -> mempty
-        T_Fun dom rng -> cts dom <> cts rng
         T_Array e _ -> cts e
         T_Tuple elems -> cts elems
         T_Object m -> cts m
         T_Data m -> cts m
-        T_Forall _ t' -> cts t'
-        T_Var _ -> mempty
-        T_Type _ -> mempty
+
+instance CollectsTypes SLType where
+  cts t =
+    S.singleton (st2dt t)
+      <> case t of
+        ST_Null -> mempty
+        ST_Bool -> mempty
+        ST_UInt -> mempty
+        ST_Bytes _ -> mempty
+        ST_Digest -> mempty
+        ST_Address -> mempty
+        ST_Array e _ -> cts e
+        ST_Tuple elems -> cts elems
+        ST_Object m -> cts m
+        ST_Data m -> cts m
+        -- XXX st2dt above will explode before it hits any of these cases
+        -- Is there a better way to handle them so that it doesn't explode?
+        ST_Fun dom rng -> cts dom <> cts rng
+        ST_Forall _ t' -> cts t'
+        ST_Var _ -> mempty
+        ST_Type _ -> mempty
 
 instance CollectsTypes InteractEnv where
   cts (InteractEnv m) = cts m

--- a/hs/src/Reach/CollectTypes.hs
+++ b/hs/src/Reach/CollectTypes.hs
@@ -2,7 +2,6 @@ module Reach.CollectTypes (cts) where
 
 import qualified Data.Map as M
 import qualified Data.Set as S
-import Reach.AST.Base
 import Reach.AST.DLBase
 import Reach.AST.LL
 import Reach.AST.PL
@@ -54,26 +53,9 @@ instance CollectsTypes DLType where
         T_Object m -> cts m
         T_Data m -> cts m
 
-instance CollectsTypes SLType where
-  cts t =
-    S.singleton (st2dt t)
-      <> case t of
-        ST_Null -> mempty
-        ST_Bool -> mempty
-        ST_UInt -> mempty
-        ST_Bytes _ -> mempty
-        ST_Digest -> mempty
-        ST_Address -> mempty
-        ST_Array e _ -> cts e
-        ST_Tuple elems -> cts elems
-        ST_Object m -> cts m
-        ST_Data m -> cts m
-        -- XXX st2dt above will explode before it hits any of these cases
-        -- Is there a better way to handle them so that it doesn't explode?
-        ST_Fun dom rng -> cts dom <> cts rng
-        ST_Forall _ t' -> cts t'
-        ST_Var _ -> mempty
-        ST_Type _ -> mempty
+instance CollectsTypes IType where
+  cts (IT_Fun dom rng) = cts dom <> cts rng
+  cts (IT_Val v) = cts v
 
 instance CollectsTypes InteractEnv where
   cts (InteractEnv m) = cts m

--- a/hs/src/Reach/Connector/ALGO.hs
+++ b/hs/src/Reach/Connector/ALGO.hs
@@ -75,14 +75,10 @@ typeSizeOf = \case
   T_Bytes sz -> sz
   T_Digest -> 32
   T_Address -> 32
-  T_Fun {} -> impossible $ "T_Fun"
   T_Array t sz -> sz * typeSizeOf t
   T_Tuple ts -> sum $ map typeSizeOf ts
   T_Object m -> sum $ map typeSizeOf $ M.elems m
   T_Data m -> 1 + (maximum $ map typeSizeOf $ M.elems m)
-  T_Forall {} -> impossible $ "T_Forall"
-  T_Var {} -> impossible $ "T_Var"
-  T_Type {} -> impossible $ "T_Type"
   where
     word = 8
 
@@ -330,14 +326,10 @@ ctobs = \case
   T_Bytes _ -> nop
   T_Digest -> nop
   T_Address -> nop
-  T_Fun {} -> impossible "fun"
   T_Array {} -> nop
   T_Tuple {} -> nop
   T_Object {} -> nop
   T_Data {} -> nop
-  T_Forall {} -> impossible "forall"
-  T_Var {} -> impossible "var"
-  T_Type {} -> impossible "type"
 
 cfrombs :: DLType -> App ()
 cfrombs = \case
@@ -347,14 +339,10 @@ cfrombs = \case
   T_Bytes _ -> nop
   T_Digest -> nop
   T_Address -> nop
-  T_Fun {} -> impossible "fun"
   T_Array {} -> nop
   T_Tuple {} -> nop
   T_Object {} -> nop
   T_Data {} -> nop
-  T_Forall {} -> impossible "forall"
-  T_Var {} -> impossible "var"
-  T_Type {} -> impossible "type"
 
 tint :: SrcLoc -> Integer -> LT.Text
 tint at i = texty $ checkIntLiteralC at connect_algo i

--- a/hs/src/Reach/Connector/ETH_Solidity.hs
+++ b/hs/src/Reach/Connector/ETH_Solidity.hs
@@ -235,14 +235,10 @@ mustBeMem = \case
   T_Bytes _ -> True
   T_Digest -> False
   T_Address -> False
-  T_Fun {} -> impossible "fun"
   T_Array {} -> True
   T_Tuple {} -> True
   T_Object {} -> True
   T_Data {} -> True
-  T_Forall {} -> impossible "forall"
-  T_Var {} -> impossible "var"
-  T_Type {} -> impossible "type"
 
 data ArgMode
   = AM_Call
@@ -760,9 +756,6 @@ _solDefineType1 getTypeName i name = \case
   T_Bytes _ -> base
   T_Digest -> base
   T_Address -> base
-  T_Fun {} -> impossible "fun in ct"
-  T_Forall {} -> impossible "forall in pl"
-  T_Var {} -> impossible "var in pl"
   T_Array t sz -> do
     tn <- getTypeName t
     let me = tn <> brackets (pretty sz)
@@ -799,7 +792,6 @@ _solDefineType1 getTypeName i name = \case
     let enump = solEnum enumn $ map (pretty . fst) $ M.toAscList tmn
     let structp = solStruct name $ ("which", enumn) : map (\(k, t) -> (pretty ("_" <> k), t)) (M.toAscList tmn)
     return $ (name, vsep [enump, structp])
-  T_Type {} -> impossible "type in pl"
   where
     base = impossible "base"
 

--- a/hs/src/Reach/Eval.hs
+++ b/hs/src/Reach/Eval.hs
@@ -680,7 +680,7 @@ typeMeet_ctxt ctxt = typeMeet (mcfs ctxt)
 typeMeets_ctxt :: HasCallStack => SLCtxt s -> SrcLoc -> [(SrcLoc, DLType)] -> DLType
 typeMeets_ctxt ctxt = typeMeets (mcfs ctxt)
 
-checkAndConvert_ctxt :: SLCtxt s -> SLState -> SrcLoc -> SLType -> [SLVal] -> (DLType, [DLArgExpr])
+checkAndConvert_ctxt :: HasCallStack => SLCtxt s -> SLState -> SrcLoc -> SLType -> [SLVal] -> (DLType, [DLArgExpr])
 checkAndConvert_ctxt ctxt st = checkAndConvert (tint ctxt st)
 
 ctxt_alloc :: SLCtxt s -> ST s Int
@@ -740,7 +740,7 @@ slvParticipant_part ctxt at = \case
   SLV_Participant _ x _ _ -> x
   x -> expect_throw_ctx ctxt at $ Err_NotParticipant x
 
-compileCheckAndConvert :: SLCtxt s -> SLState -> SrcLoc -> SLType -> [SLVal] -> ST s (DLStmts, DLType, [DLArg])
+compileCheckAndConvert :: HasCallStack => SLCtxt s -> SLState -> SrcLoc -> SLType -> [SLVal] -> ST s (DLStmts, DLType, [DLArg])
 compileCheckAndConvert ctxt st at t argvs = do
   let (res, arges) = checkAndConvert_ctxt ctxt st at t argvs
   (lifts, args) <- compileArgExprs ctxt at arges
@@ -1417,7 +1417,8 @@ evalForm ctxt at sco st f args =
         _ -> expect_throw_ctx ctxt at $ Err_ToConsensus_TimeoutArgs args
 
 evalPrimOp :: SLCtxt s -> SrcLoc -> SLScope -> SLState -> PrimOp -> [SLSVal] -> SLComp s SLSVal
-evalPrimOp ctxt at _sco st p sargs =
+evalPrimOp ctxt at _sco st p sargs = do
+  -- traceM $ "XXX " <> show at <> " XXX " <> show p
   case p of
     ADD -> nn2n (+)
     SUB -> nn2n (-)

--- a/hs/src/Reach/Eval.hs
+++ b/hs/src/Reach/Eval.hs
@@ -3955,7 +3955,7 @@ compileDApp idxr liblifts cns (SLV_Prim (SLPrim_App_Delay at opts parts top_form
           iom = case io of
             SLV_Object _ _ m -> m
             _ -> impossible $ "make_sps_entry io"
-          getType (SLSSVal _ _ (SLV_Prim (SLPrim_interact _ _ _ t))) = t
+          getType (SLSSVal _ _ (SLV_Prim (SLPrim_interact _ _ _ t))) = st2it t
           getType x = impossible $ "make_sps_entry getType " ++ show x
   let sps = SLParts $ M.fromList $ map make_sps_entry part_ios
   let dli = DLInit ctimem

--- a/hs/src/Reach/Pretty.hs
+++ b/hs/src/Reach/Pretty.hs
@@ -36,6 +36,9 @@ instance Pretty SLPart where
 instance Pretty DLType where
   pretty = viaShow
 
+instance Pretty IType where
+  pretty = viaShow
+
 instance Pretty SLType where
   pretty = viaShow
 

--- a/hs/src/Reach/Pretty.hs
+++ b/hs/src/Reach/Pretty.hs
@@ -36,6 +36,9 @@ instance Pretty SLPart where
 instance Pretty DLType where
   pretty = viaShow
 
+instance Pretty SLType where
+  pretty = viaShow
+
 instance Pretty SecurityLevel where
   pretty = \case
     Public -> "public"

--- a/hs/src/Reach/Verify/SMT.hs
+++ b/hs/src/Reach/Verify/SMT.hs
@@ -1072,10 +1072,10 @@ _smtDefineTypes smt ts = do
           T_Bytes {} -> base
           T_Digest -> base
           T_Address -> base
-          T_Fun {} -> return none
-          T_Forall {} -> impossible "forall in ll"
-          T_Var {} -> impossible "var in ll"
-          T_Type {} -> impossible "type in ll"
+          -- T_Fun {} -> return none
+          -- T_Forall {} -> impossible "forall in ll"
+          -- T_Var {} -> impossible "var in ll"
+          -- T_Type {} -> impossible "type in ll"
           T_Array et sz -> do
             tni <- type_name et
             let tn = fst tni
@@ -1206,12 +1206,12 @@ _verify_smt mc vst smt lp = do
   -- something reasonable, like 64-bit?
   let defineIE who (v, it) =
         case it of
-          T_Fun {} -> mempty
+          -- ST_Fun {} -> mempty
           _ ->
             pathAddUnbound_v ctxt Nothing at (smtInteract ctxt who v) it O_Interact
   let definePIE (who, InteractEnv iem) = do
         pathAddUnbound_v ctxt Nothing at (smtAddress who) T_Address O_BuiltIn
-        mapM_ (defineIE who) $ M.toList iem
+        mapM_ (defineIE who) $ M.toList $ M.map st2dt iem
   mapM_ definePIE $ M.toList pies_m
   let smt_s_top mode = do
         putStrLn $ "  Verifying with mode = " ++ show mode

--- a/hs/src/Reach/Verify/SMT.hs
+++ b/hs/src/Reach/Verify/SMT.hs
@@ -1206,12 +1206,12 @@ _verify_smt mc vst smt lp = do
   -- something reasonable, like 64-bit?
   let defineIE who (v, it) =
         case it of
-          -- ST_Fun {} -> mempty
-          _ ->
-            pathAddUnbound_v ctxt Nothing at (smtInteract ctxt who v) it O_Interact
+          IT_Fun {} -> mempty
+          IT_Val itv ->
+            pathAddUnbound_v ctxt Nothing at (smtInteract ctxt who v) itv O_Interact
   let definePIE (who, InteractEnv iem) = do
         pathAddUnbound_v ctxt Nothing at (smtAddress who) T_Address O_BuiltIn
-        mapM_ (defineIE who) $ M.toList $ M.map st2dt iem
+        mapM_ (defineIE who) $ M.toList iem
   mapM_ definePIE $ M.toList pies_m
   let smt_s_top mode = do
         putStrLn $ "  Verifying with mode = " ++ show mode

--- a/hs/test/Reach/Test_AST.hs
+++ b/hs/test/Reach/Test_AST.hs
@@ -8,27 +8,27 @@ import Test.Hspec
 spec_isFirstOrder :: Spec
 spec_isFirstOrder = describe "isFirstOrder" $ do
   it "returns True when obvs" $ do
-    isFirstOrder T_UInt `shouldBe` True
-    isFirstOrder ([] --> T_Null) `shouldBe` True
-    isFirstOrder (T_Array T_Bool 3) `shouldBe` True
-    isFirstOrder (T_Tuple [T_Address]) `shouldBe` True
-    isFirstOrder (T_Object (M.fromList [("x", T_Bytes 16)]))
+    isFirstOrder ST_UInt `shouldBe` True
+    isFirstOrder ([] --> ST_Null) `shouldBe` True
+    isFirstOrder (ST_Array ST_Bool 3) `shouldBe` True
+    isFirstOrder (ST_Tuple [ST_Address]) `shouldBe` True
+    isFirstOrder (ST_Object (M.fromList [("x", ST_Bytes 16)]))
       `shouldBe` True
-    isFirstOrder (T_Forall "a" $ T_Var "a")
+    isFirstOrder (ST_Forall "a" $ ST_Var "a")
       `shouldBe` True
 
   it "returns False when obvs" $ do
-    isFirstOrder ([[] --> T_Null] --> T_Null)
+    isFirstOrder ([[] --> ST_Null] --> ST_Null)
       `shouldBe` False
-    isFirstOrder ([] --> [] --> T_Null)
+    isFirstOrder ([] --> [] --> ST_Null)
       `shouldBe` False
 
   it "returns True when less obvs" $ do
-    isFirstOrder (T_Object (M.fromList [("f", [] --> T_Null)]))
+    isFirstOrder (ST_Object (M.fromList [("f", [] --> ST_Null)]))
       `shouldBe` True
-    isFirstOrder (T_Forall "a" $ [] --> T_Var "a")
+    isFirstOrder (ST_Forall "a" $ [] --> ST_Var "a")
       `shouldBe` True
 
   it "returns False when less obvs" $ do
-    isFirstOrder ([] --> T_Array ([] --> T_Null) 3)
+    isFirstOrder ([] --> ST_Array ([] --> ST_Null) 3)
       `shouldBe` False


### PR DESCRIPTION
dt2st is always safe

st2dt crashes if you give it something that is not a dt

All failing test cases are currently caused by st2dt crashing

Changed `DLType` to `SLType` in the following cases:

* funFold
* primOpType
* isFirstOrder
* SLVal constructors
* Some Eval Err_* constructors
* checkAndConvert & friends
* TypeEnv
* typeSubst
* InteractEnv

There may be something weird going on with:

* CollectsTypes
* Type.hs: checkAndConvert: typeSubst is now unused; that's definitely wrong
* SMT.hs: defineIE

