### PR TITLE
Map & Set Standard Library Functions

### DIFF
--- a/docs-src/ref-model.scrbl
+++ b/docs-src/ref-model.scrbl
@@ -42,7 +42,7 @@ In particular, it does not only refer to so-called "layer-1" protocols, nor does
 
 @deftech{Contracts} are @tech{accounts} with three extra capacities: they persistently store @tech{values} (called the @deftech{consensus state}), they may receive @tech{publications}, and when they receive @tech{publications}, they systematically process them and may modify their @tech{consensus state}, make @tech{publications}, and may @tech{transfer} @tech{network tokens} in response to the reception.
 In addition to @tech{values}, @tech{consensus state} may contain a fixed number of @deftech{mappings} between an @tech{address} and a @tech{value}.
-These @tech{mappings} are referred to as "@deftech{linear state}" because their size in linear in the number of @tech{participants} in the @tech{contract}.
+These @tech{mappings} are referred to as "@deftech{linear state}" because their size is linear in the number of @tech{participants} in the @tech{contract}.
 The creation of a @tech{contract} is called @deftech{deploy}ment.
 
 A @deftech{participant} is a logical actor which takes part in a @|DApp|.

--- a/docs-src/ref-programs.scrbl
+++ b/docs-src/ref-programs.scrbl
@@ -825,7 +825,7 @@ Such modifications may only occur in a @tech{consensus step}.
 
 @subsubsection{Sets: creation and modification}
 
-@(mint-define! '("Set") '("insert") '("delete"))
+@(mint-define! '("Set") '("insert") '("delete") '("member"))
 @reach{
   const bidders = new Set();
   Set.insert(bidders, Alice);
@@ -834,7 +834,7 @@ Such modifications may only occur in a @tech{consensus step}.
 }
 
 A @reachin{Set} is another container for @tech{linear state}. It is simply a type alias of @reachin{Map(Null)};
-so it is only useful for tracking @reachin{Address}es. Because a @reachin{Set} is internally a @reachin{Map}, it may
+it is only useful for tracking @reachin{Address}es. Because a @reachin{Set} is internally a @reachin{Map}, it may
 only be constructed in a @tech{consensus step}.
 
 A @reachin{Set} may be modified by writing @reachin{Set.insert(s, ADDRESS)} to install @reachin{ADDRESS} in the

--- a/docs-src/ref-programs.scrbl
+++ b/docs-src/ref-programs.scrbl
@@ -1385,7 +1385,151 @@ except that index @reachin{idx} is replaced with @reachin{val}.
 
 Both may be abbreviated as @reachin{expr.set(idx, val)} where @reachin{expr} evaluates to a tuple or an array.
 
+@subsubsection{Foldable operations}
+
+The following methods are available on any @(mint-define! '("Foldable"))@reachin{Foldable} containers, such as: @reachin{Array}s and @reachin{Map}s.
+
+@subsubsub*section{ @tt{Foldable.forEach} && @tt{.forEach}}
+
+@(mint-define! '("forEach"))
+@reach{
+ c.forEach(f)
+ Foldable.forEach(c, f)
+ Array.forEach(c, f)
+ Map.forEach(c, f) }
+
+@index{Foldable.forEach} @reachin{Foldable.forEach(c, f)} iterates the function @reachin{f} over the elements of a container @reachin{c}, discarding the result.
+This may be abbreviated as @reachin{c.forEach(f)}.
+
+@subsubsub*section{@tt{Foldable.all} && @tt{.all}}
+
+@(mint-define! '("all"))
+@reach{
+  Foldable.all(c, f)
+  Array.all(c, f)
+  Map.all(c, f)
+  c.all(f) }
+
+@index{Foldable.all} @reachin{Foldable.all(c, f)} determines whether the predicate, @tt{f}, is satisfied
+by every element of the container, @tt{c}.
+
+@subsubsub*section{@tt{Foldable.any} && @tt{.any}}
+
+@(mint-define! '("any"))
+@reach{
+  Foldable.any(c, f)
+  Array.any(c, f)
+  Map.any(c, f)
+  c.any(f) }
+
+@index{Foldable.any} @reachin{Foldable.any(c, f)} determines whether the predicate, @tt{f}, is satisfied
+by at least one element of the container, @tt{c}.
+
+@subsubsub*section{@tt{Foldable.or} && @tt{.or}}
+
+@(mint-define! '("or"))
+@reach{
+  Foldable.or(c)
+  Array.or(c)
+  Map.or(c)
+  c.or() }
+
+@index{Foldable.or} @reachin{Foldable.or(c)} returns the disjunction of a container of @reachin{Bool}s.
+
+@subsubsub*section{@tt{Foldable.and} && @tt{.and}}
+
+@(mint-define! '("and"))
+@reach{
+  Foldable.and(c)
+  Array.and(c)
+  Map.and(c)
+  c.and() }
+
+@index{Foldable.and} @reachin{Foldable.and(c)} returns the conjunction of a container of @reachin{Bool}s.
+
+@subsubsub*section{@tt{Foldable.includes} && @tt{.includes}}
+
+@(mint-define! '("includes"))
+@reach{
+  Foldable.includes(c, x)
+  Array.includes(c, x)
+  Map.includes(c, x)
+  c.includes(x) }
+
+@index{Foldable.includes} @reachin{Foldable.includes(c, x)} determines whether the container includes
+the element, @tt{x}.
+
+@subsubsub*section{@tt{Foldable.count} && @tt{.count}}
+
+@(mint-define! '("count"))
+@reach{
+  Foldable.count(c, f)
+  Array.count(c, f)
+  Map.count(c, f)
+  c.count(f) }
+
+@index{Foldable.count} @reachin{Foldable.count(c, f)} returns the number of elements in @tt{c} that
+satisfy the predicate, @tt{f}.
+
+@subsubsub*section{@tt{Foldable.min} && @tt{.min}}
+
+@(mint-define! '("min"))
+@reach{
+  Foldable.min(c)
+  Array.min(c)
+  Map.min(c)
+  c.min() }
+
+@index{Foldable.min} @reachin{Foldable.min(arr)} returns the lowest number in a container of @tt{UInt}s.
+
+@subsubsub*section{@tt{Foldable.max} && @tt{.max}}
+
+@(mint-define! '("max"))
+@reach{
+  Foldable.max(c)
+  Array.max(c)
+  Map.max(c)
+  c.max() }
+
+@index{Foldable.max} @reachin{Foldable.max(c)} returns the largest number in a container of @tt{UInt}s.
+
+@subsubsub*section{@tt{Foldable.sum} && @tt{.sum}}
+
+@(mint-define! '("sum"))
+@reach{
+  Foldable.sum(c)
+  Array.sum(c)
+  Map.sum(c)
+  c.sum() }
+
+@index{Foldable.sum} @reachin{Foldable.sum(c)} returns the sum of a container of @tt{UInt}s.
+
+@subsubsub*section{@tt{Foldable.product} && @tt{.product}}
+
+@(mint-define! '("product"))
+@reach{
+  Foldable.product(c)
+  Array.product(c)
+  Map.product(c)
+  c.product() }
+
+@index{Foldable.product} @reachin{Foldable.product(c)} returns the product of a container of @tt{UInt}s.
+
+@subsubsub*section{@tt{Foldable.average} && @tt{.average}}
+
+@(mint-define! '("average"))
+@reach{
+  Foldable.average(c)
+  Array.average(c)
+  Map.average(c)
+  c.average() }
+
+@index{Foldable.average} @reachin{Foldable.average(c)} returns the mean of a container of @tt{UInt}s.
+
 @subsubsection{Array group operations}
+
+@reachin{Array} is a @reachin{Foldable} container. Along with the methods of @reachin{Foldable}, the
+following methods may be used with @reachin{Array}s.
 
 @subsubsub*section{@tt{Array.iota}}
 
@@ -1467,66 +1611,6 @@ This may be abbreviated as @reachin{arr.reduce(z, f)}.
 This function is generalized to an arbitrary number of arrays of the same size, which are provided before the @reachin{z} argument.
 For example, @reachin{Array.iota(4).reduce(Array.iota(4), 0, (x, y, z) => (z + x + y))} returns @reachin{((((0 + 0 + 0) + 1 + 1) + 2 + 2) + 3 + 3)}.
 
-@subsubsub*section{@tt{Array.forEach} && @tt{.forEach}}
-
-@(mint-define! '("forEach"))
-@reach{
- arr.forEach(f)
- Array.forEach(arr, f)
- Array_forEach(arr, f)
- Array_forEach1(arr)(f) }
-
-@index{Array.forEach} @reachin{Array.forEach(arr, f)} iterates the function @reachin{f} over the elements of the array @reachin{arr}, discarding the result.
-This may be abbreviated as @reachin{arr.forEach(f)}.
-
-@subsubsub*section{@tt{Array.all} && @tt{.all}}
-
-@(mint-define! '("all"))
-@reach{
-  Array.all(arr, f)
-  arr.all(f) }
-
-@index{Array.all} @reachin{Array.all(arr, f)} determines whether the predicate, @tt{f}, is satisfied
-by every element of the array, @tt{arr}.
-
-@subsubsub*section{@tt{Array.any} && @tt{.any}}
-
-@(mint-define! '("any"))
-@reach{
-  Array.any(arr, f)
-  arr.any(f) }
-
-@index{Array.any} @reachin{Array.any(arr, f)} determines whether the predicate, @tt{f}, is satisfied
-by at least one element of the array, @tt{arr}.
-
-@subsubsub*section{@tt{Array.or} && @tt{.or}}
-
-@(mint-define! '("or"))
-@reach{
-  Array.or(arr)
-  arr.or() }
-
-@index{Array.or} @reachin{Array.or(arr)} returns the disjunction of an array of @reachin{Bool}s.
-
-@subsubsub*section{@tt{Array.and} && @tt{.and}}
-
-@(mint-define! '("and"))
-@reach{
-  Array.and(arr)
-  arr.and() }
-
-@index{Array.and} @reachin{Array.and(arr)} returns the conjunction of an array of @reachin{Bool}s.
-
-@subsubsub*section{@tt{Array.includes} && @tt{.includes}}
-
-@(mint-define! '("includes"))
-@reach{
-  Array.includes(arr, x)
-  arr.includes(x) }
-
-@index{Array.includes} @reachin{Array.includes(arr, x)} determines whether the array includes
-the element, @tt{x}.
-
 @subsubsub*section{@tt{Array.indexOf} && @tt{.indexOf}}
 
 @(mint-define! '("indexOf"))
@@ -1549,64 +1633,10 @@ the value is not present in the array, @reachin{None} is returned.
 in the given array that satisfies the predicate @tt{f}. The return value is of type @reachin{Maybe(UInt)}. If
 no value in the array satisfies the predicate, @reachin{None} is returned.
 
-@subsubsub*section{@tt{Array.count} && @tt{.count}}
-
-@(mint-define! '("count"))
-@reach{
-  Array.count(arr, f)
-  arr.count(f) }
-
-@index{Array.count} @reachin{Array.count(arr, f)} returns the number of elements in @tt{arr} that
-satisfy the predicate, @tt{f}.
-
-@subsubsub*section{@tt{Array.min} && @tt{.min}}
-
-@(mint-define! '("min"))
-@reach{
-  Array.min(arr)
-  arr.min() }
-
-@index{Array.min} @reachin{Array.min(arr)} returns the lowest number in an array of @tt{UInt}s.
-
-@subsubsub*section{@tt{Array.max} && @tt{.max}}
-
-@(mint-define! '("max"))
-@reach{
-  Array.max(arr)
-  arr.max() }
-
-@index{Array.max} @reachin{Array.max(arr)} returns the largest number in an array of @tt{UInt}s.
-
-@subsubsub*section{@tt{Array.sum} && @tt{.sum}}
-
-@(mint-define! '("sum"))
-@reach{
-  Array.sum(arr)
-  arr.sum() }
-
-@index{Array.sum} @reachin{Array.sum(arr)} returns the sum of an array of @tt{UInt}s.
-
-@subsubsub*section{@tt{Array.product} && @tt{.product}}
-
-@(mint-define! '("product"))
-@reach{
-  Array.product(arr)
-  arr.product() }
-
-@index{Array.product} @reachin{Array.product(arr)} returns the product of an array of @tt{UInt}s.
-
-@subsubsub*section{@tt{Array.average} && @tt{.average}}
-
-@(mint-define! '("average"))
-@reach{
-  Array.average(arr)
-  arr.average() }
-
-@index{Array.average} @reachin{Array.average(arr)} returns the mean of an array of @tt{UInt}s.
-
 @subsubsection{Mapping group operations}
 
-@tech{Mappings} may be aggregated with these operations within the @reachin{invariant} of a @reachin{while} loop.
+@reachin{Map} is a @reachin{Foldable} container. @tech{Mappings} may be aggregated with the following
+operations and those of @reachin{Foldable} within the @reachin{invariant} of a @reachin{while} loop.
 
 @subsubsub*section{@tt{Map.reduce} && @tt{.reduce}}
 

--- a/docs-src/ref-programs.scrbl
+++ b/docs-src/ref-programs.scrbl
@@ -825,23 +825,23 @@ Such modifications may only occur in a @tech{consensus step}.
 
 @subsubsection{Sets: creation and modification}
 
-@(mint-define! '("Set") '("insert") '("delete") '("member"))
+@(mint-define! '("Set") '("insert") '("remove") '("member"))
 @reach{
-  const bidders = new Set();
-  Set.insert(bidders, Alice);
-  Set.delete(bidders, Alice);
-  Set.member(bidders, Alice); // false
+  const bidders = Set();
+  bidders.insert(Alice);
+  bidders.remove(Alice);
+  bidders.member(Alice); // false
 }
 
 A @reachin{Set} is another container for @tech{linear state}. It is simply a type alias of @reachin{Map(Null)};
 it is only useful for tracking @reachin{Address}es. Because a @reachin{Set} is internally a @reachin{Map}, it may
 only be constructed in a @tech{consensus step}.
 
-A @reachin{Set} may be modified by writing @reachin{Set.insert(s, ADDRESS)} to install @reachin{ADDRESS} in the
-set, @reachin{s}, or @reachin{Set.delete(s, ADDRESS)} to remove the @reachin{ADDRESS} from the set.
+A @reachin{Set} may be modified by writing @reachin{s.insert(ADDRESS)} to install @reachin{ADDRESS} in the
+set, @reachin{s}, or @reachin{s.remove(ADDRESS)} to remove the @reachin{ADDRESS} from the set.
 Such modifications may only occur in a @tech{consensus step}.
 
-@reachin{Set.member(s, ADDRESS)} will return a @reachin{Bool} representing whether the address is in the set.
+@reachin{s.member(ADDRESS)} will return a @reachin{Bool} representing whether the address is in the set.
 
 @subsubsection{@tt{transfer}}
 

--- a/docs-src/ref-programs.scrbl
+++ b/docs-src/ref-programs.scrbl
@@ -827,7 +827,7 @@ Such modifications may only occur in a @tech{consensus step}.
 
 @(mint-define! '("Set") '("insert") '("remove") '("member"))
 @reach{
-  const bidders = Set();
+  const bidders = new Set();
   bidders.insert(Alice);
   bidders.remove(Alice);
   bidders.member(Alice); // false

--- a/docs-src/ref-programs.scrbl
+++ b/docs-src/ref-programs.scrbl
@@ -823,6 +823,26 @@ Such dereferences return a value of type @reachin{Maybe(TYPE_EXPR)}, because the
 A @tech{mapping} may be modified by writing @reachin{map[ADDR_EXPR] = VALUE_EXPR} to install @reachin{VALUE_EXPR} (of type @reachin{TYPE_EXPR}) at @reachin{ADDR_EXPR}, or by writing @reachin{delete map[ADDR_EXPR]} to remove the mapping entry.
 Such modifications may only occur in a @tech{consensus step}.
 
+@subsubsection{Sets: creation and modification}
+
+@(mint-define! '("Set") '("insert") '("delete"))
+@reach{
+  const bidders = new Set();
+  Set.insert(bidders, Alice);
+  Set.delete(bidders, Alice);
+  Set.member(bidders, Alice); // false
+}
+
+A @reachin{Set} is another container for @tech{linear state}. It is simply a type alias of @reachin{Map(Null)};
+so it is only useful for tracking @reachin{Address}es. Because a @reachin{Set} is internally a @reachin{Map}, it may
+only be constructed in a @tech{consensus step}.
+
+A @reachin{Set} may be modified by writing @reachin{Set.insert(s, ADDRESS)} to install @reachin{ADDRESS} in the
+set, @reachin{s}, or @reachin{Set.delete(s, ADDRESS)} to remove the @reachin{ADDRESS} from the set.
+Such modifications may only occur in a @tech{consensus step}.
+
+@reachin{Set.member(s, ADDRESS)} will return a @reachin{Bool} representing whether the address is in the set.
+
 @subsubsection{@tt{transfer}}
 
 @(mint-define! '("transfer"))

--- a/examples/rent-seeking/index.rsh
+++ b/examples/rent-seeking/index.rsh
@@ -34,8 +34,8 @@ export const main =
 
       const [ winner, winningBid ] =
         parallel_reduce([ Sponsor, 0 ])
-        .invariant( balance() == prize + bidsM.reduce(0, (acc, x) => acc + x)
-          && balance() == prize + Map.reduce(bidsM, 0, (acc, x) => acc + x) )
+        .invariant( balance() == prize + bidsM.sum()
+          && balance() == prize + Map.sum(bidsM) )
         .while( keepBidding() )
         .case( Bidder, (() => {
             const previousBid = getBid(this);

--- a/hs/rsh/stdlib.rsh
+++ b/hs/rsh/stdlib.rsh
@@ -412,3 +412,18 @@ export const makeDeadline = (deadline) => {
   return [ timeRemaining, keepGoing ];
 }
 
+export const Set_insert = (s, v) =>
+  s[v] = null;
+
+export const Set_delete = (s, v) => {
+  delete s[v];
+}
+
+export const Set_member = (s, k) => {
+  const mv = s[k];
+  switch(mv) {
+    case None: return false;
+    case Some: return true;
+  }
+}
+

--- a/hs/rsh/stdlib.rsh
+++ b/hs/rsh/stdlib.rsh
@@ -412,18 +412,17 @@ export const makeDeadline = (deadline) => {
   return [ timeRemaining, keepGoing ];
 }
 
-export const Set_insert = (s, v) =>
-  s[v] = null;
-
-export const Set_delete = (s, v) => {
-  delete s[v];
+export const Set = () => {
+  const s = new Map(Null);
+  return ({
+    insert: (v) => { s[v] = null; },
+    remove: (v) => { delete s[v]; },
+    member: (v) => {
+      const mv = s[v];
+      switch(mv) {
+        case None: return false;
+        case Some: return true;
+      }
+    }
+  });
 }
-
-export const Set_member = (s, k) => {
-  const mv = s[k];
-  switch(mv) {
-    case None: return false;
-    case Some: return true;
-  }
-}
-

--- a/hs/rsh/stdlib.rsh
+++ b/hs/rsh/stdlib.rsh
@@ -108,46 +108,48 @@ export const Array_empty =
   Array.iota(0);
 export const Array_replicate =
   (sz, v) => Array.iota(sz).map(x => v);
-export const Array_forEach =
-  (arr, f) => arr.reduce(null, (acc, xe) => f(xe));
-export const Array_forEach1 =
-  (arr) => (f) => Array_forEach(arr, f);
 
-export const Array_min =
-  (arr) => arr.reduce(UInt.max, (acc, x) => (x < acc) ? x : acc);
-export const Array_min1 = (arr) => () => Array_min(arr);
+export const Foldable_forEach =
+  (c, f) => c.reduce(null, (_, xe) => f(xe));
+export const Foldable_forEach1 =
+  (c) => (f) => Foldable_forEach(c, f);
 
-export const Array_max =
-  (arr) => arr.reduce(0, (acc, x) => (x > acc) ? x : acc);
-export const Array_max1 = (arr) => () => Array_max(arr);
+export const Foldable_min =
+  (c) => c.reduce(UInt.max, (acc, x) =>
+    (x < acc) ? x : acc);
+export const Foldable_min1 = (c) => () => Foldable_min(c);
 
-export const Array_any =
-  (arr, f) => arr.reduce(false, (acc, x) =>
+export const Foldable_max =
+  (c) => c.reduce(0, (acc, x) => (x > acc) ? x : acc);
+export const Foldable_max1 = (c) => () => Foldable_max(c);
+
+export const Foldable_any =
+  (c, f) => c.reduce(false, (acc, x) =>
     acc ? acc : f(x));
-export const Array_any1 = (arr) => (f) => Array_any(arr, f);
+export const Foldable_any1 = (c) => (f) => Foldable_any(c, f);
 
-export const Array_all =
-  (arr, f) => arr.reduce(true, (acc, x) =>
+export const Foldable_all =
+  (c, f) => c.reduce(true, (acc, x) =>
     acc ? f(x) : false);
-export const Array_all1 = (arr) => (f) => Array_all(arr, f);
+export const Foldable_all1 = (c) => (f) => Foldable_all(c, f);
 
-export const Array_or =
-  (arr) => Array_any(arr, x => x);
-export const Array_or1 = (arr) => () => Array_or(arr);
+export const Foldable_or =
+  (c) => Foldable_any(c, x => x);
+export const Foldable_or1 = (c) => () => Foldable_or(arr);
 
-export const Array_and =
-  (arr) => Array_all(arr, x => x);
-export const Array_and1 = (arr) => () => Array_and(arr);
+export const Foldable_and =
+  (c) => Foldable_all(c, x => x);
+export const Foldable_and1 = (c) => () => Foldable_and(c);
 
-export const Array_sum =
-  (arr) => arr.reduce(0, (acc, x) => acc + x);
-export const Array_sum1 = (arr) => () => Array_sum(arr);
+export const Foldable_sum =
+  (c) => c.reduce(0, (acc, x) => acc + x);
+export const Foldable_sum1 = (c) => () => Foldable_sum(c);
 
-export const Array_includes =
-  (arr, x) => arr.reduce(false, (acc, e) =>
+export const Foldable_includes =
+  (c, x) => c.reduce(false, (acc, e) =>
     acc ? acc : (x == e) ? true : false);
-export const Array_includes1 =
-  (arr) => (x) => Array_includes(arr, x);
+export const Foldable_includes1 =
+  (c) => (x) => Foldable_includes(c, x);
 
 export const Array_indexOfAux =
   (arr, f) => {
@@ -175,26 +177,29 @@ export const Array_findIndex =
 export const Array_findIndex1 =
   (arr) => (f) => Array_findIndex(arr, f);
 
-export const Array_count =
-  (arr, f) => arr.reduce(0, (acc, x) =>
+export const Foldable_count =
+  (c, f) => c.reduce(0, (acc, x) =>
     f(x) ? acc + 1 : acc);
-export const Array_count1 =
-  (arr) => (f) => Array_count(arr, f);
+export const Foldable_count1 =
+  (c) => (f) => Foldable_count(c, f);
 
 export const compose =
   (f, g) => (v) => f(g(v));
 
-export const Array_average = (arr) =>
-  arr.sum() / arr.length;
+export const Foldable_length =
+  (c) => c.reduce(0, (acc, _) => acc + 1);
+export const Foldable_length1 =
+  (c) => () => Foldable_length(c);
 
-export const Array_average1 = (arr) => () =>
-  Array_average(arr);
+export const Foldable_average = (c) =>
+  Foldable_sum(c) / Foldable_length(s);
+export const Foldable_average1 = (c) => () =>
+  Foldable_average(c);
 
-export const Array_product = (arr) =>
-  arr.reduce(1, (acc, x) => acc * x);
-
-export const Array_product1 = (arr) => () =>
-  Array_product(arr);
+export const Foldable_product = (c) =>
+  c.reduce(1, (acc, x) => acc * x);
+export const Foldable_product1 = (c) => () =>
+  Foldable_product(c);
 
 export const sqrt = (y, k) =>
   Array.iota(k).reduce([ y, (y / 2 + 1) ], ([ z, x ], a) =>
@@ -406,3 +411,4 @@ export const makeDeadline = (deadline) => {
     endTime > lastConsensusTime();
   return [ timeRemaining, keepGoing ];
 }
+

--- a/hs/rsh/stdlib.rsh
+++ b/hs/rsh/stdlib.rsh
@@ -412,17 +412,19 @@ export const makeDeadline = (deadline) => {
   return [ timeRemaining, keepGoing ];
 }
 
-export const Set = () => {
-  const s = new Map(Null);
-  return ({
-    insert: (v) => { s[v] = null; },
-    remove: (v) => { delete s[v]; },
-    member: (v) => {
-      const mv = s[v];
-      switch(mv) {
-        case None: return false;
-        case Some: return true;
+export const Set = () => ({
+  new: () => {
+    const s = new Map(Null);
+    return {
+      insert: (v) => { s[v] = null; },
+      remove: (v) => { delete s[v]; },
+      member: (v) => {
+        const mv = s[v];
+        switch(mv) {
+          case None: return false;
+          case Some: return true;
+        }
       }
     }
-  });
-}
+  },
+})

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -383,7 +383,6 @@ data SLPrimitive
   | SLPrim_Participant
   | SLPrim_ParticipantClass
   | SLPrim_Foldable
-  | SLPrim_Set
   deriving (Eq, Generic)
 
 type SLSVal = (SecurityLevel, SLVal)

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -383,6 +383,7 @@ data SLPrimitive
   | SLPrim_Participant
   | SLPrim_ParticipantClass
   | SLPrim_Foldable
+  | SLPrim_Set
   deriving (Eq, Generic)
 
 type SLSVal = (SecurityLevel, SLVal)

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -382,6 +382,7 @@ data SLPrimitive
   | SLPrim_MapReduce
   | SLPrim_Participant
   | SLPrim_ParticipantClass
+  | SLPrim_Foldable
   deriving (Eq, Generic)
 
 type SLSVal = (SecurityLevel, SLVal)

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -2166,6 +2166,8 @@ getKwdOrPrim ident env =
     -- Hack: Allow `default` to be used as object property name for `match`
     -- expr. Keywords are allowed as property names in JS anyway, *shrug*
     Just (SLSSVal _ _ (SLV_Kwd SLK_default)) -> Nothing
+    -- Allow `new` to be used as object property name for `Set`.
+    Just (SLSSVal _ _ (SLV_Kwd SLK_new)) -> Nothing
     Just s@(SLSSVal _ _ (SLV_Kwd _)) -> Just s
     Just s@(SLSSVal _ _ (SLV_Prim _)) -> Just s
     _ -> Nothing

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -367,7 +367,6 @@ base_env =
     , ("Map", SLV_Prim SLPrim_Map)
     , ("Participant", SLV_Prim SLPrim_Participant)
     , ("ParticipantClass", SLV_Prim SLPrim_ParticipantClass)
-    , ("Set", SLV_Prim SLPrim_Set)
     , ( "Reach"
       , (SLV_Object srcloc_builtin (Just $ "Reach") $
            m_fromList_public_builtin
@@ -1012,12 +1011,6 @@ evalAsEnvM obj = case obj of
     Just $
       M.fromList $
         [ ("reduce", delayCall SLPrim_MapReduce) ] <> foldableObjectEnv
-  SLV_Prim SLPrim_Set ->
-    Just $
-      M.fromList [
-          ("insert", retStdLib "Set_insert")
-        , ("delete", retStdLib "Set_delete")
-        , ("member", retStdLib "Set_member")]
   _ -> Nothing
   where
     foldableMethods = ["forEach", "min", "max", "all", "any", "or", "and", "sum", "average", "product", "includes", "length", "count"]
@@ -1999,7 +1992,6 @@ evalPrim p sargs =
       evalApplyVals' fn [public obj, public cases]
     SLPrim_Participant -> makeParticipant SLP_Participant
     SLPrim_ParticipantClass -> makeParticipant SLP_ParticipantClass
-    SLPrim_Set -> retV (lvl, SLV_MapCtor ST_Null)
     SLPrim_Map -> do
       t <- expect_ty =<< one_arg
       retV $ (lvl, SLV_MapCtor t)

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -367,6 +367,7 @@ base_env =
     , ("Map", SLV_Prim SLPrim_Map)
     , ("Participant", SLV_Prim SLPrim_Participant)
     , ("ParticipantClass", SLV_Prim SLPrim_ParticipantClass)
+    , ("Set", SLV_Prim SLPrim_Set)
     , ( "Reach"
       , (SLV_Object srcloc_builtin (Just $ "Reach") $
            m_fromList_public_builtin
@@ -1011,6 +1012,12 @@ evalAsEnvM obj = case obj of
     Just $
       M.fromList $
         [ ("reduce", delayCall SLPrim_MapReduce) ] <> foldableObjectEnv
+  SLV_Prim SLPrim_Set ->
+    Just $
+      M.fromList [
+          ("insert", retStdLib "Set_insert")
+        , ("delete", retStdLib "Set_delete")
+        , ("member", retStdLib "Set_member")]
   _ -> Nothing
   where
     foldableMethods = ["forEach", "min", "max", "all", "any", "or", "and", "sum", "average", "product", "includes", "length", "count"]
@@ -1992,6 +1999,7 @@ evalPrim p sargs =
       evalApplyVals' fn [public obj, public cases]
     SLPrim_Participant -> makeParticipant SLP_Participant
     SLPrim_ParticipantClass -> makeParticipant SLP_ParticipantClass
+    SLPrim_Set -> retV (lvl, SLV_MapCtor ST_Null)
     SLPrim_Map -> do
       t <- expect_ty =<< one_arg
       retV $ (lvl, SLV_MapCtor t)

--- a/hs/src/Reach/Eval/Error.hs
+++ b/hs/src/Reach/Eval/Error.hs
@@ -126,6 +126,7 @@ data EvalError
   | Err_Type_TooManyArguments [SLVal]
   | Err_Eval_MustBeInWhileInvariant String
   | Err_Expected_Map SLValTy
+  | Err_Prim_Foldable
   deriving (Eq, Generic)
 
 --- FIXME I think most of these things should be in Pretty
@@ -476,6 +477,8 @@ instance Show EvalError where
       "Too many arguments; surplus: " <> show (length vs)
     Err_Expected_Map v ->
       "Expected map, got: " <> show_sv v
+    Err_Prim_Foldable ->
+      "Instances of Foldable cannot be created. Did you mean to call a function provided by `Foldable`?"
     where
       displayPrim = drop (length ("SLPrim_" :: String)) . conNameOf
 

--- a/hs/test-examples/nl-eval-errors/Err_Prim_Foldable.rsh
+++ b/hs/test-examples/nl-eval-errors/Err_Prim_Foldable.rsh
@@ -1,0 +1,10 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [Participant('A', {})],
+    (A) => {
+      const x = Foldable();
+
+    });

--- a/hs/test-examples/nl-eval-errors/Err_Prim_Foldable.txt
+++ b/hs/test-examples/nl-eval-errors/Err_Prim_Foldable.txt
@@ -1,0 +1,1 @@
+reachc: error: ./Err_Prim_Foldable.rsh:8:25:application: Instances of Foldable cannot be created. Did you mean to call a function provided by `Foldable`?

--- a/hs/test-examples/nl-eval-errors/Err_Prim_InvalidArg_Dynamic.txt
+++ b/hs/test-examples/nl-eval-errors/Err_Prim_InvalidArg_Dynamic.txt
@@ -1,4 +1,4 @@
-reachc: error: reach standard library:200:13:application: Invalid arg for Array_iota. The argument must be computable at compile time
+reachc: error: reach standard library:205:13:application: Invalid arg for Array_iota. The argument must be computable at compile time
 Trace:
-  in "sqrt" from (reach standard library:199:28:function exp) at (./Err_Prim_InvalidArg_Dynamic.rsh:9:20:application)
+  in "sqrt" from (reach standard library:204:28:function exp) at (./Err_Prim_InvalidArg_Dynamic.rsh:9:20:application)
   in [unknown function] from (./Err_Prim_InvalidArg_Dynamic.rsh:8:17:function exp) at (./Err_Prim_InvalidArg_Dynamic.rsh:8:13:application)

--- a/hs/test-examples/nl-verify-errs/fxsqrt.txt
+++ b/hs/test-examples/nl-verify-errs/fxsqrt.txt
@@ -5,8 +5,8 @@ Verification failed:
   when ALL participants are honest
   of theorem: assert
   msg: "fxsqrt: Cannot find the square root of a negative number."
-  at reach standard library:300:9:application
-  at ./fxsqrt.rsh:10:30:application call to "fxsqrt" (defined at: reach standard library:299:30:function exp)
+  at reach standard library:305:9:application
+  at ./fxsqrt.rsh:10:30:application call to "fxsqrt" (defined at: reach standard library:304:30:function exp)
   at ./fxsqrt.rsh:9:13:application call to [unknown function] (defined at: ./fxsqrt.rsh:9:17:function exp)
 
   // Violation witness
@@ -20,8 +20,8 @@ Verification failed:
   when ONLY "A" is honest
   of theorem: assert
   msg: "fxsqrt: Cannot find the square root of a negative number."
-  at reach standard library:300:9:application
-  at ./fxsqrt.rsh:10:30:application call to "fxsqrt" (defined at: reach standard library:299:30:function exp)
+  at reach standard library:305:9:application
+  at ./fxsqrt.rsh:10:30:application call to "fxsqrt" (defined at: reach standard library:304:30:function exp)
   at ./fxsqrt.rsh:9:13:application call to [unknown function] (defined at: ./fxsqrt.rsh:9:17:function exp)
 
   (details omitted on repeat)

--- a/py/pygments_reach/__init__.py
+++ b/py/pygments_reach/__init__.py
@@ -95,7 +95,7 @@ class ReachLexer(RegexLexer):
              r'decodeURIComponent|encodeURI|encodeURIComponent|'
              r'Error|eval|isFinite|isNaN|isSafeInteger|parseFloat|parseInt|'
              # The reach ones
-             r'UInt|Reach|App|Fun|Null|Bool|Bytes|Address|Tuple|Participant|ParticipantClass|Data|Digest|Map|deployMode|verifyArithmetic|verifyPerConnector|connectors|ETH|ALGO|'
+             r'UInt|Reach|App|Fun|Null|Bool|Bytes|Address|Tuple|Participant|ParticipantClass|Data|Digest|Map|Set|deployMode|verifyArithmetic|verifyPerConnector|connectors|ETH|ALGO|'
              r'balance|digest|implies|ensure|hasRandom|makeCommitment|checkCommitment|closeTo|lastConsensusTime|'
              r'and|or|add|sub|mul|div|mod|lt|le|gt|ge|lsh|rsh|band|bior|bxor|eq|neq|'
              r'polyEq|polyNeq|typeEq|intEq|ite|typeOf|isType|'

--- a/py/pygments_reach/__init__.py
+++ b/py/pygments_reach/__init__.py
@@ -90,7 +90,7 @@ class ReachLexer(RegexLexer):
              r'package|private|protected|public|short|static|super|synchronized|throws|'
              r'transient|volatile)\b', Keyword.Reserved),
             (r'(true|false|null|NaN|Infinity|undefined)\b', Keyword.Constant),
-            (r'(Array|Boolean|Date|Error|Function|Math|netscape|'
+            (r'(Array|Boolean|Date|Error|Function|Foldable|Math|netscape|'
              r'Number|Object|Packages|RegExp|String|Promise|Proxy|sun|decodeURI|'
              r'decodeURIComponent|encodeURI|encodeURIComponent|'
              r'Error|eval|isFinite|isNaN|isSafeInteger|parseFloat|parseInt|'


### PR DESCRIPTION
* Abstract `Array` stdlib functions that use `reduce` into `Foldable` functions. 
* Make `Array` and `Map` reduction functions point to `Foldable` functions.
* Create `Set` data type.
* Add `Set` functions to standard library.