### PR TITLE
Fix SMT Not Showing Every Error

### DIFF
--- a/examples/tut-4-attack/index-bad.txt
+++ b/examples/tut-4-attack/index-bad.txt
@@ -8,9 +8,9 @@ Verification failed:
   at ./index-bad.rsh:45:11:application
 
   // Violation witness
-  const interact_Alice_wager = 1;
+  const interact_Alice_wager = 2;
   //    ^ from interaction at ./index-bad.rsh:14:12:application
-  const v4 = 0;
+  const v4 = 2;
   //    ^ from evaluating interact("Alice")."getHand"() at ./index-bad.rsh:20:50:application
 
   // Theorem formalization

--- a/hs/src/Reach/Verify/SMT.hs
+++ b/hs/src/Reach/Verify/SMT.hs
@@ -855,10 +855,10 @@ smt_e at_dv mdv de =
       let check_m = verify1 at f (TClaim ct) ca' mmsg
       let assert_m = smtAssertCtxt ca'
       case ct of
-        CT_Assert -> check_m <> assert_m
+        CT_Assert -> check_m
         CT_Assume -> assert_m
         CT_Require -> ctxt_mode >>= \case
-            VM_Honest -> check_m <> assert_m
+            VM_Honest -> check_m
             VM_Dishonest {} -> assert_m
         CT_Possible -> check_m
         CT_Unknowable {} -> mempty

--- a/hs/test-examples/nl-verify-errs/assert_false.rsh
+++ b/hs/test-examples/nl-verify-errs/assert_false.rsh
@@ -3,5 +3,6 @@
 export const main = Reach.App(
   {}, [], () => {
     assert(false);
+    assert(false); // Multiple failures display
   }
 );

--- a/hs/test-examples/nl-verify-errs/assert_false.txt
+++ b/hs/test-examples/nl-verify-errs/assert_false.txt
@@ -11,6 +11,12 @@ Verification failed:
   // Theorem formalization
   assert(false);
 
+Verification failed:
+  in VM_Honest mode
+  of theorem TClaim CT_Assert
+  at ./assert_false.rsh:6:11:application
+
+  (details omitted on repeat)
   Verifying with mode = VM_Dishonest RoleContract
 Verification failed:
   in VM_Dishonest RoleContract mode
@@ -18,4 +24,10 @@ Verification failed:
   at ./assert_false.rsh:5:11:application
 
   (details omitted on repeat)
-Checked 4 theorems; 2 failures. :'(
+Verification failed:
+  in VM_Dishonest RoleContract mode
+  of theorem TClaim CT_Assert
+  at ./assert_false.rsh:6:11:application
+
+  (details omitted on repeat)
+Checked 6 theorems; 4 failures. :'(

--- a/hs/test-examples/nl-verify-errs/possible_false.rsh
+++ b/hs/test-examples/nl-verify-errs/possible_false.rsh
@@ -3,5 +3,6 @@
 export const main = Reach.App(
   {}, [], () => {
     possible(false);
+    possible(false); // Multiple failures display
   }
 );

--- a/hs/test-examples/nl-verify-errs/possible_false.txt
+++ b/hs/test-examples/nl-verify-errs/possible_false.txt
@@ -11,6 +11,12 @@ Verification failed:
   // Theorem formalization
   possible(false);
 
+Verification failed:
+  in VM_Honest mode
+  of theorem TClaim CT_Possible
+  at ./possible_false.rsh:6:13:application
+
+  (details omitted on repeat)
   Verifying with mode = VM_Dishonest RoleContract
 Verification failed:
   in VM_Dishonest RoleContract mode
@@ -18,4 +24,10 @@ Verification failed:
   at ./possible_false.rsh:5:13:application
 
   (details omitted on repeat)
-Checked 4 theorems; 2 failures. :'(
+Verification failed:
+  in VM_Dishonest RoleContract mode
+  of theorem TClaim CT_Possible
+  at ./possible_false.rsh:6:13:application
+
+  (details omitted on repeat)
+Checked 6 theorems; 4 failures. :'(

--- a/hs/test-examples/nl-verify-errs/require_false.rsh
+++ b/hs/test-examples/nl-verify-errs/require_false.rsh
@@ -4,6 +4,7 @@ export const main = Reach.App(
   {}, [['A', {}]], (A) => {
     A.publish();
     require(false);
+    require(false); // Multiple failures display
     commit();
   }
 );

--- a/hs/test-examples/nl-verify-errs/require_false.txt
+++ b/hs/test-examples/nl-verify-errs/require_false.txt
@@ -11,6 +11,12 @@ Verification failed:
   // Theorem formalization
   require(false);
 
+Verification failed:
+  in VM_Honest mode
+  of theorem TClaim CT_Require
+  at ./require_false.rsh:7:12:application
+
+  (details omitted on repeat)
   Verifying with mode = VM_Dishonest RoleContract
   Verifying with mode = VM_Dishonest (RolePart "A")
-Checked 6 theorems; 1 failures. :'(
+Checked 7 theorems; 2 failures. :'(


### PR DESCRIPTION
The SMT solver should fail if the negation of a claim (excluding `possible`) is `satisfiable`. There was an issue where subsequent false claims were not causing errors because the solver would incorrectly determine the assertion was `unsatisfiable`. 

## Issue

After a false `assert` was verified (`check_m`), `smt_e` would also assert the expression as well (`assert_m`). 

https://github.com/reach-sh/reach-lang/blob/4a0f9a126ef2f273d2a38bee3c2315f9000cbf3f/hs/src/Reach/Verify/SMT.hs#L853-L858

This is an issue because the claim may have to be negated if it is not `possible`.

https://github.com/reach-sh/reach-lang/blob/4a0f9a126ef2f273d2a38bee3c2315f9000cbf3f/hs/src/Reach/Verify/SMT.hs#L647-L649

This causes the next check to fail since it will try to verify `(assert false)`, as well.

From what I can tell, the `assert_m` in  `check_m <> assert_m` is redundant anyway, since it is performed correctly in `verify1`, so I removed it.