### PR TITLE
0944/RPC: loosen newTestAccount stdlib type sig + fix subtly-broken test suite + fix docs discrepancy

### DIFF
--- a/docs-src/ref-backends.scrbl
+++ b/docs-src/ref-backends.scrbl
@@ -263,7 +263,7 @@ this is the current block number, represented as a @litchar{BigNumber}.
 
 @(mint-define! '("waitUntilTime"))
 @js{
- waitUntilTime(time, onProgress) => Promise<void>
+ waitUntilTime(time, onProgress) => Promise<time>
 }
 
 Returns a Promise that will only be resolved after the specified consensus network @tech{time}.
@@ -281,7 +281,7 @@ It will receive an object with keys @jsin{currentTime} and @jsin{targetTime},
 
 @(mint-define! '("wait"))
 @js{
- wait(timedelta, onProgress) => Promise<void>
+ wait(timedelta, onProgress) => Promise<time>
 }
 
 Returns a Promise that will only be resolved after the specified @tech{time delta} has elapsed.

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -1159,10 +1159,10 @@ export const fundFromFaucet = async (account: Account, value: BigNumber) => {
   await transfer(faucet, account, value);
 }
 
-export const newTestAccount = async (startingBalance: BigNumber) => {
+export const newTestAccount = async (startingBalance: any) => {
   const account = await createAccount();
   if (getDEBUG()) { await showBalance('before', account.networkAccount); }
-  await fundFromFaucet(account, startingBalance);
+  await fundFromFaucet(account, bigNumberify(startingBalance));
   if (getDEBUG()) { await showBalance('after', account.networkAccount); }
   return account;
 };

--- a/js/stdlib/ts/ETH.ts
+++ b/js/stdlib/ts/ETH.ts
@@ -912,15 +912,16 @@ export const fundFromFaucet = async (account: AccountTransferable, value: BigNum
   await transfer(faucet, account, value);
 };
 
-export const newTestAccount = async (startingBalance: BigNumber): Promise<Account> => {
-  debug(`newTestAccount(${startingBalance})`);
+export const newTestAccount = async (startingBalance: any): Promise<Account> => {
+  const sb = bigNumberify(startingBalance);
+  debug(`newTestAccount(${sb})`);
   requireIsolatedNetwork('newTestAccount');
   const acc = await createAccount();
   const to = getAddr(acc);
 
   try {
     debug(`newTestAccount awaiting transfer: ${to}`);
-    await fundFromFaucet(acc, startingBalance);
+    await fundFromFaucet(acc, sb);
     debug(`newTestAccount got transfer: ${to}`);
     return acc;
   } catch (e) {

--- a/js/stdlib/ts/FAKE.ts
+++ b/js/stdlib/ts/FAKE.ts
@@ -380,10 +380,10 @@ export async function getFaucet(): Promise<Account> {
   return REACHY_RICH_P;
 }
 
-export const newTestAccount = async (startingBalance: BigNumber) => {
+export const newTestAccount = async (startingBalance: any) => {
   const account = await createAccount();
   debug(`new account: ${account.networkAccount.address}`);
-  await fundFromFaucet(account, startingBalance);
+  await fundFromFaucet(account, bigNumberify(startingBalance));
   return account;
 };
 

--- a/js/stdlib/ts/rpc_server.ts
+++ b/js/stdlib/ts/rpc_server.ts
@@ -43,7 +43,7 @@ export const serveRpc = async (backend: any) => {
   const rpc_stdlib = {
     ...real_stdlib,
     "newTestAccount": (async (bal: BigNumber) =>
-      makeACC(await real_stdlib.newTestAccount(real_stdlib.bigNumberify(bal)))),
+      makeACC(await real_stdlib.newTestAccount(bal))),
     "balanceOf": (async (id: number) =>
       await real_stdlib.balanceOf(ACC[id])),
     "formatCurrency": (async (x: BigNumber, y: number) =>


### PR DESCRIPTION
This pull request corresponds to the
> Push `bigNumberify` into real `stdlib` to widen interface for `stdlib` functions

line item in Trello, and was originally going to include all the other components which need similar treatment, but while working on it I discovered some issues in our current test suite which probably ought to have other eyeballs on before I move forward (in case I'm missing some context).

Likewise with my docs type signature fix; I'm not sure if those functions were labelled as returning `Promise<void>` deliberately for some reason, but AFAICT each of the backend providers' code disagree and this was probably just a mistake.

The test suite issues were subtle and easy to miss but basically boil down to timing gotchas. Before I added the extra `awaits` and rethought the `describe: wait` stanza I was getting failures because the suite presently `expects` very specific block numbers instead of using more dynamic+permissive logic. In my experience, you can make reliable assertions about "not before", and perhaps "only after", but rarely "exactly at".

I'm not in love with how it works now but it seems to mostly stick with the original intention this way... Any thoughts?

