### PR TITLE
Use Strict Mode in Standard Library and Examples

### DIFF
--- a/docs-src/overview.scrbl
+++ b/docs-src/overview.scrbl
@@ -45,82 +45,84 @@ Let's look at a simple Reach program where two principals, Alice and Bob, intera
 The main part of the program looks like this:
 
 @reachex[#:show-lines? #t "overview/index.rsh"
-         'skip 11 29 "      // ...body..."]
+         'skip 12 30 "      // ...body..."]
 
 @itemlist[
 
 @item{Line 1 specifies that this is a Reach program.}
 
-@item{Line 3 defines the main @tech{export} from program. @litchar{main} is the default used by Reach.}
+@item{Line 2 specifies that this program will be compiled with @tech{strict mode}, which enables unused variable checks.}
 
-@item{Line 4 specifies that it is an application.}
+@item{Line 4 defines the main @tech{export} from program. @litchar{main} is the default used by Reach.}
 
-@item{Lines 6 and 7 specify the interface between Alice's @tech{participant} and @tech{frontend}. In this case, Alice's @tech{frontend} must provide a number called @litchar{request} and a string called @litchar{info}.}
+@item{Line 5 specifies that it is an application.}
 
-@item{Lines 8 and 9 specify the interface for Bob, which includes a function named @litchar{want}, that takes a number and returns @reachin{null}, as well as a function named @litchar{got}, that receives the information.}
+@item{Lines 7 and 8 specify the interface between Alice's @tech{participant} and @tech{frontend}. In this case, Alice's @tech{frontend} must provide a number called @litchar{request} and a string called @litchar{info}.}
 
-@item{Finally, line 10, binds these @tech{participants} to the program identifiers @reachin{A} and @reachin{B}.}
+@item{Lines 9 and 10 specify the interface for Bob, which includes a function named @litchar{want}, that takes a number and returns @reachin{null}, as well as a function named @litchar{got}, that receives the information.}
+
+@item{Finally, line 11, binds these @tech{participants} to the program identifiers @reachin{A} and @reachin{B}.}
 
 ]
 
-The elided lines, 11 through 29, contain the body of the application, which we can divide into four parts.
+The elided lines, 12 through 30, contain the body of the application, which we can divide into four parts.
 
 @reachex[#:show-lines? #t "overview/index.rsh"
-         'only 11 14 "      // ..."]
+         'only 12 15 "      // ..."]
 
 @itemlist[
 
-@item{Lines 11 and 12 specify that Alice takes a @tech{local step} where she @tech{declassifies} the amount of tokens requested.
+@item{Lines 12 and 13 specify that Alice takes a @tech{local step} where she @tech{declassifies} the amount of tokens requested.
 In Reach, all values from the @tech{frontend} are @tech{secret} until explicitly made @tech{public} with @tech{declassify}.}
 
-@item{Line 13 has Alice @tech{joins} the application by publishing that value and the logic of the program transitions to specifying what the @tech{contract} does.}
+@item{Line 14 has Alice @tech{joins} the application by publishing that value and the logic of the program transitions to specifying what the @tech{contract} does.}
 
-@item{Line 14 has the @tech{contract} commit to these values and continue the rest of the program.}
+@item{Line 15 has the @tech{contract} commit to these values and continue the rest of the program.}
 
 ]
 
 At this point, Bob's @tech{backend} has learned the value of @reachin{request} and can deliver it to Bob's @tech{frontend} for his approval. This happens next.
 
 @reachex[#:show-lines? #t "overview/index.rsh"
-         'only 16 19 "      // ..."]
+         'only 17 20 "      // ..."]
 
 @itemlist[
 
-@item{Lines 16 and 17 has Bob perform that delivery.
+@item{Lines 17 and 18 has Bob perform that delivery.
 @reachin{interact.want} doesn't explicitly return a boolean, because the frontend can not return if Bob doesn't want to continue.
 A better version of this program might return @reachin{false} and have that communicated to Alice.}
 
-@item{Lines 18 and 19 have Bob @tech{join} the application and submit a payment matching the appropriate amount and then the @tech{contract} commits.}
+@item{Lines 19 and 20 have Bob @tech{join} the application and submit a payment matching the appropriate amount and then the @tech{contract} commits.}
 
 ]
 
 It's now Alice's turn again,
 
 @reachex[#:show-lines? #t "overview/index.rsh"
-         'only 21 25 "      // ..."]
+         'only 22 26 "      // ..."]
 
 @itemlist[
 
-@item{Lines 21 and 22 specify that Alice @tech{declassifies} the information.}
+@item{Lines 22 and 23 specify that Alice @tech{declassifies} the information.}
 
-@item{Line 23 has her publish it.}
+@item{Line 24 has her publish it.}
 
-@item{Line 24 has the @tech{contract} transfer the requested amount to her.}
+@item{Line 25 has the @tech{contract} transfer the requested amount to her.}
 
-@item{Line 25 commits the transactions on the @tech{consensus network}.}
+@item{Line 26 commits the transactions on the @tech{consensus network}.}
 
 ]
 
 The only thing left is for Bob's @tech{backend} to deliver the information to his @tech{frontend}.
 
 @reachex[#:show-lines? #t "overview/index.rsh"
-         'only 27 29 "      // ..."]
+         'only 28 30 "      // ..."]
 
 @itemlist[
 
-@item{Line 27 and 28 do this.}
+@item{Line 28 and 29 do this.}
 
-@item{Line 29 exits the program.}
+@item{Line 30 exits the program.}
 
 ]
 

--- a/docs-src/workshop-fomo-generalized.scrbl
+++ b/docs-src/workshop-fomo-generalized.scrbl
@@ -53,7 +53,7 @@ specialize it when we compile.
 
 @reachex[#:show-lines? #t "workshop-fomo-generalized/index.rsh"
          #:link #t
-         'only 4 22 "  // ..."]
+         'only 5 23 "  // ..."]
 
 At this point, you can modify your JavaScript file (@tt{index.mjs}) to contain defintions of these values, although you may want to use a placeholders for the actual value.
 When you're writing a Reach program, especially in the early phases, you should have these two files open side-by-side and update them in tandem as you're deciding the @tech{participant interact interface}.

--- a/docs-src/workshop-fomo.scrbl
+++ b/docs-src/workshop-fomo.scrbl
@@ -94,7 +94,7 @@ Our @tech{participant interact interface}, with the addition of some handy loggi
 
 @reachex[#:show-lines? #t "workshop-fomo/index.rsh"
          #:link #t
-         'only 3 21 "  // ..."]
+         'only 4 22 "  // ..."]
 
 
 At this point, you can modify your JavaScript file (@tt{index.mjs}) to contain defintions of these values, although you may want to use a placeholders for the actual value.

--- a/docs-src/workshop-hash-lock.scrbl
+++ b/docs-src/workshop-hash-lock.scrbl
@@ -244,11 +244,11 @@ Here's what we did:
          #:link #t]
 
 @itemlist[
- @item{Lines 10-13 have Alice declassify some of her values.}
- @item{Line 20 has Bob provide his password.}
+ @item{Lines 11-14 have Alice declassify some of her values.}
+ @item{Line 21 has Bob provide his password.}
 ]
 
-@margin-note{Did you notice that we didn't mention what line 4 is for?
+@margin-note{Did you notice that we didn't mention what line 5 is for?
 We'll discuss that in the next section; don't worry!}
 
 At this point, when we

--- a/docs-src/workshop-relay.scrbl
+++ b/docs-src/workshop-relay.scrbl
@@ -72,7 +72,7 @@ Here's what we wrote in our program:
 
 @reachex[#:show-lines? #t "workshop-relay/index.rsh"
          #:link #t
-         'only 5 7 "  // ..."]
+         'only 6 8 "  // ..."]
 
 We chose to represent the amount as a @reachin{UInt} field, which should be unsurprising.
 We then have two functions that take no arguments and return an @reachin{Address} which respectively return the Relay identity and the Bob identity.

--- a/examples/chicken-fork/index.rsh
+++ b/examples/chicken-fork/index.rsh
@@ -1,6 +1,7 @@
 'reach 0.1';
+'use strict';
 
-const [ isOutcome, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
+const [ _, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
 
 const Common = {
   showOutcome: Fun([UInt], Null),

--- a/examples/chicken-parallel/index.rsh
+++ b/examples/chicken-parallel/index.rsh
@@ -1,6 +1,7 @@
 'reach 0.1';
+'use strict';
 
-const [ isOutcome, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
+const [ _, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
 
 const Common = {
   showOutcome: Fun([UInt], Null),

--- a/examples/chicken-race/index.rsh
+++ b/examples/chicken-race/index.rsh
@@ -1,6 +1,7 @@
 'reach 0.1';
+'use strict';
 
-const [ isOutcome, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
+const [ _, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
 
 const Common = {
   showOutcome: Fun([UInt], Null),

--- a/examples/maybe-send/index.rsh
+++ b/examples/maybe-send/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 export const main = Reach.App(
   {},

--- a/examples/multiple-pr-case/index.rsh
+++ b/examples/multiple-pr-case/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 const Common = ({
   doCase: Fun([UInt], Bool) });

--- a/examples/multisig/index.rsh
+++ b/examples/multisig/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 /*
   This is an abstraction of a multi-signature wallet.

--- a/examples/nft-dumb/index.rsh
+++ b/examples/nft-dumb/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 export const main =
   Reach.App(

--- a/examples/nim/index.rsh
+++ b/examples/nim/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 // Protocol
 const DELAY = 10; // in blocks

--- a/examples/object-digest/index.rsh
+++ b/examples/object-digest/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 const Obj = Object({x: UInt, y: Bool});
 

--- a/examples/overview-more-deps/index.rsh
+++ b/examples/overview-more-deps/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 export const main =
   Reach.App(

--- a/examples/overview-react/index.rsh
+++ b/examples/overview-react/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-undef */
 

--- a/examples/overview/index.rsh
+++ b/examples/overview/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 export const main =
   Reach.App(

--- a/examples/own-addr/index.rsh
+++ b/examples/own-addr/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 export const main =
   Reach.App(

--- a/examples/popularity-contest/index.rsh
+++ b/examples/popularity-contest/index.rsh
@@ -1,6 +1,7 @@
 'reach 0.1';
+'use strict';
 
-const [ isOutcome, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
+const [ _, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
 
 const Common = {
   showOutcome: Fun([UInt, UInt, UInt], Null),

--- a/examples/race/index.rsh
+++ b/examples/race/index.rsh
@@ -1,6 +1,7 @@
 'reach 0.1';
+'use strict';
 
-const [ isOutcome, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
+const [ _, ALICE_WINS, BOB_WINS, TIMEOUT ] = makeEnum(3);
 
 const Common = {
   showOutcome: Fun([UInt], Null),

--- a/examples/raffle/index.rsh
+++ b/examples/raffle/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 const Common = {
   ...hasRandom,

--- a/examples/remote/index.rsh
+++ b/examples/remote/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 const Posn = Struct([["x", UInt], ["y", UInt]]);
 const PosnO = Object({x: UInt, y: UInt});

--- a/examples/rent-seeking/index.rsh
+++ b/examples/rent-seeking/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 const Common = {
   showWinner: Fun([Bool, Address, UInt], Null),

--- a/examples/secured-loan/index.rsh
+++ b/examples/secured-loan/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 const ParamsType = Object({
   collateral: UInt,

--- a/examples/timeoutception/index.rsh
+++ b/examples/timeoutception/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 const Player = {
   ask: Fun([], UInt),
@@ -15,10 +16,6 @@ function go(who, k) {
     .pay(amt)
     .timeout(DELAY, () => k());
   commit();
-}
-
-function gogo(who, kTim) {
-  return () => go(who, kTim);
 }
 
 function thrice(f, x) {

--- a/examples/ttt/index.rsh
+++ b/examples/ttt/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 // Tic Tac Toe
 const ROWS = 3;

--- a/examples/tut-5-attack/index-bad.txt
+++ b/examples/tut-5-attack/index-bad.txt
@@ -10,15 +10,15 @@ Verification failed:
   // Violation witness
   const interact_Alice_wager = 2;
   //    ^ from interaction at ./index-bad.rsh:14:12:application
-  const handA/4 = 2;
+  const handA/10 = 2;
   //    ^ from evaluating interact("Alice")."getHand"() at ./index-bad.rsh:20:50:application
 
   // Theorem formalization
-  const outcome/26 = (handA/4 + (4 - ((handA/4 + 1) % 3))) % 3;
+  const outcome/32 = (handA/10 + (4 - ((handA/10 + 1) % 3))) % 3;
   //    ^ would be 0
-  const v37 = (outcome/26 == 0) ? [0, 1] : ((outcome/26 == 1) ? [1, 1] : [2, 0]);
+  const v43 = (outcome/32 == 0) ? [0, 1] : ((outcome/32 == 1) ? [1, 1] : [2, 0]);
   //    ^ would be [0, 1]
-  assert(0 == (((interact_Alice_wager + interact_Alice_wager) - (v37[0] * interact_Alice_wager)) - (v37[1] * interact_Alice_wager)));
+  assert(0 == (((interact_Alice_wager + interact_Alice_wager) - (v43[0] * interact_Alice_wager)) - (v43[1] * interact_Alice_wager)));
 
   Verifying when NO participants are honest
 Verification failed:

--- a/examples/tut-5-attack/index-fails.txt
+++ b/examples/tut-5-attack/index-fails.txt
@@ -1,9 +1,9 @@
 Verifying knowledge assertions
 Verification failed:
-  of theorem unknowable("Bob", handA/7)
+  of theorem unknowable("Bob", handA/13)
   at ./index-fails.rsh:25:17:application
 
-  Bob knows of handA/7 because it is published.
+  Bob knows of handA/13 because it is published.
 
 Verifying for generic connector
   Verifying when ALL participants are honest

--- a/examples/variable_transfers/index.rsh
+++ b/examples/variable_transfers/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 export const main =
   Reach.App(

--- a/examples/workshop-fomo-generalized/index.rsh
+++ b/examples/workshop-fomo-generalized/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 // FOMO Workshop generalized to last N winners
 const NUM_OF_WINNERS = 3;

--- a/examples/workshop-fomo/index.rsh
+++ b/examples/workshop-fomo/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 const CommonInterface = {
   // Show the address of winner

--- a/examples/workshop-hash-lock/index.rsh
+++ b/examples/workshop-hash-lock/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 export const main = Reach.App(
   { deployMode: 'firstMsg' },

--- a/examples/workshop-relay/index.rsh
+++ b/examples/workshop-relay/index.rsh
@@ -1,4 +1,5 @@
 'reach 0.1';
+'use strict';
 
 export const main = Reach.App(
   { deployMode: 'firstMsg' },

--- a/hs/rsh/stdlib.rsh
+++ b/hs/rsh/stdlib.rsh
@@ -1,5 +1,7 @@
 'reach 0.1';
 
+'use strict';
+
 export function not (x) {
   return (x ? false : true); }
 export const boolEq = (x, y) => (x ? y : !y);
@@ -107,7 +109,7 @@ export const Object_setIfUnset = (o, k, dv) =>
 export const Array_empty =
   Array.iota(0);
 export const Array_replicate =
-  (sz, v) => Array.iota(sz).map(x => v);
+  (sz, v) => Array.iota(sz).map(_ => v);
 
 export const Foldable_forEach =
   (c, f) => c.reduce(null, (_, xe) => f(xe));
@@ -202,7 +204,7 @@ export const Foldable_product1 = (c) => () =>
   Foldable_product(c);
 
 export const sqrt = (y, k) =>
-  Array.iota(k).reduce([ y, (y / 2 + 1) ], ([ z, x ], a) =>
+  Array.iota(k).reduce([ y, (y / 2 + 1) ], ([ z, x ], _) =>
     (x < z)
       ? [ x, ((y / x + x) / 2) ]
       : [ z, x ]
@@ -258,6 +260,9 @@ export const fxint = (i) =>
 
 const fxi2int = (x) =>
   int(x.sign, x.i.i);
+
+// do not export, but count it as used in strict mode
+void fxi2int;
 
 export const fxrescale = (x, scale) => {
   if (x.i.scale == scale) {
@@ -353,6 +358,7 @@ const fxpowRatio = (x, numerator, denominator, precision, scalePrecision) => {
     return fxrescale(fxsub(acc, t), scalePrecision);
   });
 }
+void fxpowRatio;
 
 const getNumDenom = (value, precision) => {
   const [ numerator, denominator, _ ] =
@@ -383,6 +389,7 @@ const getNumDenom = (value, precision) => {
 
   return [ idiv(numerator, lo_), idiv(denominator, lo_) ];
 }
+void getNumDenom;
 
 export const fxpow = (base, power, precision, scalePrecision) => {
   const whole = fxfloor(power);

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -406,7 +406,7 @@ data SLPrimitive
   | SLPrim_tuple_set
   | SLPrim_Object
   | SLPrim_Object_has
-  | SLPrim_App_Delay SrcLoc SLEnv [SLCompiledPartInfo] [JSExpression] JSStatement SLEnv
+  | SLPrim_App_Delay SrcLoc SLEnv [SLCompiledPartInfo] [JSExpression] JSStatement (SLEnv, Bool)
   | SLPrim_op PrimOp
   | SLPrim_transfer
   | SLPrim_transfer_amt_to SLVal

--- a/hs/src/Reach/Eval.hs
+++ b/hs/src/Reach/Eval.hs
@@ -74,7 +74,7 @@ app_options =
 type CompiledDApp = M.Map DLMVar DLMapInfo -> DLStmts -> DLProg
 
 compileDApp :: Connectors -> SLVal -> App CompiledDApp
-compileDApp cns (SLV_Prim (SLPrim_App_Delay at opts part_ios top_formals top_s top_env)) = locAt (srcloc_at "compileDApp" Nothing at) $ do
+compileDApp cns (SLV_Prim (SLPrim_App_Delay at opts part_ios top_formals top_s (top_env, top_use_strict))) = locAt (srcloc_at "compileDApp" Nothing at) $ do
   at' <- withAt id
   idr <- e_id <$> ask
   let use_opt k SLSSVal {sss_val = v, sss_at = opt_at} acc =
@@ -115,7 +115,6 @@ compileDApp cns (SLV_Prim (SLPrim_App_Delay at opts part_ios top_formals top_s t
         env0 <- locAt slcpi_at $ env_insert "interact" iov top_env_wps
         return $ (slcpi_who, env0)
   penvs <- M.fromList <$> mapM make_penvp part_ios
-  use_strict <- asks (sco_use_strict . e_sco)
   let sco =
         SLScope
           { sco_ret = Nothing
@@ -123,7 +122,7 @@ compileDApp cns (SLV_Prim (SLPrim_App_Delay at opts part_ios top_formals top_s t
           , sco_while_vars = Nothing
           , sco_penvs = penvs
           , sco_cenv = top_env_wps
-          , sco_use_strict = use_strict
+          , sco_use_strict = top_use_strict
           }
   setSt st_step
   doFluidSet FV_balance $ public $ SLV_Int at' 0

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -342,7 +342,6 @@ whenUsingStrict :: App () -> App ()
 whenUsingStrict e = useStrict >>= flip when e
 
 shouldNotTrackVariable :: (SrcLoc, SLVar) -> Bool
-shouldNotTrackVariable (SrcLoc _ _ (Just ReachStdLib), _) = True
 shouldNotTrackVariable (_, "main") = True
 shouldNotTrackVariable (_, "_") = True
 shouldNotTrackVariable _ = False
@@ -1161,8 +1160,8 @@ evalForm f args = do
             [(SLV_Object _ _ opts), (SLV_Tuple _ parts)] -> do
               at <- withAt id
               part_ios <- mapM make_partio parts
-              env <- (sco_cenv . e_sco) <$> ask
-              retV $ public $ SLV_Prim $ SLPrim_App_Delay at opts part_ios (parseJSArrowFormals at top_formals) top_s env
+              SLScope {..} <- e_sco <$> ask
+              retV $ public $ SLV_Prim $ SLPrim_App_Delay at opts part_ios (parseJSArrowFormals at top_formals) top_s (sco_cenv, sco_use_strict)
             _ -> expect_ $ Err_App_InvalidArgs args
         _ -> expect_ $ Err_App_InvalidArgs args
     SLForm_Part_Only who mv -> do

--- a/hs/test-examples/nl-eval-errors/Err_Invalid_Statement.txt
+++ b/hs/test-examples/nl-eval-errors/Err_Invalid_Statement.txt
@@ -1,1 +1,1 @@
-reachc: error: ./Err_Invalid_Statement.rsh:65:30:id: Effects cannot be bound, got: <SLV_Form>
+reachc: error: ./Err_Invalid_Statement.rsh:67:30:id: Effects cannot be bound, got: <SLV_Form>

--- a/hs/test-examples/nl-eval-errors/Err_Prim_InvalidArg_Dynamic.txt
+++ b/hs/test-examples/nl-eval-errors/Err_Prim_InvalidArg_Dynamic.txt
@@ -1,4 +1,4 @@
-reachc: error: reach standard library:205:13:application: Invalid arg for Array_iota. The argument must be computable at compile time
+reachc: error: reach standard library:207:13:application: Invalid arg for Array_iota. The argument must be computable at compile time
 Trace:
-  in "sqrt" from (reach standard library:204:28:function exp) at (./Err_Prim_InvalidArg_Dynamic.rsh:9:20:application)
+  in "sqrt" from (reach standard library:206:28:function exp) at (./Err_Prim_InvalidArg_Dynamic.rsh:9:20:application)
   in [unknown function] from (./Err_Prim_InvalidArg_Dynamic.rsh:8:17:function exp) at (./Err_Prim_InvalidArg_Dynamic.rsh:8:13:application)

--- a/hs/test-examples/nl-verify-errs/assert_gt.txt
+++ b/hs/test-examples/nl-verify-errs/assert_gt.txt
@@ -8,11 +8,11 @@ Verification failed:
   at ./assert_gt.rsh:5:11:application call to [unknown function] (defined at: ./assert_gt.rsh:5:15:function exp)
 
   // Violation witness
-  const _x/3 = 0;
+  const _x/9 = 0;
   //    ^ from evaluating interact("A")."getX"() at ./assert_gt.rsh:6:31:application
 
   // Theorem formalization
-  assert(_x/3 > 0);
+  assert(_x/9 > 0);
 
   Verifying when NO participants are honest
   Verifying when ONLY "A" is honest

--- a/hs/test-examples/nl-verify-errs/assert_more_expr.txt
+++ b/hs/test-examples/nl-verify-errs/assert_more_expr.txt
@@ -8,13 +8,13 @@ Verification failed:
   at ./assert_more_expr.rsh:7:11:application call to [unknown function] (defined at: ./assert_more_expr.rsh:7:15:function exp)
 
   // Violation witness
-  const _x1/3 = 0;
+  const _x1/9 = 0;
   //    ^ from evaluating interact("A")."getX"() at ./assert_more_expr.rsh:8:32:application
-  const _x2/4 = 1;
+  const _x2/10 = 1;
   //    ^ from evaluating interact("A")."getX"() at ./assert_more_expr.rsh:9:32:application
 
   // Theorem formalization
-  assert((_x1/3 + _x2/4) == (_x1/3 * 2));
+  assert((_x1/9 + _x2/10) == (_x1/9 * 2));
 
   Verifying when NO participants are honest
   Verifying when ONLY "A" is honest

--- a/hs/test-examples/nl-verify-errs/class_addr.txt
+++ b/hs/test-examples/nl-verify-errs/class_addr.txt
@@ -7,13 +7,13 @@ Verification failed:
   at ./class_addr.rsh:16:14:application
 
   // Violation witness
-  const C/25 = Address!val!1;
+  const C/30 = Address!val!0;
   //    ^ from builtin at ./class_addr.rsh:4:12:application
-  const C/24 = Address!val!0;
+  const C/31 = Address!val!1;
   //    ^ from builtin at ./class_addr.rsh:4:12:application
 
   // Theorem formalization
-  require(selfAddress(""C"", #t, 1) == selfAddress(""C"", #t, 11));
+  require(selfAddress(""C"", #t, 7) == selfAddress(""C"", #t, 17));
 
   Verifying when NO participants are honest
   Verifying when ONLY "C" is honest

--- a/hs/test-examples/nl-verify-errs/fxsqrt.txt
+++ b/hs/test-examples/nl-verify-errs/fxsqrt.txt
@@ -5,8 +5,8 @@ Verification failed:
   when ALL participants are honest
   of theorem: assert
   msg: "fxsqrt: Cannot find the square root of a negative number."
-  at reach standard library:305:9:application
-  at ./fxsqrt.rsh:10:30:application call to "fxsqrt" (defined at: reach standard library:304:30:function exp)
+  at reach standard library:310:9:application
+  at ./fxsqrt.rsh:10:30:application call to "fxsqrt" (defined at: reach standard library:309:30:function exp)
   at ./fxsqrt.rsh:9:13:application call to [unknown function] (defined at: ./fxsqrt.rsh:9:17:function exp)
 
   // Violation witness
@@ -20,8 +20,8 @@ Verification failed:
   when ONLY "A" is honest
   of theorem: assert
   msg: "fxsqrt: Cannot find the square root of a negative number."
-  at reach standard library:305:9:application
-  at ./fxsqrt.rsh:10:30:application call to "fxsqrt" (defined at: reach standard library:304:30:function exp)
+  at reach standard library:310:9:application
+  at ./fxsqrt.rsh:10:30:application call to "fxsqrt" (defined at: reach standard library:309:30:function exp)
   at ./fxsqrt.rsh:9:13:application call to [unknown function] (defined at: ./fxsqrt.rsh:9:17:function exp)
 
   (details omitted on repeat)

--- a/hs/test-examples/nl-verify-errs/impossible.txt
+++ b/hs/test-examples/nl-verify-errs/impossible.txt
@@ -10,7 +10,7 @@ Verification failed:
   // Violation witness
 
   // Theorem formalization
-  possible(_x/3 < 0);
+  possible(_x/9 < 0);
 
   Verifying when NO participants are honest
   Verifying when ONLY "A" is honest

--- a/hs/test-examples/nl-verify-errs/loop_var_sub.txt
+++ b/hs/test-examples/nl-verify-errs/loop_var_sub.txt
@@ -7,13 +7,13 @@ Verification failed:
   at ./loop_var_sub.rsh:13:7:invariant
 
   // Violation witness
-  const balance/26 = 0;
+  const balance/32 = 0;
   //    ^ from loop variable at ./loop_var_sub.rsh:14:7:while
-  const x/8 = [0, false];
+  const x/14 = [0, false];
   //    ^ from loop variable at ./loop_var_sub.rsh:14:7:while
 
   // Theorem formalization
-  invariant((balance/26 + 1) == [(x/8[0] + 2), x/8[1]][0]);
+  invariant((balance/32 + 1) == [(x/14[0] + 2), x/14[1]][0]);
 
   Verifying when NO participants are honest
 Verification failed:
@@ -22,15 +22,15 @@ Verification failed:
   at ./loop_var_sub.rsh:13:7:invariant
 
   // Violation witness
-  const v14 = 1;
+  const v20 = 1;
   //    ^ from a dishonest payment from "A" at ./loop_var_sub.rsh:16:11:dot
-  const balance/26 = 0;
+  const balance/32 = 0;
   //    ^ from loop variable at ./loop_var_sub.rsh:14:7:while
-  const x/8 = [0, false];
+  const x/14 = [0, false];
   //    ^ from loop variable at ./loop_var_sub.rsh:14:7:while
 
   // Theorem formalization
-  invariant((balance/26 + v14) == [(x/8[0] + 2), x/8[1]][0]);
+  invariant((balance/32 + v20) == [(x/14[0] + 2), x/14[1]][0]);
 
   Verifying when ONLY "A" is honest
 Verification failed:
@@ -39,13 +39,13 @@ Verification failed:
   at ./loop_var_sub.rsh:13:7:invariant
 
   // Violation witness
-  const balance/26 = 0;
+  const balance/32 = 0;
   //    ^ from loop variable at ./loop_var_sub.rsh:14:7:while
-  const x/8 = [0, false];
+  const x/14 = [0, false];
   //    ^ from loop variable at ./loop_var_sub.rsh:14:7:while
 
   // Theorem formalization
-  invariant((balance/26 + 1) == [(x/8[0] + 2), x/8[1]][0]);
+  invariant((balance/32 + 1) == [(x/14[0] + 2), x/14[1]][0]);
 
   Verifying when ONLY "B" is honest
 Verification failed:
@@ -54,14 +54,14 @@ Verification failed:
   at ./loop_var_sub.rsh:13:7:invariant
 
   // Violation witness
-  const v14 = 1;
+  const v20 = 1;
   //    ^ from a dishonest payment from "A" at ./loop_var_sub.rsh:16:11:dot
-  const balance/26 = 0;
+  const balance/32 = 0;
   //    ^ from loop variable at ./loop_var_sub.rsh:14:7:while
-  const x/8 = [0, false];
+  const x/14 = [0, false];
   //    ^ from loop variable at ./loop_var_sub.rsh:14:7:while
 
   // Theorem formalization
-  invariant((balance/26 + v14) == [(x/8[0] + 2), x/8[1]][0]);
+  invariant((balance/32 + v20) == [(x/14[0] + 2), x/14[1]][0]);
 
 Checked 16 theorems; 4 failures. :'(

--- a/hs/test-examples/nl-verify-errs/multiple_binding_locations.txt
+++ b/hs/test-examples/nl-verify-errs/multiple_binding_locations.txt
@@ -11,9 +11,9 @@ Verification failed:
   //    ^ from interaction at ./multiple_binding_locations.rsh:4:12:application
 
   // Theorem formalization
-  const x/4 = interact_A_x - 4;
+  const x/10 = interact_A_x - 4;
   //    ^ would be 0
-  assert((x/4 + x/4) == 4);
+  assert((x/10 + x/10) == 4);
 
   Verifying when NO participants are honest
 Verification failed:

--- a/hs/test-examples/nl-verify-errs/overflow.txt
+++ b/hs/test-examples/nl-verify-errs/overflow.txt
@@ -8,13 +8,13 @@ Verification failed:
   at ./overflow.rsh:12:17:application
 
   // Violation witness
+  const x/9 = 1;
+  //    ^ from evaluating interact("A")."get"() at ./overflow.rsh:9:40:application
   const dlc_UInt_max = 1;
   //    ^ from builtin at ./overflow.rsh:3:30:application
-  const x/3 = 1;
-  //    ^ from evaluating interact("A")."get"() at ./overflow.rsh:9:40:application
 
   // Theorem formalization
-  assert(x/3 <= (UInt.max - 1));
+  assert(x/9 <= (UInt.max - 1));
 
   Verifying when NO participants are honest
 Verification failed:

--- a/hs/test-examples/nl-verify-errs/overflow_con.txt
+++ b/hs/test-examples/nl-verify-errs/overflow_con.txt
@@ -8,13 +8,13 @@ Verification failed:
   at ./overflow_con.rsh:14:17:application
 
   // Violation witness
+  const x/9 = 1;
+  //    ^ from evaluating interact("A")."get"() at ./overflow_con.rsh:9:40:application
   const dlc_UInt_max = 1;
   //    ^ from builtin at ./overflow_con.rsh:3:30:application
-  const x/3 = 1;
-  //    ^ from evaluating interact("A")."get"() at ./overflow_con.rsh:9:40:application
 
   // Theorem formalization
-  assert(x/3 <= (UInt.max - 1));
+  assert(x/9 <= (UInt.max - 1));
 
   Verifying when NO participants are honest
 Verification failed:

--- a/hs/test-examples/nl-verify-errs/unknowable.txt
+++ b/hs/test-examples/nl-verify-errs/unknowable.txt
@@ -1,14 +1,14 @@
 Verifying knowledge assertions
 Verification failed:
-  of theorem unknowable("Bob", x/0)
+  of theorem unknowable("Bob", x/6)
   at ./unknowable.rsh:22:17:application
 
-  Bob could learn of x/0 via z/8.
+  Bob could learn of x/6 via z/14.
 
-  z/8 was published at ./unknowable.rsh:19:9:dot
-  ^ which contains info about v6 (defined at ./unknowable.rsh:16:22:application)
-  ^ which contains info about v5 (defined at ./unknowable.rsh:15:21:application)
-  ^ which contains info about x/0 (defined at ./unknowable.rsh:14:15:id)
+  z/14 was published at ./unknowable.rsh:19:9:dot
+  ^ which contains info about v12 (defined at ./unknowable.rsh:16:22:application)
+  ^ which contains info about v11 (defined at ./unknowable.rsh:15:21:application)
+  ^ which contains info about x/6 (defined at ./unknowable.rsh:14:15:id)
 
 Verifying for generic connector
   Verifying when ALL participants are honest


### PR DESCRIPTION
Fixed an issue where a top-level `use strict` did not infect `main`. This issue was caused by returning `App_delay` when `main` is encountered in `evalLib`. I added another field to `Prim_AppDelay` to reflect whether the module is using strict mode.

Update the standard library and most examples to use strict mode. I did not use strict mode for the tutorials, examples that do not compile successfully or anything specifically relying on dynamic typing such as the trust fund workshop.