### PR TITLE
Fix ETH `newTestAccount` race condition by explicitly awaiting receipt

### DIFF
--- a/js/Makefile
+++ b/js/Makefile
@@ -21,7 +21,7 @@ build:
 
 .PHONY: test
 test: build
-	(cd stdlib && $(MAKE) test)
+	(cd stdlib && $(MAKE) check clean-test && sbin/test.sh)
 
 # No need to push js-deps or stdlib
 .PHONY: push

--- a/js/stdlib/Makefile
+++ b/js/stdlib/Makefile
@@ -33,14 +33,6 @@ build: package.json
 	  .
 	TAG_ONLY=1 $(ROOT)/scripts/docker-push.sh $(IMAGE)
 
-.PHONY: test
-test: build check clean-test
-	sbin/test.sh
-
-# TODO re-enable these once `reach` script is ready
-#	  && REACH_CONNECTOR_MODE=ALGO $(REACH) run \
-#	  && REACH_CONNECTOR_MODE=FAKE $(REACH) run \
-
 .PHONY: format
 format: package.json
 	npm run beautify

--- a/js/stdlib/sbin/test.sh
+++ b/js/stdlib/sbin/test.sh
@@ -17,6 +17,11 @@ cd test/stdlib-test || exit 1
 REACH=../../../../reach
 $REACH compile
 REACH_CONNECTOR_MODE=ETH $REACH run
+
+# TODO re-enable these once `reach` script is ready
+# REACH_CONNECTOR_MODE=ALGO $REACH run
+# REACH_CONNECTOR_MODE=FAKE $REACH run
+
 RESULT=$?
 $REACH down
 


### PR DESCRIPTION
Also:
 - Prevent subtle timing issue in js/Makefile vs. js/stdlib/Makefile
   when invoking `test` target: by pulling `test` completely into the
   parent Makefile we can ensure that a fresh `runner` Docker image has
   already been created first (and therefore local changes make it into
   test suite container)

 - Clean up missed TODO comments and move them into relevant spot in
   sbin/test.sh script

Based on my reading the FAKE and ALGO connectors don't appear to have
been affected by the same problem as ETH. I've also traced through the
ETH code related to this change to make sure I wasn't introducing
another bug/regression.

See the following Slack discussion from 2021-03-17 ~9:45am EST:
https://reachsh.slack.com/archives/CMY3E5B3J/p1615988581004600