### PR TITLE
Add Message Support to Refinement Types

### DIFF
--- a/docs-src/ref-programs.scrbl
+++ b/docs-src/ref-programs.scrbl
@@ -1261,11 +1261,20 @@ Reach's @deftech{type}s are represented with programs by the following identifie
   (Refer to @secref["ref-programs-arrays"] for constructing arrays.)}
   @item{@(mint-define! '("Data")) @reachin{Data({variant_0: Type_0, ..., variant_N: Type_N})}, which denotes a @link["https://en.wikipedia.org/wiki/Tagged_union"]{tagged union} (or @emph{sum type}).
   (Refer to @secref["ref-programs-data"] for constructing @tech{data instances}.)}
-  @item{@(mint-define! '("Refine")) @reachin{Refine(Type_0, Predicate)}, where @reachin{Predicate} is a unary function returning a boolean, which denotes a @link["https://en.wikipedia.org/wiki/Refinement_type"]{refinement type}, that is instances of @reachin{Type_0} that satisfy @reachin{Predicate}.
-  When a refinement type appears in a negative position of a @reachin{Fun} (such as in a @tech{participant interact interface}), it introduces an @reachin{assert}; while when it is in a positive position, it introduces an @reachin{assume}.
-  For example, if @reachin{f} had type @reachin{Fun([Refine(UInt, (x => x < 5))], Refine(UInt, (x => x > 10)))}, then @reachin{const z = f(y)} is equivalent to @reachin{assert(y < 5); const z = f(y); assume(z > 10);}.}
- @item{@reachin{Refine(Type_0, PreCondition, PostCondition)}, where @reachin{Type_0} is a @tech{function type}, @reachin{PreCondition} is a unary function that accepts a tuple of the domain and returns a boolean, and @reachin{PostCondition} is a binary function that accepts a tuple of the domain and the range and returns a boolean, denotes a @tech{function type} with a @link["https://en.wikipedia.org/wiki/Precondition"]{precondition} and @link["https://en.wikipedia.org/wiki/Postcondition"]{postcondition}.
- Preconditions are enforced with @reachin{assert} and postconditions are enforced with @reachin{assume}.
+  @item{@(mint-define! '("Refine")) @reachin{Refine(Type_0, Predicate, ?Message)}, where @reachin{Predicate} is a unary function returning a boolean, which denotes a @link["https://en.wikipedia.org/wiki/Refinement_type"]{refinement type}, that is instances of @reachin{Type_0} that satisfy @reachin{Predicate}.
+  When a refinement type appears in a negative position of a @reachin{Fun} (such as in a @tech{participant interact interface}), it introduces an @reachin{assert}; while when it is in a positive position, it introduces an @reachin{assume}. @reachin{Message} is an optional string to display if the predicate fails verification.
+
+  For example, if @reachin{f} had type @reach{Fun([Refine(UInt, (x => x < 5))], Refine(UInt, (x => x > 10)))}
+
+  then @reachin{const z = f(y)} is equivalent to
+
+  @reach{
+    assert(y < 5);
+    const z = f(y);
+    assume(z > 10);}}
+ @item{@reachin{Refine(Type_0, PreCondition, PostCondition, ?Messages)}, where @reachin{Type_0} is a @tech{function type}, @reachin{PreCondition} is a unary function that accepts a tuple of the domain and returns a boolean, and @reachin{PostCondition} is a binary function that accepts a tuple of the domain and the range and returns a boolean, denotes a @tech{function type} with a @link["https://en.wikipedia.org/wiki/Precondition"]{precondition} and @link["https://en.wikipedia.org/wiki/Postcondition"]{postcondition}.
+ Preconditions are enforced with @reachin{assert} and postconditions are enforced with @reachin{assume}. @reachin{Messages} is an optional two-tuple of @reachin{Bytes}. The first message will be displayed when the precondition fails verification and the second when the postcondition fails verification.
+
  For example, @reachin{Refine(Fun([UInt, UInt], UInt), ([x, y] => x < y), (([x, y], z) => x + y < z))} is a function that requires its second argument to be larger than its first and its result to be larger than its input.}
 ]
 

--- a/examples/exports/index.rsh
+++ b/examples/exports/index.rsh
@@ -23,8 +23,8 @@ const sumMul2_impl = (x, y) => {
 
 const sumMul2_ty = Refine(
   Fun([UInt, UInt], UInt),
-  (([x, y]) => x < y),
-  (([x, y], z) => x + y < z)
+  (([x, y]) => x < y), (([x, y], z) => x + y < z),
+  [ "first arg must be less than second arg" , "result must be larger than sum of args" ]
 );
 
 export const sumMul2 = is(sumMul2_impl, sumMul2_ty);

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -36,14 +36,16 @@ data SLType
   | ST_Struct [(SLVar, SLType)]
   | ST_Fun SLTypeFun
   | ST_Type SLType
-  | ST_Refine SLType SLVal
+  | ST_Refine SLType SLVal (Maybe SLVal)
   deriving (Eq, Generic)
 
 data SLTypeFun = SLTypeFun
   { stf_dom :: [SLType]
   , stf_rng :: SLType
   , stf_pre :: Maybe SLVal
-  , stf_post :: Maybe SLVal }
+  , stf_post :: Maybe SLVal
+  , stf_pre_msg :: Maybe SLVal
+  , stf_post_msg :: Maybe SLVal }
   deriving (Eq, Generic)
 
 instance Show SLType where
@@ -59,12 +61,12 @@ instance Show SLType where
     ST_Object tyMap -> "Object({" <> showTyMap tyMap <> "})"
     ST_Data tyMap -> "Data({" <> showTyMap tyMap <> "})"
     ST_Struct tys -> "Struct([" <> showTyList tys <> "])"
-    ST_Fun (SLTypeFun tys ty Nothing Nothing) ->
+    ST_Fun (SLTypeFun tys ty Nothing Nothing Nothing Nothing) ->
       "Fun([" <> showTys tys <> "], " <> show ty <> ")"
-    ST_Fun (SLTypeFun tys ty _ _) ->
+    ST_Fun (SLTypeFun tys ty _ _ _ _) ->
       "Refine(Fun([" <> showTys tys <> "], " <> show ty <> "), ...., ....)"
     ST_Type ty -> "Type(" <> show ty <> ")"
-    ST_Refine ty _ -> "Refine(" <> show ty <> ", ....)"
+    ST_Refine ty _ _ -> "Refine(" <> show ty <> ", ....)"
 
 instance Pretty SLType where
   pretty = viaShow
@@ -84,7 +86,7 @@ st2dt = \case
   ST_Struct tys -> T_Struct <$> traverse (\(k, t) -> (,) k <$> st2dt t) tys
   ST_Fun {} -> Nothing
   ST_Type {} -> Nothing
-  ST_Refine t _ -> st2dt t
+  ST_Refine t _ _ -> st2dt t
 
 dt2st :: DLType -> SLType
 dt2st = \case


### PR DESCRIPTION
Changed
```javascript
Refine(T, PRED) => Refine(T, PRED, ?MSG)
```
and
```javascript
Refine(T, PRE, POST) => Refine(T, PRE, POST, ?[PRE_MSG, POST_MSG])
```

Also made the docs for `Refine` a bit easier to read by changing inline code to regular blocks