### PR TITLE
[Do Not Merge]: Track Unused Variables

### DIFF
--- a/examples/chicken-fork/index.rsh
+++ b/examples/chicken-fork/index.rsh
@@ -2,6 +2,8 @@
 
 const [ isOutcome, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
 
+void isOutcome;
+
 const Common = {
   showOutcome: Fun([UInt], Null),
   keepGoing: Fun([], Bool),

--- a/examples/chicken-parallel/index.rsh
+++ b/examples/chicken-parallel/index.rsh
@@ -2,6 +2,8 @@
 
 const [ isOutcome, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
 
+void isOutcome;
+
 const Common = {
   showOutcome: Fun([UInt], Null),
   keepGoing: Fun([], Bool),

--- a/examples/chicken-race/index.rsh
+++ b/examples/chicken-race/index.rsh
@@ -2,6 +2,8 @@
 
 const [ isOutcome, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
 
+void isOutcome;
+
 const Common = {
   showOutcome: Fun([UInt], Null),
   keepGoing: Fun([], Bool),

--- a/examples/maybe-send/index.rsh
+++ b/examples/maybe-send/index.rsh
@@ -14,7 +14,7 @@ export const main = Reach.App(
       const x = declassify(interact.getX());
     });
     Alice.publish(x);
-    const [i, mx0] = [0, Maybe(UInt).None()];
+    const [_, mx0] = [0, Maybe(UInt).None()];
     commit();
 
     Bob.only(() => {

--- a/examples/multisig/index.rsh
+++ b/examples/multisig/index.rsh
@@ -17,8 +17,6 @@
 
 */
 
-const DELAY = 10; // in blocks
-
 export const main =
   Reach.App(
     {},

--- a/examples/nim/index-abstract.rsh
+++ b/examples/nim/index-abstract.rsh
@@ -51,7 +51,7 @@ export const main =
       const AisFirst = (((coinFlipA % 2) + (coinFlipB % 2)) % 2) == 0;
 
       var [ AsTurn, heaps ] =
-        [ AisFirst, Array.iota(howMany).map(x => initialHeap) ];
+        [ AisFirst, Array.iota(howMany).map(_ => initialHeap) ];
       invariant(balance() == (2 * wagerAmount));
       while ( heaps.reduce(0, add) > 0 ) {
         const doMove = (now, next) => {

--- a/examples/popularity-contest/index.rsh
+++ b/examples/popularity-contest/index.rsh
@@ -2,6 +2,8 @@
 
 const [ isOutcome, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
 
+void isOutcome;
+
 const Common = {
   showOutcome: Fun([UInt, UInt, UInt], Null),
 };

--- a/examples/race/index.rsh
+++ b/examples/race/index.rsh
@@ -2,6 +2,8 @@
 
 const [ isOutcome, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
 
+void isOutcome;
+
 const Common = {
   showOutcome: Fun([UInt], Null),
 };

--- a/examples/raffle/index.rsh
+++ b/examples/raffle/index.rsh
@@ -122,7 +122,6 @@ export const main =
       Sponsor.publish(sponsort);
       require(sponsortc == digest(sponsort));
 
-      const howManyNotReturned = howMany - howManyReturned;
       const winningNo = (hwinner + (sponsort % howManyReturned)) % howManyReturned;
       commit();
 

--- a/examples/rent-seeking/index.rsh
+++ b/examples/rent-seeking/index.rsh
@@ -41,7 +41,6 @@ export const main =
             const previousBid = getBid(this);
             const addl =
               declassify(interact.getBid(prize, winningBid, previousBid));
-            const newBid = previousBid + addl;
             return { msg: addl, when: addl != 0 };
           }),
           ((addl) => addl),

--- a/examples/timeoutception/index.rsh
+++ b/examples/timeoutception/index.rsh
@@ -21,6 +21,8 @@ function gogo(who, kTim) {
   return () => go(who, kTim);
 }
 
+void gogo;
+
 function thrice(f, x) {
   return f(f(f(x)));
 }

--- a/examples/ttt/index.rsh
+++ b/examples/ttt/index.rsh
@@ -69,7 +69,6 @@ const tttWinnerIsX = ( st ) => winningP(st.xs);
 const tttWinnerIsO = ( st ) => winningP(st.os);
 
 // Protocol
-const DELAY = 20; // in blocks
 
 const Player =
       { ...hasRandom,

--- a/examples/tut-4/index.rsh
+++ b/examples/tut-4/index.rsh
@@ -3,6 +3,8 @@
 const [ isHand, ROCK, PAPER, SCISSORS ] = makeEnum(3);
 const [ isOutcome, B_WINS, DRAW, A_WINS ] = makeEnum(3);
 
+void [ isHand, SCISSORS ];
+
 const winner = (handA, handB) =>
       ((handA + (4 - handB)) % 3);
 

--- a/examples/tut-5/index.rsh
+++ b/examples/tut-5/index.rsh
@@ -3,6 +3,8 @@
 const [ isHand, ROCK, PAPER, SCISSORS ] = makeEnum(3);
 const [ isOutcome, B_WINS, DRAW, A_WINS ] = makeEnum(3);
 
+void [ isHand, SCISSORS ];
+
 const winner = (handA, handB) =>
       ((handA + (4 - handB)) % 3);
 

--- a/examples/tut-6-array/index.rsh
+++ b/examples/tut-6-array/index.rsh
@@ -3,6 +3,8 @@
 const [ isHand, ROCK, PAPER, SCISSORS ] = makeEnum(3);
 const [ isOutcome, B_WINS, DRAW, A_WINS ] = makeEnum(3);
 
+void [isHand, SCISSORS];
+
 const winner = (handA, handB) =>
       ((handA + (4 - handB)) % 3);
 

--- a/examples/tut-6-rpc/server/index.rsh
+++ b/examples/tut-6-rpc/server/index.rsh
@@ -3,6 +3,8 @@
 const [ isHand, ROCK, PAPER, SCISSORS ] = makeEnum(3);
 const [ isOutcome, B_WINS, DRAW, A_WINS ] = makeEnum(3);
 
+void [isHand, SCISSORS];
+
 const winner = (handA, handB) =>
       ((handA + (4 - handB)) % 3);
 

--- a/examples/tut-6/index.rsh
+++ b/examples/tut-6/index.rsh
@@ -3,6 +3,8 @@
 const [ isHand, ROCK, PAPER, SCISSORS ] = makeEnum(3);
 const [ isOutcome, B_WINS, DRAW, A_WINS ] = makeEnum(3);
 
+void [isHand, SCISSORS];
+
 const winner = (handA, handB) =>
       ((handA + (4 - handB)) % 3);
 

--- a/examples/tut-7/index.rsh
+++ b/examples/tut-7/index.rsh
@@ -3,6 +3,8 @@
 const [ isHand, ROCK, PAPER, SCISSORS ] = makeEnum(3);
 const [ isOutcome, B_WINS, DRAW, A_WINS ] = makeEnum(3);
 
+void [isHand, SCISSORS];
+
 const winner = (handA, handB) =>
       ((handA + (4 - handB)) % 3);
 

--- a/examples/tut-8/index.rsh
+++ b/examples/tut-8/index.rsh
@@ -3,6 +3,8 @@
 const [ isHand, ROCK, PAPER, SCISSORS ] = makeEnum(3);
 const [ isOutcome, B_WINS, DRAW, A_WINS ] = makeEnum(3);
 
+void [isHand, SCISSORS];
+
 const winner = (handA, handB) =>
       ((handA + (4 - handB)) % 3);
 

--- a/examples/workshop-trust-fund/index.rsh
+++ b/examples/workshop-trust-fund/index.rsh
@@ -56,4 +56,4 @@ export const main =
             Funder,
             { deadline: dormant,
               after: () =>
-              giveChance(Bystander, false) }) }); } );
+              giveChance(Bystander, None); } );

--- a/hs/rsh/stdlib.rsh
+++ b/hs/rsh/stdlib.rsh
@@ -328,7 +328,7 @@ export const fxpowi = (base, power, precision) => {
   const r = fxpowui(base, power.i, precision);
   return (power.sign)
     ? r
-    : fxdiv(1, r, base.scale);
+    : fxdiv(+1.0, r, base.i.scale);
 }
 
 export const fxmod = (x, y) => {

--- a/hs/src/Reach/AST/DLBase.hs
+++ b/hs/src/Reach/AST/DLBase.hs
@@ -147,6 +147,9 @@ litTypeOf = \case
 data DLVar = DLVar SrcLoc (Maybe (SrcLoc, SLVar)) DLType Int
   deriving (Generic)
 
+instance SrcLocOf DLVar where
+  srclocOf (DLVar a _ _ _) = a
+
 instance Eq DLVar where
   (DLVar _ _ _ x) == (DLVar _ _ _ y) = x == y
 

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -16,7 +16,7 @@ import Reach.AST.DLBase
 import Reach.JSOrphans ()
 import Reach.Texty
 import Reach.Util
-import Reach.Deprecation (Deprecation)
+import Reach.Warning (Deprecation)
 
 -- SL types are a superset of DL types.
 -- We copy/paste constructors instead of using `ST_Val DLType`
@@ -398,7 +398,7 @@ data SLSSVal = SLSSVal
   deriving (Eq, Generic)
 
 instance Pretty SLSSVal where
-  pretty (SLSSVal _ level val) = pretty (level, val) -- <> "@" <> pretty at
+  pretty (SLSSVal at level val) = viaShow at <> pretty (level, val) -- <> "@" <> pretty at
   -- TODO: incorporate srcloc in pretty?
 
 sss_restrict :: SecurityLevel -> SLSSVal -> SLSSVal

--- a/hs/src/Reach/Eval.hs
+++ b/hs/src/Reach/Eval.hs
@@ -22,6 +22,7 @@ import Reach.Eval.Types
 import Reach.JSUtil
 import Reach.Parser
 import Reach.Util
+import Reach.Warning
 
 app_default_opts :: Counter -> [T.Text] -> DLOpts
 app_default_opts idxr cns =
@@ -189,10 +190,13 @@ compileBundle cns jsb main = do
   e_lifts <- newIORef mempty
   me_id <- newCounter 0
   me_ms <- newIORef mempty
+  e_unused_variables <- newIORef mempty
   let e_mape = MapEnv {..}
   mkprog <-
     flip runReaderT (Env {..}) $
       compileBundle_ cns jsb main
   ms' <- readIORef me_ms
   final <- readIORef e_lifts
+  unused_vars <- readIORef e_unused_variables
+  forM_ unused_vars $  emitWarning . uncurry W_UnusedVariable
   return $ mkprog ms' final

--- a/hs/src/Reach/Warning.hs
+++ b/hs/src/Reach/Warning.hs
@@ -1,6 +1,7 @@
-module Reach.Deprecation (
+module Reach.Warning (
+  Warning(..),
   Deprecation(..),
-  deprecated_warning
+  emitWarning
 ) where
 
 import Reach.AST.Base (SrcLoc)
@@ -18,23 +19,34 @@ camlCase _ [] = ""
 camlCase acc (h:t) = acc <> capitalized h <> camlCase acc t
 
 data Deprecation
-  = Deprecated_ParticipantTuples SrcLoc
-  | Deprecated_SnakeToCamelCase String
+  = D_ParticipantTuples SrcLoc
+  | D_SnakeToCamelCase String
+  deriving (Eq)
+
+data Warning
+  = W_Deprecated Deprecation
+  | W_UnusedVariable SrcLoc String
   deriving (Eq)
 
 instance Show Deprecation where
   show = \case
-    Deprecated_ParticipantTuples at ->
+    D_ParticipantTuples at ->
       "Declaring Participants with a tuple is now deprecated. "
         <> "Please use `Participant(name, interface)` or `ParticipantClass(name, interface)` at "
         <> show at
-    Deprecated_SnakeToCamelCase name ->
+    D_SnakeToCamelCase name ->
       let name' = case splitOn "_" name of
                     []  -> name
                     h:t -> camlCase h t
       in
       "`" <> name <> "` is now deprecated. It has been renamed from snake case to camel case. Use `" <> name' <> "`"
 
-deprecated_warning :: Deprecation -> IO ()
-deprecated_warning d =
+instance Show Warning where
+  show = \case
+    W_Deprecated d -> show d
+    W_UnusedVariable at v ->
+      "unused variable: " <> v <> " at " <> show at
+
+emitWarning :: Warning -> IO ()
+emitWarning d =
   hPutStrLn stderr $ "WARNING: " <> show d

--- a/hs/test-examples/features/default_fn_arguments_dependent.rsh
+++ b/hs/test-examples/features/default_fn_arguments_dependent.rsh
@@ -11,4 +11,5 @@ export const main =
     (A) => {
       const a = 20;
       assert(foo(1, 2) == 13);
+      void a;
     });

--- a/hs/test-examples/features/fork_exp.rsh
+++ b/hs/test-examples/features/fork_exp.rsh
@@ -1,6 +1,6 @@
 'reach 0.1';
 
-const [ isOutcome, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
+const [ _, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
 
 const Common = {
   showOutcome: Fun([UInt], Null),

--- a/hs/test-examples/features/lct_in_only.rsh
+++ b/hs/test-examples/features/lct_in_only.rsh
@@ -11,7 +11,7 @@ export const main =
       commit();
 
       A.only(() => {
-        const z =
+        const _ =
           declassify(interact.getZ()).map((a) => lastConsensusTime() + a);
         const y = lastConsensusTime();
       });

--- a/hs/test-examples/features/lib.rsh
+++ b/hs/test-examples/features/lib.rsh
@@ -5,5 +5,5 @@
 export const x = 3;
 
 export const main = Reach.App(
-  {}, [], () => {}
+  {}, [], () => { void x; }
 );

--- a/hs/test-examples/features/objects.rsh
+++ b/hs/test-examples/features/objects.rsh
@@ -4,6 +4,7 @@ export const main = Reach.App(
   {}, [], () => {
     // empty object literal
     const obj0 = {};
+    void obj0;
 
     // Normal object literal
     const obj1 = {x: 1};
@@ -35,6 +36,7 @@ export const main = Reach.App(
     const {x, ...obj4a} = obj4;
     assert(x == 1);
     // TODO assert(obj4a.y == 'yval');
+    void obj4a;
 
     const obj4b = Object.set(obj4, field, 2);
     assert(obj4b.x == 2);
@@ -51,6 +53,7 @@ export const main = Reach.App(
     const {y, ...obj7} = obj4;
     // TODO assert(y == 'yval');
     assert(obj7.x == 1);
+    void y;
 
     // TODO: structural object equality comparison
     // "Err_Type_Mismatch" (int vs obj)

--- a/hs/test-examples/features/objects_lifted.rsh
+++ b/hs/test-examples/features/objects_lifted.rsh
@@ -41,6 +41,7 @@ export const main = Reach.App(
     const {y, ...obj6} = obj2;
     // TODO assert(y == 'y_val');
     require(obj6.x == 1);
+    void y;
 
     // TODO: structural object equality comparison
     // "Err_Type_Mismatch" (int vs obj)

--- a/hs/test-examples/features/tut6-refined.rsh
+++ b/hs/test-examples/features/tut6-refined.rsh
@@ -3,6 +3,8 @@
 const [ isHand, ROCK, PAPER, SCISSORS ] = makeEnum(3);
 const [ isOutcome, B_WINS, DRAW, A_WINS ] = makeEnum(3);
 
+void SCISSORS;
+
 const winner = (handA, handB) =>
       ((handA + (4 - handB)) % 3);
 

--- a/hs/test-examples/features/underscore.rsh
+++ b/hs/test-examples/features/underscore.rsh
@@ -10,6 +10,6 @@ export const main = Reach.App(
 
     // Ignore arguments
     const f = (_, _, z) => { return z; };
-    const v = f('blah', null, x);
+    const _ = f('blah', null, x);
   }
 );

--- a/hs/test-examples/nl-verify-errs/div_by_zero.rsh
+++ b/hs/test-examples/nl-verify-errs/div_by_zero.rsh
@@ -6,6 +6,6 @@ export const main =
     [Participant('A', { x: UInt })],
     (A) => {
       A.only(() => {
-        const x = 5 / declassify(interact.x);
+        const _ = 5 / declassify(interact.x);
       });
     });

--- a/hs/test-examples/nl-verify-errs/multiple_binding_locations.rsh
+++ b/hs/test-examples/nl-verify-errs/multiple_binding_locations.rsh
@@ -9,7 +9,7 @@ export const main =
         // Lets say `declassify(interact.x) - 4` evaluates
         // to DLVar with counter 4.
         const u = declassify(interact.x) - 4;
-        const w = u;
+        const _ = u;
         const x = u;
         const y = u;
         // Ensure that the SMT error displays `x` and not


### PR DESCRIPTION
Tracking unused variables was more complicated than expected. This PR is to have a record of the work done for it.

The first issue that arose was that of short-circuiting/compile time evaluation. Some `if/else/switch` branches were not evaluated; these scenarios would lead to unused variable warnings although the erroneous variables **were used** in the unevaluated branches.

I attempted to always evaluate (but ignore the results of) the unused branches of `if/else/switch` via `ignoreAll`. However, this change causes the type system to behave as if it were static as opposed to dynamic, as demonstrated in the trust fund workshop:

```javascript
const giveChance = (Who, then) => {
        Who.only(() => interact.ready());

        if ( then ) {
          Who.publish()
            .timeout(then.deadline, () => then.after()); }
        else {
          Who.publish(); }
```
when the `Bystander` passes `false`, the if true branch is evaluated and throws an error because it expects `then` to be an `object`.

An alternative way to track whether variables are used in unevaluated branches, aside from evaluating them, is with `lookThroughThisJSExprAndFindIdsThenMarkThemAsLookedAt`. However, this may not work due to macros (`SLV_Form`)