### PR TITLE
reach: use reach-network for docker stuff

### DIFF
--- a/reach
+++ b/reach
@@ -223,11 +223,17 @@ ensure_connector_mode () {
   export REACH_CONNECTOR_MODE
 }
 
+ensure_docker_reach_network () {
+  docker network inspect reach-network >/dev/null 2>&1 || \
+    (echo creating reach-network && docker network create --driver bridge reach-network)
+}
+
 do_whoami () {
   docker info --format '{{.ID}}' 2>/dev/null
 }
 
 do_compile () {
+	ensure_docker_reach_network
     HS=${HERE}/hs
 
     # Note: shellcheck says splatting is dangerous,
@@ -477,6 +483,10 @@ EOF
 version: '3.4'
 x-app-base: &app-base
   image: ${IMAGE_TAG}
+networks:
+  default:
+    external:
+      name: reach-network
 services:
   ethereum-devnet:
     image: reachsh/ethereum-devnet:${REACH_VERSION}
@@ -682,6 +692,7 @@ run_ () {
 }
 
 do_run () {
+  ensure_docker_reach_network
   # reach run args
   # check state of scaffolded files
   # * if none exist: scaffold in --isolate --quiet mode, set flag UNSCAFFOLD
@@ -855,6 +866,10 @@ react_compose () {
   fi
   cat<<EOF > docker-compose.yml.react
 version: '3.4'
+networks:
+  default:
+    external:
+      name: reach-network
 services:
   dev-server:
     image: reachsh/react_runner:$REACH_VERSION
@@ -899,6 +914,7 @@ EOF
 }
 
 do_react () {
+  ensure_docker_reach_network
   USE_EXISTING_DEVNET=false
   if [ "x$1" = "x--use-existing-devnet" ]; then
     shift

--- a/reach
+++ b/reach
@@ -228,6 +228,14 @@ ensure_docker_reach_network () {
     (echo creating reach-network && docker network create --driver bridge reach-network)
 }
 
+# If docker network for current dir exists,
+# call `reach down` to clean up some stuff,
+# and `docker network rm $NET` to remove it.
+down_old_network () {
+  NET="$(basename $(pwd))_default"
+  (docker network inspect "$NET" >/dev/null 2>&1 && reach down && docker network rm "$NET") || :
+}
+
 do_whoami () {
   docker info --format '{{.ID}}' 2>/dev/null
 }
@@ -727,6 +735,8 @@ do_run () {
     cd "$(dirname "$ARG")" || exit
     APP="$(basename "$ARG")"
   fi
+
+  down_old_network
 
   RSH="${APP}.rsh"
   MJS="${APP}.mjs"

--- a/reach
+++ b/reach
@@ -232,7 +232,7 @@ ensure_docker_reach_network () {
 # call `reach down` to clean up some stuff,
 # and `docker network rm $NET` to remove it.
 down_old_network () {
-  NET="$(basename $(pwd))_default"
+  NET="$(basename "$(pwd)")_default"
   (docker network inspect "$NET" >/dev/null 2>&1 && reach down && docker network rm "$NET") || :
 }
 


### PR DESCRIPTION
See: https://trello.com/c/SjbwvzNU/879-improve-our-docker-network-hygiene

This is a fairly simple change, and it does the thing it's supposed to do.

However, there's an awkward catch, which is that sometimes if you've already done `reach run` for a project, using this new `reach` script for `reach run` may fail for dumb docker caching reasons. The workaround is to run `reach down` first, which will disassociate the already-built containers from their old docker network.

I'm opening this as a PR as a place to discuss how we want to roll this out to our users. Just tell them to `reach down` if they encounter the known problem? The known problem looks like this:

```
Successfully tagged reachsh/reach-app-tut-6-index:latest
docker-compose -f "docker-compose.yml.index" run --rm reach-app-tut-6-index-${REACH_CONNECTOR_MODE} index
Starting tut-6_ethereum-devnet_1 ... error

ERROR: for tut-6_ethereum-devnet_1  Cannot start service ethereum-devnet: network 0b986a7b7b552a3b8e83a12d99633e438742b6eba1d3874d39f6f6f17b8c6537 not found

ERROR: for ethereum-devnet  Cannot start service ethereum-devnet: network 0b986a7b7b552a3b8e83a12d99633e438742b6eba1d3874d39f6f6f17b8c6537 not found
ERROR: Encountered errors while bringing up the project.
make[1]: *** [run-target] Error 1
make: *** [run] Error 2
```

"cannot start service", "network not found"