### PR TITLE
Rename Snake Case Words To Camel Case

### DIFF
--- a/docs-src/ref-programs.scrbl
+++ b/docs-src/ref-programs.scrbl
@@ -708,12 +708,12 @@ A @tech{continue statement} may be written without the preceding identifier upda
 A @tech{continue statement} must be dominated by a @tech{consensus transfer}, which means that the body of a @tech{while statement} must always @reachin{commit();} before calling @reachin{continue;}.
 This restriction may be lifted in future versions of Reach, which will perform termination checking.
 
-@subsubsection{@tt{parallel_reduce}}
+@subsubsection{@tt{parallelReduce}}
 
-@(mint-define! '("parallel_reduce"))
+@(mint-define! '("parallelReduce"))
 @reach{
 const [ keepGoing, as, bs ] =
-  parallel_reduce([ true, 0, 0 ])
+  parallelReduce([ true, 0, 0 ])
   .invariant(balance() == 2 * wager)
   .while(keepGoing)
   .case(Alice, (() => ({
@@ -738,7 +738,7 @@ A @deftech{parallel reduce statement} is written:
 
 @reach{
 const LHS =
-  parallel_reduce(INIT_EXPR)
+  parallelReduce(INIT_EXPR)
   .invariant(INVARIANT_EXPR)
   .while(COND_EXPR)
   .case(PART_EXPR,
@@ -755,20 +755,20 @@ while the @reachin{.case} and @reachin{.timeout} components are like the corresp
 
 The @reachin{.case} component may be repeated many times, provided the @reachin{PART_EXPR}s each evaluate to a unique @tech{participant}, just like in a @reachin{fork} statement.
 
-@subsubsub*section{@tt{.time_remaining}}
+@subsubsub*section{@tt{.timeRemaining}}
 
-When dealing with absolute deadlines in @reachin{parallel_reduce}, there is a common pattern in the
+When dealing with absolute deadlines in @reachin{parallelReduce}, there is a common pattern in the
 @reachin{TIMEOUT_BLOCK} to have participants @reachin{race} to @reachin{publish} and return the accumulator.
-There is a shorthand, @reachin{.time_remaining}, available for this situation:
+There is a shorthand, @reachin{.timeRemaining}, available for this situation:
 
-@(mint-define! '("time_remaining"))
+@(mint-define! '("timeRemaining"))
 @reach{
   const [ timeRemaining, keepGoing ] = makeDeadline(deadline);
   const [ x, y, z ] =
-    parallel_reduce([ 1, 2, 3 ])
+    parallelReduce([ 1, 2, 3 ])
       .while(keepGoing())
       ...
-      .time_remaining(timeRemaining()) }
+      .timeRemaining(timeRemaining()) }
 
 which will expand to:
 
@@ -2035,18 +2035,18 @@ This aides scalability, because it increases the number of times when an operati
 that can be used for dealing with absolute deadlines. It internally determines the end time based off of the deadline
 and the last consensus time—at the time of calling @reachin{makeDeadline}. @tt{timeRemaining} will calculate the difference
 between the end time and the current last consensus time. @tt{keepGoing} determines whether the current last consensus time
-is less than the end time. It is typical to use the two fields for the @tt{while} and @tt{timeout} field of a @reachin{parallel_reduce}
+is less than the end time. It is typical to use the two fields for the @tt{while} and @tt{timeout} field of a @reachin{parallelReduce}
 expression. For example:
 
 @reach{
   const [ timeRemaining, keepGoing ] = makeDeadline(10);
-  const _ = parallel_reduce(...)
+  const _ = parallelReduce(...)
     .invariant(...)
     .while( keepGoing() )
     .case(...)
     .timeout( timeRemaining(), () => { ... }) }
 
-This pattern is so common that it can be abbreviated as @reachin{.time_remaining}.
+This pattern is so common that it can be abbreviated as @reachin{.timeRemaining}.
 
 
 @subsubsection{@tt{implies}}

--- a/docs-src/workshop-fomo-generalized.scrbl
+++ b/docs-src/workshop-fomo-generalized.scrbl
@@ -100,7 +100,7 @@ The body of your application should look something like this:
 
   const [ keepGoing, winners, ticketsSold ] =
     // 2. While the deadline has yet to be reached:
-    parallel_reduce([ true, initialWinners, 0 ])
+    parallelReduce([ true, initialWinners, 0 ])
       .invariant(balance() == ticketsSold * ticketPrice)
       .while(keepGoing)
       .case(
@@ -149,7 +149,7 @@ will transfer @tt{1 ETH} to the Funder, and split the remaining @tt{39 ETH} betw
 
 This program doesn't have many interesting properties to prove
 as assertions, beyond the @tech{token linearity property}. The
-only property of interest is the @reachin{parallel_reduce} invariant
+only property of interest is the @reachin{parallelReduce} invariant
 which states that the balance must be equal to the number of tickets
 sold multiplied by the ticket price.
 

--- a/docs-src/workshop-fomo.scrbl
+++ b/docs-src/workshop-fomo.scrbl
@@ -141,7 +141,7 @@ The body of your application should look something like this:
 
   const [ keepGoing, winner, ticketsSold ] =
     // 2. While the deadline has yet to be reached
-    parallel_reduce([ true, Funder, 0 ])
+    parallelReduce([ true, Funder, 0 ])
       .invariant(balance() == ticketsSold * ticketPrice)
       .while(keepGoing)
       .case(
@@ -167,7 +167,7 @@ The body of your application should look something like this:
   commit();
 }
 
-We use @reachin{parallel_reduce} to allow Buyers to purchase tickets until
+We use @reachin{parallelReduce} to allow Buyers to purchase tickets until
 the deadline passes and accumulate the current winner. We maintain the invariant
 that the balance must be equal to the number of tickets sold multiplied by the
 ticket price.
@@ -176,7 +176,7 @@ ticket price.
 
 This program doesn't have many interesting properties to prove
 as assertions, beyond the @tech{token linearity property}. The
-only property of interest is the @reachin{parallel_reduce} invariant
+only property of interest is the @reachin{parallelReduce} invariant
 which states that the balance must be equal to the number of tickets
 sold multiplied by the ticket price.
 

--- a/docs-src/workshop.scrbl
+++ b/docs-src/workshop.scrbl
@@ -182,7 +182,7 @@ Like @secref["workshop-race"], this demonstrates the deadweight losses associate
 
 In this workshop, we implement a @link["https://en.wikipedia.org/wiki/Plurality_voting"]{two-party winner-takes-all vote}, where a pollster proposes two candidates---Alice and Bob---along with a voting price and a deadline, then a @tech{participant class} of voters each pay and cast their ballot.
 Once the deadline passes, the winning candidates takes the entire pot.
-This workshop introduces effective use of @tech{participant class}es and @reachin{parallel_reduce}.
+This workshop introduces effective use of @tech{participant class}es and @reachin{parallelReduce}.
 
 @(WIP/XXX "popularity-contest")
 
@@ -200,7 +200,7 @@ This workshop uses a @tech{participant class} to represent owners and is a kind 
 
 @(workshop-deps "workshop-popularity-contest")
 
-In this workshop, we implement a @link["https://en.wikipedia.org/wiki/Raffle"]{raffle}, where a sponsor starts a timed raffle and a @tech{participant class} of ticket buyers each buy tickets. This workshop contains two interesting ideas: first, it uses @tech{linear state} through the @reachin{Map} structure; second, it uses an commitment pattern structure to acquire safe randomness from the set of buyers. 
+In this workshop, we implement a @link["https://en.wikipedia.org/wiki/Raffle"]{raffle}, where a sponsor starts a timed raffle and a @tech{participant class} of ticket buyers each buy tickets. This workshop contains two interesting ideas: first, it uses @tech{linear state} through the @reachin{Map} structure; second, it uses an commitment pattern structure to acquire safe randomness from the set of buyers.
 
 @(WIP/XXX "raffle")
 

--- a/examples/abstract-simul/index.rsh
+++ b/examples/abstract-simul/index.rsh
@@ -12,7 +12,7 @@ const Bob = (Move, Outcome) =>
       ({ ...Player(Move, Outcome),
          acceptTerms: Fun([UInt], Null) });
 
-const simultaneous_loop =
+const simultaneousLoop =
       (A, B, DEADLINE, isOutcome, outcome0, stop, combine, divide) => {
         const informTimeout = () => {
           each([A, B], () => {
@@ -76,7 +76,7 @@ export const rps =
     {},
     [Participant('Alice', Alice(UInt, UInt)), Participant('Bob', Bob(UInt, UInt))],
     (A, B) =>
-    simultaneous_loop(
+    simultaneousLoop(
       A, B,
       10, isRPSOutcome, DRAW, ((o) => (o != DRAW)), winner,
       ((o) => (o == A_WINS ? [ 2, 0 ] : [ 0, 2 ]))));
@@ -90,7 +90,7 @@ export const rental =
     {},
     [Participant('Landlord', Alice(Bool, UInt)), Participant('Tenant', Bob(Bool, UInt))],
     (A, B) =>
-    simultaneous_loop(
+    simultaneousLoop(
       A, B,
       10, isRentalOutcome, NONE, ((o) => (o != NONE)),
       ((l, t) => (l && t ? BOTH :

--- a/examples/chicken-parallel/index.rsh
+++ b/examples/chicken-parallel/index.rsh
@@ -38,7 +38,7 @@ export const main =
         .timeout(deadline, () => closeTo(Alice, showOutcome(TIMEOUT)));
 
       const [ keepGoing, as, bs ] =
-        parallel_reduce([ true, 0, 0 ])
+        parallelReduce([ true, 0, 0 ])
         .invariant(balance() == 2 * wager)
         .while(keepGoing)
         .case(Alice, (() => ({

--- a/examples/popularity-contest/index.rsh
+++ b/examples/popularity-contest/index.rsh
@@ -36,7 +36,7 @@ export const main =
       const [ timeRemaining, keepGoing ] = makeDeadline(deadline);
 
       const [ forA, forB ] =
-        parallel_reduce([ 0, 0])
+        parallelReduce([ 0, 0])
         .invariant(balance() == (forA + forB) * ticketPrice)
         .while( keepGoing() )
         .case(Voter, (() => ({

--- a/examples/raffle/index.rsh
+++ b/examples/raffle/index.rsh
@@ -45,7 +45,7 @@ export const main =
 
       const randomsM = new Map(Digest);
       const [ howMany ] =
-        parallel_reduce([ 0 ])
+        parallelReduce([ 0 ])
         .invariant(balance() == ticketPrice * howMany)
         .while( keepBuying() )
         .case( Player, (() => {
@@ -63,7 +63,7 @@ export const main =
             return [ howMany + 1 ];
           })
         )
-        .time_remaining(buyTimeout());
+        .timeRemaining(buyTimeout());
 
       const randomMatches = (who, r) => {
         const rc = randomsM[who];
@@ -77,7 +77,7 @@ export const main =
 
       const ticketsM = new Map(UInt);
       const [ hwinner, howManyReturned ] =
-        parallel_reduce([ 0, 0 ])
+        parallelReduce([ 0, 0 ])
         .invariant(balance() == howMany * ticketPrice)
         .while( keepReturning() && howManyReturned < howMany )
         .case( Player, (() => {
@@ -98,7 +98,7 @@ export const main =
                      howManyReturned + 1 ];
           })
         )
-        .time_remaining(returnTimeout());
+        .timeRemaining(returnTimeout());
       commit();
 
       Sponsor.only(() => { interact.showReturned(howManyReturned); });
@@ -123,18 +123,18 @@ export const main =
       require(sponsortc == digest(sponsort));
 
       const howManyNotReturned = howMany - howManyReturned;
-      const winning_no = (hwinner + (sponsort % howManyReturned)) % howManyReturned;
+      const winningNo = (hwinner + (sponsort % howManyReturned)) % howManyReturned;
       commit();
 
       each([Sponsor, Player], () => {
-        interact.showWinner(winning_no);
+        interact.showWinner(winningNo);
       });
 
       const isWinner = (who) => {
         const tn = ticketsM[who];
         switch ( tn ) {
           case None: return false;
-          case Some: return tn == winning_no;
+          case Some: return tn == winningNo;
         }
       };
 

--- a/examples/rent-seeking/index.rsh
+++ b/examples/rent-seeking/index.rsh
@@ -33,7 +33,7 @@ export const main =
         fromMaybe(bidsM[who], (() => 0), (x => x));
 
       const [ winner, winningBid ] =
-        parallel_reduce([ Sponsor, 0 ])
+        parallelReduce([ Sponsor, 0 ])
         .invariant( balance() == prize + bidsM.sum()
           && balance() == prize + Map.sum(bidsM) )
         .while( keepBidding() )
@@ -65,7 +65,7 @@ export const main =
             }
           })
         )
-        .time_remaining(bidTimeout());
+        .timeRemaining(bidTimeout());
       commit();
 
       Bidder.only(() => {

--- a/examples/rental/index.rsh
+++ b/examples/rental/index.rsh
@@ -11,7 +11,7 @@ const Tenant =
         acceptTerms: Fun([UInt], Null) };
 
 const DEADLINE = 10;
-export const l_first = Reach.App(
+export const lFirst = Reach.App(
   {}, [Participant('Tenant', Tenant), Participant('Landlord', Landlord)], (T, L) => {
 
     L.only(() => {
@@ -56,7 +56,7 @@ export const l_first = Reach.App(
     }
   } );
 
-export const t_first = Reach.App(
+export const tFirst = Reach.App(
   {}, [Participant('Tenant', Tenant), Participant('Landlord', Landlord)], (T, L) => {
 
     L.only(() => {

--- a/examples/ttt/index.rsh
+++ b/examples/ttt/index.rsh
@@ -5,23 +5,23 @@ const ROWS = 3;
 const COLS = 3;
 const CELLS = ROWS * COLS;
 const Board = Array(Bool, CELLS);
-const State = Object({ xs_turn: Bool,
+const State = Object({ xsTurn: Bool,
                        xs: Board,
                        os: Board });
 
-const board_mt =
+const boardMt =
       Array.replicate(9, false);
 
-const ttt_initial = (XisFirst) =>
-      ({ xs_turn: XisFirst,
-         xs: board_mt,
-         os: board_mt });
+const tttInitial = (XisFirst) =>
+      ({ xsTurn: XisFirst,
+         xs: boardMt,
+         os: boardMt });
 
-const cell_both = (st, i) =>
+const cellBoth = (st, i) =>
       (st.xs[i] || st.os[i]);
 
-const marks_all = (st) =>
-      Array.iota(9).map(i => cell_both(st, i));
+const marksAll = (st) =>
+      Array.iota(9).map(i => cellBoth(st, i));
 
 const cell = (r, c) => c + r * COLS;
 
@@ -35,21 +35,21 @@ const seq = (b, r, c, dr, dc) =>
 const row = (b, r) => seq(b, r, 0, 0, op(add, 1));
 const col = (b, c) => seq(b, 0, c, 1, op(add, 0));
 
-const winning_p = (b) =>
+const winningP = (b) =>
       (row(b, 0) || row(b, 1) || row(b, 2) ||
        col(b, 0) || col(b, 1) || col(b, 2) ||
        seq(b, 0, 0, 1, op(add, 1)) ||
        seq(b, 0, 2, 1, op(sub, 1)));
 
-const complete_p = (b) => b.and();
+const completeP = (b) => b.and();
 
-const ttt_done = (st) =>
-      (winning_p(st.xs)
-       || winning_p(st.os)
-       || complete_p(marks_all(st)));
+const tttDone = (st) =>
+      (winningP(st.xs)
+       || winningP(st.os)
+       || completeP(marksAll(st)));
 
 const legalMove = (m) => (0 <= m && m < CELLS);
-const validMove = (st, m) => (! cell_both(st, m));
+const validMove = (st, m) => (! cellBoth(st, m));
 
 function getValidMove(interact, st) {
   const _m = interact.getMove(st);
@@ -60,13 +60,13 @@ function getValidMove(interact, st) {
 function applyMove(st, m) {
   require(legalMove(m));
   require(validMove(st, m));
-  const turn = st.xs_turn;
-  return { xs_turn: ! turn,
+  const turn = st.xsTurn;
+  return { xsTurn: ! turn,
            xs: (turn ? st.xs.set(m, true) : st.xs),
            os: (turn ? st.os : st.os.set(m, true)) }; }
 
-const ttt_winner_is_x = ( st ) => winning_p(st.xs);
-const ttt_winner_is_o = ( st ) => winning_p(st.os);
+const tttWinnerIsX = ( st ) => winningP(st.xs);
+const tttWinnerIsO = ( st ) => winningP(st.os);
 
 // Protocol
 const DELAY = 20; // in blocks
@@ -109,10 +109,10 @@ export const main =
       require(commitA == digest(coinFlipA));
       const XisFirst = (((coinFlipA % 2) + (coinFlipB % 2)) % 2) == 0;
 
-      var state = ttt_initial(XisFirst);
+      var state = tttInitial(XisFirst);
       invariant(balance() == (2 * wagerAmount));
-      while ( ! ttt_done(state) ) {
-        if ( state.xs_turn ) {
+      while ( ! tttDone(state) ) {
+        if ( state.xsTurn ) {
           commit();
 
           A.only(() => {
@@ -132,8 +132,8 @@ export const main =
           continue; } }
 
       const [ toA, toB ] =
-            (ttt_winner_is_x( state ) ? [ 2, 0 ]
-             : (ttt_winner_is_o( state ) ? [ 0, 2 ]
+            (tttWinnerIsX( state ) ? [ 2, 0 ]
+             : (tttWinnerIsO( state ) ? [ 0, 2 ]
                 : [ 1, 1 ]));
       transfer(toA * wagerAmount).to(A);
       transfer(toB * wagerAmount).to(B);

--- a/examples/workshop-fomo-generalized/index.rsh
+++ b/examples/workshop-fomo-generalized/index.rsh
@@ -38,7 +38,7 @@ export const main = Reach.App(
 
     // Until deadline, allow buyers to buy ticket
     const [ keepGoing, winners, ticketsSold ] =
-      parallel_reduce([ true, initialWinners, 0 ])
+      parallelReduce([ true, initialWinners, 0 ])
         .invariant(balance() == ticketsSold * ticketPrice)
         .while(keepGoing)
         .case(

--- a/examples/workshop-fomo/index.rsh
+++ b/examples/workshop-fomo/index.rsh
@@ -42,7 +42,7 @@ export const main = Reach.App(
 
     // Until timeout, allow buyers to buy ticket
     const [ keepGoing, winner, ticketsSold ] =
-      parallel_reduce([ true, Funder, 0 ])
+      parallelReduce([ true, Funder, 0 ])
         .invariant(balance() == ticketsSold * ticketPrice)
         .while(keepGoing)
         .case(

--- a/hs/rsh/stdlib.rsh
+++ b/hs/rsh/stdlib.rsh
@@ -292,10 +292,10 @@ export const fxmul = (x, y) => {
   return fx(x.i.scale * y.i.scale )(r.sign, r.i);
 }
 
-export const fxdiv = (x, y, scale_factor) => {
+export const fxdiv = (x, y, scaleFactor) => {
   const x_ = {
-    i: imul( fxi2int(x), + scale_factor),
-    scale: x.i.scale * scale_factor
+    i: imul( fxi2int(x), + scaleFactor),
+    scale: x.i.scale * scaleFactor
   };
   const r = idiv( x_.i, fxi2int(y) );
   return fx(x_.scale / y.i.scale)(r.sign, r.i);
@@ -343,7 +343,7 @@ export const fxfloor = (x) =>
   ? int(x.sign, fxrescale(x, 1).i.i)
   : int(x.sign, fxrescale(x, 1).i.i + 1);
 
-const fxpow_ratio = (x, numerator, denominator, precision, scalePrecision) => {
+const fxpowRatio = (x, numerator, denominator, precision, scalePrecision) => {
   const xN = fxpowi(x, numerator, precision);
   const fxd = fxint(denominator);
   return Array.iota(precision).reduce(xN, (acc, _) => {
@@ -393,7 +393,7 @@ export const fxpow = (base, power, precision, scalePrecision) => {
     const remain = fxsub(power, fwhole);
     const wholePow = fxpowi(base, whole, precision);
     const [ num, den ] = getNumDenom(remain, precision);
-    return fxmul(wholePow, fxpow_ratio(base, num, den, precision, scalePrecision));
+    return fxmul(wholePow, fxpowRatio(base, num, den, precision, scalePrecision));
   }
 }
 

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -16,6 +16,7 @@ import Reach.AST.DLBase
 import Reach.JSOrphans ()
 import Reach.Texty
 import Reach.Util
+import Reach.Deprecation (Deprecation)
 
 -- SL types are a superset of DL types.
 -- We copy/paste constructors instead of using `ST_Val DLType`
@@ -129,6 +130,7 @@ data SLVal
   | SLV_MapCtor SLType
   | SLV_Map DLMVar
   | SLV_ParticipantConstructor SLParticipantType
+  | SLV_Deprecated Deprecation SLVal
   deriving (Eq, Generic)
 
 instance Pretty SLVal where
@@ -160,6 +162,7 @@ instance Pretty SLVal where
     SLV_Map mv -> "<map: " <> pretty mv <> ">"
     SLV_ParticipantConstructor p -> pretty p
     SLV_Anybody -> "Anybody"
+    SLV_Deprecated d s -> "<deprecated: " <> viaShow d <> ">(" <> pretty s <> ")"
 
 instance Pretty SLParticipantType where
   pretty p =

--- a/hs/src/Reach/Deprecation.hs
+++ b/hs/src/Reach/Deprecation.hs
@@ -9,9 +9,9 @@ import System.IO.Extra (stderr)
 import Data.List.Extra (splitOn)
 import Data.Char (toUpper, toLower)
 
-capitalised :: String -> String
-capitalised [] = []
-capitalised x = toUpper (head x) : map toLower (tail x)
+capitalized :: String -> String
+capitalized [] = []
+capitalized (h:t) = toUpper h : map toLower t
 
 data Deprecation
   = Deprecated_ParticipantTuples SrcLoc
@@ -25,7 +25,10 @@ instance Show Deprecation where
         <> "Please use `Participant(name, interface)` or `ParticipantClass(name, interface)` at "
         <> show at
     Deprecated_SnakeToCamelCase name ->
-      let name' = foldl1 (\ acc w -> acc <> capitalised w) $ splitOn "_" name in
+      let name' = case splitOn "_" name of
+                    []  -> name
+                    h:t -> foldl (\ acc w -> acc <> capitalized w) h t
+      in
       "`" <> name <> "` is now deprecated. It has been renamed from snake case to camel case. Use `" <> name' <> "`"
 
 deprecated_warning :: Deprecation -> IO ()

--- a/hs/src/Reach/Deprecation.hs
+++ b/hs/src/Reach/Deprecation.hs
@@ -1,0 +1,33 @@
+module Reach.Deprecation (
+  Deprecation(..),
+  deprecated_warning
+) where
+
+import Reach.AST.Base (SrcLoc)
+import System.IO (hPutStrLn)
+import System.IO.Extra (stderr)
+import Data.List.Extra (splitOn)
+import Data.Char (toUpper, toLower)
+
+capitalised :: String -> String
+capitalised [] = []
+capitalised x = toUpper (head x) : map toLower (tail x)
+
+data Deprecation
+  = Deprecated_ParticipantTuples SrcLoc
+  | Deprecated_SnakeToCamelCase String
+  deriving (Eq)
+
+instance Show Deprecation where
+  show = \case
+    Deprecated_ParticipantTuples at ->
+      "Declaring Participants with a tuple is now deprecated. "
+        <> "Please use `Participant(name, interface)` or `ParticipantClass(name, interface)` at "
+        <> show at
+    Deprecated_SnakeToCamelCase name ->
+      let name' = foldl1 (\ acc w -> acc <> capitalised w) $ splitOn "_" name in
+      "`" <> name <> "` is now deprecated. It has been renamed from snake case to camel case. Use `" <> name' <> "`"
+
+deprecated_warning :: Deprecation -> IO ()
+deprecated_warning d =
+  hPutStrLn stderr $ "WARNING: " <> show d

--- a/hs/src/Reach/Deprecation.hs
+++ b/hs/src/Reach/Deprecation.hs
@@ -13,6 +13,10 @@ capitalized :: String -> String
 capitalized [] = []
 capitalized (h:t) = toUpper h : map toLower t
 
+camlCase :: String -> [String] -> String
+camlCase _ [] = ""
+camlCase acc (h:t) = acc <> capitalized h <> camlCase acc t
+
 data Deprecation
   = Deprecated_ParticipantTuples SrcLoc
   | Deprecated_SnakeToCamelCase String
@@ -27,7 +31,7 @@ instance Show Deprecation where
     Deprecated_SnakeToCamelCase name ->
       let name' = case splitOn "_" name of
                     []  -> name
-                    h:t -> foldl (\ acc w -> acc <> capitalized w) h t
+                    h:t -> camlCase h t
       in
       "`" <> name <> "` is now deprecated. It has been renamed from snake case to camel case. Use `" <> name' <> "`"
 

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -31,6 +31,7 @@ import Reach.Parser
 import Reach.Util
 import Safe (atMay)
 import Text.ParserCombinators.Parsec.Number (numberValue)
+import Reach.Deprecation
 
 --- New Types
 
@@ -309,6 +310,9 @@ env_lookup :: LookupCtx -> SLVar -> SLEnv -> App SLSSVal
 env_lookup _ "_" _ = expect_ $ Err_Eval_LookupUnderscore
 env_lookup ctx x env =
   case M.lookup x env of
+    Just sv@(SLSSVal { sss_val = SLV_Deprecated d v }) -> do
+          liftIO $ deprecated_warning d
+          return $ sv { sss_val = v }
     Just v -> return $ v
     Nothing ->
       expect_ $ Err_Eval_UnboundId ctx x $ M.keys $ M.filter (not . isKwd) env
@@ -364,7 +368,8 @@ base_env =
     , ("wait", SLV_Form SLForm_wait)
     , ("race", SLV_Prim SLPrim_race)
     , ("fork", SLV_Form SLForm_fork)
-    , ("parallel_reduce", SLV_Form SLForm_parallel_reduce)
+    , ("parallelReduce", SLV_Form SLForm_parallel_reduce)
+    , ("parallel_reduce", SLV_Deprecated (Deprecated_SnakeToCamelCase "parallel_reduce") $ SLV_Form SLForm_parallel_reduce)
     , ("Map", SLV_Prim SLPrim_Map)
     , ("Anybody", SLV_Anybody)
     , ("Participant", SLV_Prim SLPrim_Participant)
@@ -452,6 +457,7 @@ slToDL = \case
   SLV_MapCtor {} -> no
   SLV_Map {} -> no
   SLV_ParticipantConstructor {} -> no
+  SLV_Deprecated {} -> no
   where
     yes = return . Just
     no = return Nothing
@@ -833,7 +839,7 @@ evalAsEnv obj = case obj of
           <> gom "while" PRM_While pr_mwhile
           <> go "case" PRM_Case
           <> gom "timeout" PRM_Timeout pr_mtime
-          <> gom "time_remaining" PRM_TimeRemaining pr_mtime
+          <> gom "timeRemaining" PRM_TimeRemaining pr_mtime
     where
       gom key mode me =
         case me of

--- a/hs/src/Reach/Eval/Error.hs
+++ b/hs/src/Reach/Eval/Error.hs
@@ -2,8 +2,6 @@ module Reach.Eval.Error
   ( EvalError (..)
   , LookupCtx (..)
   , didYouMean
-  , deprecated_warning
-  , Deprecation (..)
   )
 where
 
@@ -21,7 +19,6 @@ import Reach.Eval.Types
 import Reach.Texty (pretty)
 import Reach.Util
 import Reach.Version
-import System.IO
 import Text.EditDistance (defaultEditCosts, restrictedDamerauLevenshteinDistance)
 
 data LookupCtx
@@ -457,7 +454,7 @@ instance Show EvalError where
     Err_ParallelReduceIncomplete lab ->
       "parallel reduce incomplete: " <> lab
     Err_ParallelReduceTimeRemainingArgs args ->
-      "The `time_remaining` branch of `parallel_reduce` expects 1 argument, but received " <> show (length args)
+      "The `timeRemaining` branch of `parallelReduce` expects 1 argument, but received " <> show (length args)
     Err_Type_None val ->
       "Value cannot exist at runtime: " <> show (pretty val)
     Err_Type_NotDT t ->
@@ -475,17 +472,3 @@ instance Show EvalError where
     where
       displayPrim = drop (length ("SLPrim_" :: String)) . conNameOf
 
-data Deprecation
-  = Deprecated_ParticipantTuples SrcLoc
-  deriving (Eq)
-
-instance Show Deprecation where
-  show = \case
-    Deprecated_ParticipantTuples at ->
-      "Declaring Participants with a tuple is now deprecated. "
-        <> "Please use `Participant(name, interface)` or `ParticipantClass(name, interface)` at "
-        <> show at
-
-deprecated_warning :: Deprecation -> IO ()
-deprecated_warning d =
-  hPutStrLn stderr $ "WARNING: " <> show d

--- a/hs/test-examples/features/fork_exp.rsh
+++ b/hs/test-examples/features/fork_exp.rsh
@@ -42,43 +42,43 @@ export const main =
       while ( keepGoing ) {
         commit();
 
-        const F = Data({F_Alice: Null, F_Bob: Null});
+        const F = Data({fAlice: Null, fBob: Null});
         Alice.only(() => {
-          const f_Alice = () => ({
+          const fAlice = () => ({
             when: declassify(interact.keepGoing()) });
-          const f_res0 = f_Alice();
-          const f_res1 = Object.setIfUnset(f_res0, "msg", null);
-          const f_res2 = Object.setIfUnset(f_res1, "when", true)
-          const f_res3 = Object.setIfUnset(f_res2, "pay", 0);
-          const f_res = f_res3;
-          const f_msg = F.F_Alice(f_res.msg);
-          const f_when = f_res.when;
-          const f_pay = f_res.pay; });
+          const fRes0 = fAlice();
+          const fRes1 = Object.setIfUnset(fRes0, "msg", null);
+          const fRes2 = Object.setIfUnset(fRes1, "when", true)
+          const fRes3 = Object.setIfUnset(fRes2, "pay", 0);
+          const fRes = fRes3;
+          const fMsg = F.fAlice(fRes.msg);
+          const fWhen = fRes.when;
+          const fPay = fRes.pay; });
         Bob.only(() => {
-          const f_Bob = () => ({
+          const fBob = () => ({
             when: declassify(interact.keepGoing()) });
-          const f_res0 = f_Bob();
-          const f_res1 = Object.setIfUnset(f_res0, "msg", null);
-          const f_res2 = Object.setIfUnset(f_res1, "when", true)
-          const f_res3 = Object.setIfUnset(f_res2, "pay", 0);
-          const f_res = f_res3;
-          const f_msg = F.F_Bob(f_res.msg);
-          const f_when = f_res.when;
-          const f_pay = f_res.pay; });
+          const fRes0 = fBob();
+          const fRes1 = Object.setIfUnset(fRes0, "msg", null);
+          const fRes2 = Object.setIfUnset(fRes1, "when", true)
+          const fRes3 = Object.setIfUnset(fRes2, "pay", 0);
+          const fRes = fRes3;
+          const fMsg = F.fBob(fRes.msg);
+          const fWhen = fRes.when;
+          const fPay = fRes.pay; });
 
-        Anybody.publish(f_msg, f_pay).when(f_when).pay(f_pay)
+        Anybody.publish(fMsg, fPay).when(fWhen).pay(fPay)
           .timeout(deadline, () => {
             showOutcome(TIMEOUT)();
             Anybody.publish();
             keepGoing = false;
             continue; });
-        require(f_msg.match({F_Alice: (() => this == Alice),
-                             F_Bob  : (() => this == Bob  ) }));
-        switch ( f_msg ) {
-          case F_Alice: {
+        require(fMsg.match({fAlice: (() => this == Alice),
+                             fBob  : (() => this == Bob  ) }));
+        switch ( fMsg ) {
+          case fAlice: {
             assert(this == Alice);
-            const f_hadpay = false; // <-- we know this by inspecting the object statically
-            require(f_hadpay || f_pay == 0);
+            const fHadPay = false; // <-- we know this by inspecting the object statically
+            require(fHadPay || fPay == 0);
             // <code that Alice wrote>
             each([Alice, Bob], () => {
               interact.roundWinnerWas(true); });
@@ -86,10 +86,10 @@ export const main =
             continue;
             // </>
           }
-          case F_Bob: {
+          case fBob: {
             assert(this == Bob);
-            const f_hadpay = false; // <-- we know this by inspecting the object statically
-            require(f_hadpay || f_pay == 0);
+            const fHadPay = false; // <-- we know this by inspecting the object statically
+            require(fHadPay || fPay == 0);
             // <code that Bob wrote>
             each([Alice, Bob], () => {
               interact.roundWinnerWas(false); });

--- a/hs/test-examples/features/objects.rsh
+++ b/hs/test-examples/features/objects.rsh
@@ -9,13 +9,13 @@ export const main = Reach.App(
     const obj1 = {x: 1};
 
     // object field reference .
-    const obj1_x0 = obj1.x;
-    assert(obj1_x0 == 1);
+    const obj1X0 = obj1.x;
+    assert(obj1X0 == 1);
 
     // TODO: object field ref []
     // "Invalid array index"
-    // const obj1_x1 = obj1["x"];
-    // assert(obj1_x1 == 1);
+    // const obj1X1 = obj1["x"];
+    // assert(obj1X1 == 1);
 
     // object str field
     const obj2 = {'x': 1};

--- a/hs/test-examples/features/objects_lifted.rsh
+++ b/hs/test-examples/features/objects_lifted.rsh
@@ -21,8 +21,8 @@ export const main = Reach.App(
 
     // TODO: object field ref []
     // "Invalid array index"
-    // const obj1_x1 = obj1["x"];
-    // assert(obj1_x1 == 1);
+    // const obj1X1 = obj1["x"];
+    // assert(obj1X1 == 1);
 
     // object splice, keys can be added
     const obj2 = {...obj0, y: 'y_val'};

--- a/hs/test-examples/features/parallel_reduce_deprecated.rsh
+++ b/hs/test-examples/features/parallel_reduce_deprecated.rsh
@@ -1,0 +1,25 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [Participant('A', {})],
+    (A) => {
+      A.publish();
+
+      const [ x ] =
+        parallel_reduce([ 0 ])
+          .invariant(balance() == balance())
+          .while(true)
+          .case(A,
+            (() => ({
+              when: true })),
+            (() => {
+              return [x + 1];}))
+          .timeout(1, () => {
+            Anybody.publish();
+            return [ x ]; });
+
+      transfer(balance()).to(A);
+      commit();
+    });

--- a/hs/test-examples/features/parallel_reduce_deprecated.txt
+++ b/hs/test-examples/features/parallel_reduce_deprecated.txt
@@ -1,0 +1,7 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+  Verifying when ONLY "A" is honest
+Checked 25 theorems; No failures!
+WARNING: `parallel_reduce` is now deprecated. It has been renamed from snake case to camel case. Use `parallelReduce`

--- a/hs/test-examples/nl-eval-errors/Err_ParallelReduceIncomplete.rsh
+++ b/hs/test-examples/nl-eval-errors/Err_ParallelReduceIncomplete.rsh
@@ -6,5 +6,5 @@ export const main =
     [Participant('A', {})],
     (A) => {
       const a =
-        parallel_reduce(null);
+        parallelReduce(null);
     });

--- a/hs/test-examples/nl-eval-errors/Err_ParallelReduceIncomplete.txt
+++ b/hs/test-examples/nl-eval-errors/Err_ParallelReduceIncomplete.txt
@@ -1,1 +1,1 @@
-reachc: error: ./Err_ParallelReduceIncomplete.rsh:9:24:application: parallel reduce incomplete: missing invariant
+reachc: error: ./Err_ParallelReduceIncomplete.rsh:9:23:application: parallel reduce incomplete: missing invariant

--- a/hs/test-examples/nl-eval-errors/Err_ParallelReduceTimeRemainingArgs.rsh
+++ b/hs/test-examples/nl-eval-errors/Err_ParallelReduceTimeRemainingArgs.rsh
@@ -6,7 +6,7 @@ export const main =
     [Participant('A', {})],
     (A) => {
       const [ x ] =
-        parallel_reduce([ 0 ])
+        parallelReduce([ 0 ])
           .invariant(balance() == balance())
           .while(true)
           .case(A,
@@ -15,5 +15,5 @@ export const main =
               return [ x + 1]
             })
           )
-         .time_remaining(1, () => {});
+         .timeRemaining(1, () => {});
     });

--- a/hs/test-examples/nl-eval-errors/Err_ParallelReduceTimeRemainingArgs.txt
+++ b/hs/test-examples/nl-eval-errors/Err_ParallelReduceTimeRemainingArgs.txt
@@ -1,1 +1,1 @@
-reachc: error: ./Err_ParallelReduceTimeRemainingArgs.rsh:9:24:application: The `time_remaining` branch of `parallel_reduce` expects 1 argument, but received 2
+reachc: error: ./Err_ParallelReduceTimeRemainingArgs.rsh:9:23:application: The `timeRemaining` branch of `parallelReduce` expects 1 argument, but received 2

--- a/hs/test-examples/non-features/foreign_to_reach.rsh
+++ b/hs/test-examples/non-features/foreign_to_reach.rsh
@@ -12,7 +12,7 @@ export const main =
       A.publish().pay(1).exposeAs("initialPay");
 
       const [ keepGoing ] =
-        parallel_reduce([ true ])
+        parallelReduce([ true ])
           .while(keepGoing)
           .invariant(true)
           .case(A,

--- a/hs/test-examples/non-features/pay_multiple_currency.rsh
+++ b/hs/test-examples/non-features/pay_multiple_currency.rsh
@@ -1,6 +1,6 @@
 'reach 0.1';
 
-// Allow multiple payments/currencies in parallel_reduce
+// Allow multiple payments/currencies in parallelReduce
 // Depends on: non-network_token.rsh
 
 const N = 2;
@@ -26,7 +26,7 @@ export const main =
       const consensusE = (amtIns) => { return [ false, amtIns ]; };
 
       const [ keepGoing, amtIns ] =
-        parallel_reduce([ true, Array.replicate(N, 0) ])
+        parallelReduce([ true, Array.replicate(N, 0) ])
           .while(keepGoing)
           .invariant(true)
           .case(A, publishE, payE, consensusE)

--- a/non-examples/amm/README.md
+++ b/non-examples/amm/README.md
@@ -39,7 +39,7 @@ The structure is something like:
 Admin.publish(params);
 
 const [ alive, pool, market ] =
-  parallel_reduce( [ true, mempty, mempty ] )
+  parallelReduce( [ true, mempty, mempty ] )
   .while( alive )
   .case(Admin,
     /* maybe decide to close the pool */)

--- a/non-examples/amm/bal.rsh
+++ b/non-examples/amm/bal.rsh
@@ -153,7 +153,7 @@ export const main =
       };
 
       const [ alive, pool, market ] =
-        parallel_reduce([ true, initialPool, initialMarket ])
+        parallelReduce([ true, initialPool, initialMarket ])
           .invariant(alive || pool.totalSupply() > 0)
           .while(true)
           .define(() => {

--- a/non-examples/amm/index.rsh
+++ b/non-examples/amm/index.rsh
@@ -156,7 +156,7 @@ export const main =
 
       // XXX Feature: Export some variables
       const [ alive, pool, market ] =
-        parallel_reduce([ true, initialPool, initialMarket ])
+        parallelReduce([ true, initialPool, initialMarket ])
           .while(alive || pool.totalSupply() > 0)
           .invariant(true)
           // XXX Feature: `define` will allow definitions

--- a/non-examples/anti/rps_double.rsh
+++ b/non-examples/anti/rps_double.rsh
@@ -22,7 +22,7 @@ function whoWinsBestOfThree(winCountA, winCountB, lastOutcome) {
 }
 
 
-function do_round_1(a_1, b_1, wagerAmount_1, escrowAmount_1) {
+function doRound1(a_1, b_1, wagerAmount_1, escrowAmount_1) {
   var [ count_1, outcome_1 ] = [ 0, DRAW ];
   invariant((balance() == ((2 * wagerAmount_1) + escrowAmount_1))
             && isOutcome(outcome_1));
@@ -63,12 +63,12 @@ function do_round_1(a_1, b_1, wagerAmount_1, escrowAmount_1) {
         continue; });
     checkCommitment(commitA_1, saltA_1, handA_1);
     require(isHand(handA_1));
-    const this_outcome_1 = winner(handA_1, handB_1);
-    assert(implies(this_outcome_1 == A_WINS, isHand(handA_1)));
-    assert(implies(this_outcome_1 == B_WINS, isHand(handB_1)));
-    fair_game(handA_1, handB_1, this_outcome_1);
+    const thisOutcome1 = winner(handA_1, handB_1);
+    assert(implies(thisOutcome1 == A_WINS, isHand(handA_1)));
+    assert(implies(thisOutcome1 == B_WINS, isHand(handB_1)));
+    fairGame(handA_1, handB_1, thisOutcome1);
 
-    [ count_1, outcome_1 ] = [ 1 + count_1, this_outcome_1 ];
+    [ count_1, outcome_1 ] = [ 1 + count_1, thisOutcome1 ];
     continue; }
 
   return [ count_1, outcome_1 ]
@@ -97,7 +97,7 @@ function main() {
   // var [ winCountA, winCountB, roundCount, anyQuitters, lastOutcome ] = [ 0, 0, 0, false, A_WINS ];
   // invariant(balance() == 2 * wagerAmount + escrowAmount);
   // while ( winCountA < 2 && winCountB < 2 && !anyQuitters ) {
-  //   const [ count, outcome ] = do_round_1(A, B, wagerAmount, escrowAmount);
+  //   const [ count, outcome ] = doRound1(A, B, wagerAmount, escrowAmount);
   //   assert(outcome != DRAW);
   //   assert(isOutcome(outcome));
 
@@ -157,15 +157,15 @@ function main() {
           continue; });
       checkCommitment(commitA_1, saltA_1, handA_1);
       require(isHand(handA_1));
-      const this_outcome_1 = winner(handA_1, handB_1);
-      assert(implies(this_outcome_1 == A_WINS, isHand(handA_1)));
-      assert(implies(this_outcome_1 == B_WINS, isHand(handB_1)));
-      fair_game(handA_1, handB_1, this_outcome_1);
+      const thisOutcome1 = winner(handA_1, handB_1);
+      assert(implies(thisOutcome1 == A_WINS, isHand(handA_1)));
+      assert(implies(thisOutcome1 == B_WINS, isHand(handB_1)));
+      fairGame(handA_1, handB_1, thisOutcome1);
 
-      [ count_1, outcome_1 ] = [ 1 + count_1, this_outcome_1 ];
+      [ count_1, outcome_1 ] = [ 1 + count_1, thisOutcome1 ];
       continue; }
 
-    
+
     [ i, count, outcome ] = [ i + 1, count + count_1, outcome_1 ];
     continue;
   }

--- a/non-examples/anti/rps_double_break_invariant.rsh
+++ b/non-examples/anti/rps_double_break_invariant.rsh
@@ -24,7 +24,7 @@ function whoWinsBestOfThree(winCountA, winCountB, lastOutcome) {
 }
 
 
-function do_round_1(a_1, b_1, wagerAmount_1, escrowAmount_1) {
+function doRound1(a_1, b_1, wagerAmount_1, escrowAmount_1) {
   var [ count_1, outcome_1 ] = [ 0, DRAW ];
   invariant((balance() == ((2 * wagerAmount_1) + escrowAmount_1))
             && isOutcome(outcome_1));
@@ -65,12 +65,12 @@ function do_round_1(a_1, b_1, wagerAmount_1, escrowAmount_1) {
         continue; });
     checkCommitment(commitA_1, saltA_1, handA_1);
     require(isHand(handA_1));
-    const this_outcome_1 = winner(handA_1, handB_1);
-    assert(implies(this_outcome_1 == A_WINS, isHand(handA_1)));
-    assert(implies(this_outcome_1 == B_WINS, isHand(handB_1)));
-    fair_game(handA_1, handB_1, this_outcome_1);
+    const thisOutcome1 = winner(handA_1, handB_1);
+    assert(implies(thisOutcome1 == A_WINS, isHand(handA_1)));
+    assert(implies(thisOutcome1 == B_WINS, isHand(handB_1)));
+    fairGame(handA_1, handB_1, thisOutcome1);
 
-    [ count_1, outcome_1 ] = [ 1 + count_1, this_outcome_1 ];
+    [ count_1, outcome_1 ] = [ 1 + count_1, thisOutcome1 ];
     continue; }
 
   return [ count_1, outcome_1 ]
@@ -81,7 +81,7 @@ function bestOfThree(a, b, wagerAmount, escrowAmount, doubleOrNothing) {
   var [ winCountA, winCountB, roundCount, anyQuitters, lastOutcome ] = [ 0, 0, 0, false, A_WINS ];
   invariant(balance() == expectedBalance);
   while ( winCountA < 2 && winCountB < 2 && !anyQuitters ) {
-    const [ count, outcome ] = do_round_1(a, b, wagerAmount, escrowAmount);
+    const [ count, outcome ] = doRound1(a, b, wagerAmount, escrowAmount);
     assert(isOutcome(outcome));
     assert(outcome != DRAW);
 

--- a/non-examples/anti/rps_double_isHand_fail.rsh
+++ b/non-examples/anti/rps_double_isHand_fail.rsh
@@ -24,7 +24,7 @@ function whoWinsBestOfThree(winCountA, winCountB, lastOutcome) {
 }
 
 
-function do_round_1(a_1, b_1, wagerAmount_1, escrowAmount_1) {
+function doRound1(a_1, b_1, wagerAmount_1, escrowAmount_1) {
   var [ count_1, outcome_1 ] = [ 0, DRAW ];
   invariant((balance() == ((2 * wagerAmount_1) + escrowAmount_1))
             && isOutcome(outcome_1));
@@ -65,12 +65,12 @@ function do_round_1(a_1, b_1, wagerAmount_1, escrowAmount_1) {
         continue; });
     checkCommitment(commitA_1, saltA_1, handA_1);
     require(isHand(handA_1));
-    const this_outcome_1 = winner(handA_1, handB_1);
-    assert(implies(this_outcome_1 == A_WINS, isHand(handA_1)));
-    assert(implies(this_outcome_1 == B_WINS, isHand(handB_1)));
-    fair_game(handA_1, handB_1, this_outcome_1);
+    const thisOutcome1 = winner(handA_1, handB_1);
+    assert(implies(thisOutcome1 == A_WINS, isHand(handA_1)));
+    assert(implies(thisOutcome1 == B_WINS, isHand(handB_1)));
+    fairGame(handA_1, handB_1, thisOutcome1);
 
-    [ count_1, outcome_1 ] = [ 1 + count_1, this_outcome_1 ];
+    [ count_1, outcome_1 ] = [ 1 + count_1, thisOutcome1 ];
     continue; }
 
   return [ count_1, outcome_1 ]
@@ -80,7 +80,7 @@ function bestOfThree(a, b, wagerAmount, escrowAmount, doubleOrNothing) {
   var [ winCountA, winCountB, roundCount, anyQuitters, lastOutcome ] = [ 0, 0, 0, false, A_WINS ];
   invariant(balance() == (doubleOrNothing ? 3 : 2) * wagerAmount + escrowAmount);
   while ( winCountA < 2 && winCountB < 2 && !anyQuitters ) {
-    const [ count, outcome ] = do_round_1(a, b, wagerAmount, escrowAmount);
+    const [ count, outcome ] = doRound1(a, b, wagerAmount, escrowAmount);
     assert(isOutcome(outcome));
     assert(outcome != DRAW);
 

--- a/non-examples/auction/index.rsh
+++ b/non-examples/auction/index.rsh
@@ -43,7 +43,7 @@ function main() {
       const endorsement = sign(Seller, Buyer); });
     Seller.publish(endorsement)
       .timeout(DELAY, closeTo(Buyer, false));
-    require(check_sign(endorsement, Seller, Buyer));
+    require(checkSign(endorsement, Seller, Buyer));
     transfer(bid).to(Seller);
     call(product).go(endorsement, Buyer);
     commit();

--- a/py/pygments_reach/__init__.py
+++ b/py/pygments_reach/__init__.py
@@ -78,7 +78,7 @@ class ReachLexer(RegexLexer):
             (r'(for|in|while|do|break|return|continue|match|switch|case|default|if|else|'
              r'throw|try|catch|finally|new|delete|typeof|instanceof|void|yield|'
              # Reach ones
-             r'interact|commit|exit|only|each|race|fork|parallel_reduce|when|timeout|time_remaining|publish|pay|declassify|transfer|'
+             r'interact|commit|exit|only|each|race|fork|parallelReduce|when|timeout|timeRemaining|publish|pay|declassify|transfer|'
              r'invariant|assert|require|assume|possible|unknowable|forall|'
              r'this|of)\b', Keyword, 'slashstartsregex'),
             (r'(var|let|with|function|'


### PR DESCRIPTION
* Add a deprecation warning to `parallel_reduce` that points to `parallelReduce`. 
* `fxpow_ratio` isn't exported from the stdlib but it has been renamed to `fxpowRatio`.
* Rename `.time_remaining` to `.timeRemaining`, I _think_ it's safe to just rename this one as well since it's a week old?
* Rename variable names in examples to camel case.