### PR TITLE
Add `timeout` short hand for `parallel_reduce`

### DIFF
--- a/docs-src/ref-programs.scrbl
+++ b/docs-src/ref-programs.scrbl
@@ -751,10 +751,13 @@ while the @reachin{.case} and @reachin{.timeout} components are like the corresp
 
 The @reachin{.case} component may be repeated many times, provided the @reachin{PART_EXPR}s each evaluate to a unique @tech{participant}, just like in a @reachin{fork} statement.
 
-In the case of absolute deadlines, there is a common pattern in the @reachin{TIMEOUT_BLOCK} to have participants
-@reachin{race} to @reachin{publish} and return the accumulator. There is a shorthand, @reachin{.time_remaining},
-available for this situation:
+@subsubsub*section{@tt{.time_remaining}}
 
+When dealing with absolute deadlines in @reachin{parallel_reduce}, there is a common pattern in the
+@reachin{TIMEOUT_BLOCK} to have participants @reachin{race} to @reachin{publish} and return the accumulator.
+There is a shorthand, @reachin{.time_remaining}, available for this situation:
+
+@(mint-define! '("time_remaining"))
 @reach{
   const [ timeRemaining, keepGoing ] = makeDeadline(deadline);
   const [ x, y, z ] =
@@ -1923,24 +1926,8 @@ expression. For example:
     .case(...)
     .timeout( timeRemaining(), () => { ... }) }
 
-When dealing with absolute deadlines in @reachin{parallel_reduce}, there is a common pattern in the
-@reachin{TIMEOUT_BLOCK} to have participants @reachin{race} to @reachin{publish} and return the accumulator.
-There is a shorthand, @reachin{.time_remaining}, available for this situation:
+This pattern is so common that it can be abbreviated as @reachin{.time_remaining}.
 
-@reach{
-  const [ timeRemaining, keepGoing ] = makeDeadline(deadline);
-  const [ x, y, z ] =
-    parallel_reduce([ 1, 2, 3 ])
-      .while(keepGoing())
-      ...
-      .time_remaining(timeRemaining()) }
-
-which will expand to:
-
-@reach{
-  .timeout(timeRemaining(), () => {
-    race(...Participants).publish();
-    return [ x, y, z ]; }) }
 
 @subsubsection{@tt{implies}}
 

--- a/docs-src/ref-programs.scrbl
+++ b/docs-src/ref-programs.scrbl
@@ -751,6 +751,25 @@ while the @reachin{.case} and @reachin{.timeout} components are like the corresp
 
 The @reachin{.case} component may be repeated many times, provided the @reachin{PART_EXPR}s each evaluate to a unique @tech{participant}, just like in a @reachin{fork} statement.
 
+In the case of absolute deadlines, there is a common pattern in the @reachin{TIMEOUT_BLOCK} to have participants
+@reachin{race} to @reachin{publish} and return the accumulator. There is a shorthand, @reachin{.time_remaining},
+available for this situation:
+
+@reach{
+  const [ timeRemaining, keepGoing ] = makeDeadline(deadline);
+  const [ x, y, z ] =
+    parallel_reduce([ 1, 2, 3 ])
+      .while(keepGoing())
+      ...
+      .time_remaining(timeRemaining()) }
+
+which will expand to:
+
+@reach{
+  .timeout(timeRemaining(), () => {
+    race(...Participants).publish();
+    return [ x, y, z ]; }) }
+
 @(hrule)
 
 A @tech{parallel reduce statement} is essentially an abbreviation of pattern of a @reachin{while} loop combined with a @reachin{fork} statement that you could write yourself.
@@ -1902,7 +1921,26 @@ expression. For example:
     .invariant(...)
     .while( keepGoing() )
     .case(...)
-    .timeout( timeRemaining(), ...) }
+    .timeout( timeRemaining(), () => { ... }) }
+
+When dealing with absolute deadlines in @reachin{parallel_reduce}, there is a common pattern in the
+@reachin{TIMEOUT_BLOCK} to have participants @reachin{race} to @reachin{publish} and return the accumulator.
+There is a shorthand, @reachin{.time_remaining}, available for this situation:
+
+@reach{
+  const [ timeRemaining, keepGoing ] = makeDeadline(deadline);
+  const [ x, y, z ] =
+    parallel_reduce([ 1, 2, 3 ])
+      .while(keepGoing())
+      ...
+      .time_remaining(timeRemaining()) }
+
+which will expand to:
+
+@reach{
+  .timeout(timeRemaining(), () => {
+    race(...Participants).publish();
+    return [ x, y, z ]; }) }
 
 @subsubsection{@tt{implies}}
 

--- a/examples/raffle/index.rsh
+++ b/examples/raffle/index.rsh
@@ -63,10 +63,7 @@ export const main =
             return [ howMany + 1 ];
           })
         )
-        // XXX Add a short-hand for timeouts like this
-        .timeout(buyTimeout(), () => {
-          race(Sponsor, Player).publish();
-          return [ howMany ]; });
+        .time_remaining(buyTimeout());
 
       const randomMatches = (who, r) => {
         const rc = randomsM[who];
@@ -101,9 +98,7 @@ export const main =
                      howManyReturned + 1 ];
           })
         )
-        .timeout(returnTimeout(), () => {
-          race(Sponsor, Player).publish();
-          return [ hwinner, howManyReturned ]; });
+        .time_remaining(returnTimeout());
       commit();
 
       Sponsor.only(() => { interact.showReturned(howManyReturned); });

--- a/examples/rent-seeking/index.rsh
+++ b/examples/rent-seeking/index.rsh
@@ -58,9 +58,7 @@ export const main =
             }
           })
         )
-        .timeout(bidTimeout(), () => {
-          race(Sponsor, Bidder).publish();
-          return [ winner, winningBid ]; });
+        .time_remaining(bidTimeout());
       commit();
 
       Bidder.only(() => {

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -215,6 +215,7 @@ data ParallelReduceMode
   | PRM_While
   | PRM_Case
   | PRM_Timeout
+  | PRM_TimeRemaining
   deriving (Eq, Generic, Show)
 
 data SLForm
@@ -248,7 +249,7 @@ data SLForm
       , slpr_minv :: Maybe JSExpression
       , slpr_mwhile :: Maybe JSExpression
       , slpr_cases :: [(SrcLoc, [JSExpression])]
-      , slpr_mtime :: Maybe (SrcLoc, [JSExpression])
+      , slpr_mtime :: Maybe (ParallelReduceMode, SrcLoc, [JSExpression])
       }
   | SLForm_wait
   deriving (Eq, Generic)

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -7,6 +7,7 @@ import Control.Monad.Extra
 import Control.Monad.Reader
 import Data.Bits
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as BC
 import Data.Foldable
 import Data.IORef
 import Data.List (transpose, (\\))
@@ -905,6 +906,7 @@ evalAsEnvM obj = case obj of
           <> gom "while" PRM_While pr_mwhile
           <> go "case" PRM_Case
           <> gom "timeout" PRM_Timeout pr_mtime
+          <> gom "time_remaining" PRM_TimeRemaining pr_mtime
     where
       gom key mode me =
         case me of
@@ -1177,7 +1179,6 @@ evalForm f args = do
       retV $ public $ SLV_Form $ SLForm_parallel_reduce_partial at Nothing x Nothing Nothing [] Nothing
     SLForm_parallel_reduce_partial pr_at pr_mode pr_init pr_minv pr_mwhile pr_cases pr_mtime -> do
       aa <- withAt $ \at -> (at, args)
-      let jaa = Just aa
       case pr_mode of
         Just PRM_Invariant -> do
           x <- one_arg
@@ -1188,9 +1189,15 @@ evalForm f args = do
         Just PRM_Case ->
           retV $ public $ SLV_Form $ SLForm_parallel_reduce_partial pr_at Nothing pr_init pr_minv pr_mwhile (pr_cases <> [aa]) pr_mtime
         Just PRM_Timeout ->
-          retV $ public $ SLV_Form $ SLForm_parallel_reduce_partial pr_at Nothing pr_init pr_minv pr_mwhile pr_cases jaa
+          retV $ public $ SLV_Form $ SLForm_parallel_reduce_partial pr_at Nothing pr_init pr_minv pr_mwhile pr_cases
+            $ makeTimeoutArgs PRM_Timeout aa
+        Just PRM_TimeRemaining ->
+          retV $ public $ SLV_Form $ SLForm_parallel_reduce_partial pr_at Nothing pr_init pr_minv pr_mwhile pr_cases
+            $ makeTimeoutArgs PRM_TimeRemaining aa
         Nothing ->
           expect_t rator $ Err_Eval_NotApplicable
+      where
+        makeTimeoutArgs mode aa = Just (mode, fst aa, snd aa)
     SLForm_Part_ToConsensus to_at who vas mmode mpub mpay mwhen mtime ->
       case mmode of
         Just TCM_Publish ->
@@ -2947,7 +2954,7 @@ doFork ks cases mtime = do
   let exp_ss = before_tc_ss <> tc_ss <> after_tc_ss
   evalStmt $ exp_ss <> ks
 
-doParallelReduce :: JSExpression -> SrcLoc -> Maybe ParallelReduceMode -> JSExpression -> Maybe JSExpression -> Maybe JSExpression -> [(SrcLoc, [JSExpression])] -> Maybe (SrcLoc, [JSExpression]) -> App [JSStatement]
+doParallelReduce :: JSExpression -> SrcLoc -> Maybe ParallelReduceMode -> JSExpression -> Maybe JSExpression -> Maybe JSExpression -> [(SrcLoc, [JSExpression])] -> Maybe (ParallelReduceMode, SrcLoc, [JSExpression]) -> App [JSStatement]
 doParallelReduce lhs pr_at pr_mode init_e pr_minv pr_mwhile pr_cases pr_mtime = locAt pr_at $ do
   idx <- ctxt_alloc
   let prid x = ".pr" <> (show idx) <> "." <> x
@@ -2967,12 +2974,32 @@ doParallelReduce lhs pr_at pr_mode init_e pr_minv pr_mwhile pr_cases pr_mtime = 
   let var_s = JSVariable a var_decls sp
   let inv_s = JSMethodCall (JSIdentifier a "invariant") a (JSLOne inv_e) a sp
   let fork_e0 = JSCallExpression (jid "fork") a JSLNil a
-  let fork_e1 =
+  fork_e1 <-
         case pr_mtime of
-          Nothing -> fork_e0
-          Just (t_at, t_es) ->
-            JSCallExpression (JSMemberDot fork_e0 ta (jid "timeout")) ta (toJSCL t_es) ta
+          Nothing -> return fork_e0
+          Just (mode, t_at, args) ->
+            case (mode, args) of
+              (PRM_TimeRemaining, [t_e]) -> do
+                ps <- asks $ M.keys . e_ios
+                let pids = map (jid . BC.unpack) ps
+                let semi = JSSemiAuto
+                let race = call (jid "race") pids
+                let dot o f = JSCallExpressionDot o ta f
+                let publish = dot race $ jid "publish"
+                let pubApp = call publish []
+                let noArgs = JSParenthesizedArrowParameterList ta JSLNil ta
+                let bodys = [
+                      JSExpressionStatement pubApp semi,
+                      JSReturn ta (Just lhs) semi ]
+                let block = JSStatementBlock ta bodys ta semi
+                let thunk = JSArrowExpression noArgs ta block
+                return $ call (JSMemberDot fork_e0 ta timeOutId) [ t_e, thunk ]
+              (PRM_TimeRemaining, _) -> expect_ $ Err_ParallelReduceTimeRemainingArgs args
+              (PRM_Timeout, t_es) -> return $ call (JSMemberDot fork_e0 ta timeOutId) t_es
+              _ -> impossible "pr_mtime must be PRM_TimeRemaining or PRM_Timeout"
             where
+              timeOutId = jid "timeout"
+              call f es = JSCallExpression f ta (toJSCL es) ta
               ta = ao t_at
   let forkcase fork_eN (case_at, case_es) = JSCallExpression (JSMemberDot fork_eN ca (jid "case")) ca (toJSCL case_es) ca
         where

--- a/hs/src/Reach/Eval/Error.hs
+++ b/hs/src/Reach/Eval/Error.hs
@@ -116,6 +116,7 @@ data EvalError
   | Err_Fork_ConsensusBadArrow JSExpression
   | Err_Fork_CaseAppearsTwice SLPart SrcLoc SrcLoc
   | Err_ParallelReduceIncomplete String
+  | Err_ParallelReduceTimeRemainingArgs [JSExpression]
   | Err_Type_None SLVal
   | Err_Type_NotDT SLType
   | Err_Type_NotApplicable SLType
@@ -451,6 +452,8 @@ instance Show EvalError where
       "fork cases must be unique: " <> show who <> " was defined previously at " <> show at0
     Err_ParallelReduceIncomplete lab ->
       "parallel reduce incomplete: " <> lab
+    Err_ParallelReduceTimeRemainingArgs args ->
+      "The `time_remaining` branch of `parallel_reduce` expects 1 argument, but received " <> show (length args)
     Err_Type_None val ->
       "Value cannot exist at runtime: " <> show (pretty val)
     Err_Type_NotDT t ->

--- a/hs/test-examples/nl-eval-errors/Err_ParallelReduceTimeRemainingArgs.rsh
+++ b/hs/test-examples/nl-eval-errors/Err_ParallelReduceTimeRemainingArgs.rsh
@@ -1,0 +1,19 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [Participant('A', {})],
+    (A) => {
+      const [ x ] =
+        parallel_reduce([ 0 ])
+          .invariant(balance() == balance())
+          .while(true)
+          .case(A,
+            (() => { when: true }),
+            (() => {
+              return [ x + 1]
+            })
+          )
+         .time_remaining(1, () => {});
+    });

--- a/hs/test-examples/nl-eval-errors/Err_ParallelReduceTimeRemainingArgs.txt
+++ b/hs/test-examples/nl-eval-errors/Err_ParallelReduceTimeRemainingArgs.txt
@@ -1,0 +1,1 @@
+reachc: error: ./Err_ParallelReduceTimeRemainingArgs.rsh:9:24:application: The `time_remaining` branch of `parallel_reduce` expects 1 argument, but received 2

--- a/py/pygments_reach/__init__.py
+++ b/py/pygments_reach/__init__.py
@@ -78,7 +78,7 @@ class ReachLexer(RegexLexer):
             (r'(for|in|while|do|break|return|continue|match|switch|case|default|if|else|'
              r'throw|try|catch|finally|new|delete|typeof|instanceof|void|yield|'
              # Reach ones
-             r'interact|commit|exit|only|each|race|fork|parallel_reduce|when|timeout|publish|pay|declassify|transfer|'
+             r'interact|commit|exit|only|each|race|fork|parallel_reduce|when|timeout|time_remaining|publish|pay|declassify|transfer|'
              r'invariant|assert|require|assume|possible|unknowable|forall|'
              r'this|of)\b', Keyword, 'slashstartsregex'),
             (r'(var|let|with|function|'


### PR DESCRIPTION
Add a shorthand in `parallel_reduce` for specifying:

```Javascript
.timeout(timeRemaining(), () => {
    race(...Participants).publish();
    return LHS; })
```

It can now be written simply as:

```Javascript
.time_remaining(timeRemaining())
```