### PR TITLE
Have Frontend Provide Labels for JS Debugging

### DIFF
--- a/docs-src/ref-frontends-js.scrbl
+++ b/docs-src/ref-frontends-js.scrbl
@@ -95,7 +95,7 @@ These functions create and interact with @tech{account} representations.
 @(hrule)
 @(mint-define! '("getDefaultAccount"))
 @js{
- getDefaultAccount() => Promise<acc> }
+ getDefaultAccount(?label: string) => Promise<acc> }
 
 Returns a Promise for a Reach @tech{account} abstraction for a "default" @tech{account} on the @tech{consensus network}.
 The meaning of "default account" varies between contexts.
@@ -105,38 +105,43 @@ When running in node.js while connected to one of reach's standard devnets,
 the default account will be connected to a faucet on the devnet.
 This promise will be rejected with an exception
 if no sensible default account can be accessed for the current context.
+A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first 4 digits of the account address will be used.
 
 @(hrule)
 @(mint-define! '("newAccountFromSecret"))
 @js{
- newAccountFromSecret(string) => Promise<acc> }
+ newAccountFromSecret(secret: string, ?label: string) => Promise<acc> }
 
 Returns a Promise for a Reach @tech{account} abstraction for an @tech{account} on the @tech{consensus network} specified by the given secret.
-The details of the secret encoding are specified uniquely to the @tech{consensus network}.
+The details of the secret encoding are specified uniquely to the @tech{consensus network}. A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first 4 digits of the account address will be used.
+
 
 @(hrule)
 @(mint-define! '("newAccountFromMnemonic"))
 @js{
- newAccountFromMnemonic(string) => Promise<acc> }
+ newAccountFromMnemonic(phrase: string, ?label: string) => Promise<acc> }
 
 Returns a Promise for a Reach @tech{account} abstraction for an @tech{account} on the @tech{consensus network} specified by the given mnemonic phrase.
-The details of the mnemonic phrase encoding are specified uniquely to the @tech{consensus network}.
+The details of the mnemonic phrase encoding are specified uniquely to the @tech{consensus network}. A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first 4 digits of the account address will be used.
+
 
 @(hrule)
 @(mint-define! '("newTestAccount"))
 @js{
- newTestAccount(balance) => Promise<acc> }
+ newTestAccount(balance, ?label) => Promise<acc> }
 
 Returns a Promise for a Reach @tech{account} abstraction for a new @tech{account} on the @tech{consensus network} with a given balance of @tech{network tokens}. This can only be used in private testing scenarios, as it uses a private faucet to issue @tech{network tokens}.
+A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first 4 digits of the account address will be used.
 
 @jsin{bigNumberify} is transparently applied to the @jsin{balance} argument.
 
 @(hrule)
 @(mint-define! '("createAccount"))
 @js{
-  createAccount() => Promise<acc> }
+  createAccount(?label) => Promise<acc> }
 
 Returns a Promise for a Reach @tech{account} abstraction for a new @tech{account} on the @tech{consensus network}. The account will have an empty balance of @tech{network tokens}.
+A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first 4 digits of the account address will be used.
 
 @(hrule)
 @(mint-define! '("fundFromFaucet"))
@@ -150,9 +155,10 @@ Adds the given balance of @tech{network tokens} to a Reach @tech{account} abstra
 @(hrule)
 @(mint-define! '("connectAccount"))
 @js{
- connectAccount(networkAccount) => Promise<acc> }
+ connectAccount(networkAccount, ?label) => Promise<acc> }
 
 Returns a Promise for a Reach @tech{account} abstraction for an existing @tech{account} for the @tech{consensus network} based on the @tech{connector}-specific @tech{account} specification provided by the @jsin{networkAccount} argument.
+A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first 4 digits of the account address will be used.
 
 @js{
     // network => networkAccount type

--- a/docs-src/ref-frontends-js.scrbl
+++ b/docs-src/ref-frontends-js.scrbl
@@ -105,7 +105,7 @@ When running in node.js while connected to one of reach's standard devnets,
 the default account will be connected to a faucet on the devnet.
 This promise will be rejected with an exception
 if no sensible default account can be accessed for the current context.
-A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first 4 digits of the account address will be used.
+A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first four digits of the account address will be used.
 
 @(hrule)
 @(mint-define! '("newAccountFromSecret"))
@@ -113,7 +113,7 @@ A @tt{label} that distinguishes the account may optionally be provided to use in
  newAccountFromSecret(secret: string, ?label: string) => Promise<acc> }
 
 Returns a Promise for a Reach @tech{account} abstraction for an @tech{account} on the @tech{consensus network} specified by the given secret.
-The details of the secret encoding are specified uniquely to the @tech{consensus network}. A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first 4 digits of the account address will be used.
+The details of the secret encoding are specified uniquely to the @tech{consensus network}. A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first four digits of the account address will be used.
 
 
 @(hrule)
@@ -122,7 +122,7 @@ The details of the secret encoding are specified uniquely to the @tech{consensus
  newAccountFromMnemonic(phrase: string, ?label: string) => Promise<acc> }
 
 Returns a Promise for a Reach @tech{account} abstraction for an @tech{account} on the @tech{consensus network} specified by the given mnemonic phrase.
-The details of the mnemonic phrase encoding are specified uniquely to the @tech{consensus network}. A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first 4 digits of the account address will be used.
+The details of the mnemonic phrase encoding are specified uniquely to the @tech{consensus network}. A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first four digits of the account address will be used.
 
 
 @(hrule)
@@ -131,7 +131,7 @@ The details of the mnemonic phrase encoding are specified uniquely to the @tech{
  newTestAccount(balance, ?label) => Promise<acc> }
 
 Returns a Promise for a Reach @tech{account} abstraction for a new @tech{account} on the @tech{consensus network} with a given balance of @tech{network tokens}. This can only be used in private testing scenarios, as it uses a private faucet to issue @tech{network tokens}.
-A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first 4 digits of the account address will be used.
+A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first four digits of the account address will be used.
 
 @jsin{bigNumberify} is transparently applied to the @jsin{balance} argument.
 
@@ -141,7 +141,7 @@ A @tt{label} that distinguishes the account may optionally be provided to use in
   createAccount(?label) => Promise<acc> }
 
 Returns a Promise for a Reach @tech{account} abstraction for a new @tech{account} on the @tech{consensus network}. The account will have an empty balance of @tech{network tokens}.
-A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first 4 digits of the account address will be used.
+A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first four digits of the account address will be used.
 
 @(hrule)
 @(mint-define! '("fundFromFaucet"))
@@ -158,7 +158,7 @@ Adds the given balance of @tech{network tokens} to a Reach @tech{account} abstra
  connectAccount(networkAccount, ?label) => Promise<acc> }
 
 Returns a Promise for a Reach @tech{account} abstraction for an existing @tech{account} for the @tech{consensus network} based on the @tech{connector}-specific @tech{account} specification provided by the @jsin{networkAccount} argument.
-A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first 4 digits of the account address will be used.
+A @tt{label} that distinguishes the account may optionally be provided to use in debug logs. If no label is provided, then the first four digits of the account address will be used.
 
 @js{
     // network => networkAccount type

--- a/hs/src/Reach/Backend/JS.hs
+++ b/hs/src/Reach/Backend/JS.hs
@@ -513,7 +513,6 @@ jsETail = \case
     let time_defp = "const" <+> timev' <+> "=" <+> txn <> ".time" <> semi <> hardline
     fs_ok' <- withCtxt $ jsFromSpec fs_ok
     let k_defp = msg_vs_defp <> amt_defp <> time_defp <> fs_ok'
-    whop <- jsCon =<< ((DLL_Bytes . ctxt_who) <$> ask)
     k_ok' <- withCtxt $ jsETail k_ok
     let k_okp = k_defp <> k_ok'
     (delayp, k_p) <-
@@ -533,8 +532,7 @@ jsETail = \case
     let recvp =
           jsApply
             "ctc.recv"
-            [ whop
-            , pretty which
+            [ pretty which
             , pretty $ length msg_vs
             , jsArray msg_ctcs
             , "false"
@@ -569,8 +567,7 @@ jsETail = \case
             let sendp =
                   jsApply
                     "ctc.sendrecv"
-                    [ whop
-                    , pretty which
+                    [ pretty which
                     , pretty (length msg_vs)
                     , last_timev'
                     , jsArray msgts

--- a/js/stdlib/ts/FAKE.ts
+++ b/js/stdlib/ts/FAKE.ts
@@ -174,8 +174,9 @@ export const transfer = async (
   BLOCKS.push(block);
 };
 
-export const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> => {
+export const connectAccount = async (networkAccount: NetworkAccount, _label: string): Promise<Account> => {
   const { address } = networkAccount;
+  const label = _label || address.substring(2, 6);
 
   const selfAddress = (): Address => {
     return address;
@@ -216,7 +217,7 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
     };
 
     const sendrecv = async (
-      label: string, funcNum: number, evt_cnt: number,
+      funcNum: number, evt_cnt: number,
       hasLastTime: (BigNumber | false),
       tys: Array<FAKE_Ty>,
       args: Array<any>, value: BigNumber, out_tys: Array<FAKE_Ty>,
@@ -226,7 +227,7 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
     ): Promise<Recv> => {
       void(hasLastTime);
       const doRecv = async (waitIfNotPresent: boolean): Promise<Recv> =>
-        await recv(label, funcNum, evt_cnt, out_tys, waitIfNotPresent, timeout_delay);
+        await recv(funcNum, evt_cnt, out_tys, waitIfNotPresent, timeout_delay);
       if ( ! onlyIf ) {
         return await doRecv(true);
       }
@@ -306,7 +307,7 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
     };
 
     const recv = async (
-      label: string, funcNum: number, ok_cnt: number, out_tys: Array<FAKE_Ty>,
+      funcNum: number, ok_cnt: number, out_tys: Array<FAKE_Ty>,
       waitIfNotPresent: boolean, timeout_delay: BigNumber | false,
     ): Promise<Recv> => {
       void(ok_cnt);
@@ -384,7 +385,7 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
 };
 
 const REACHY_RICH_P: Promise<Account> = (async () => {
-  return await connectAccount({address: T_Address.defaultValue});
+  return await connectAccount({address: T_Address.defaultValue}, "Faucet");
 })();
 
 export async function getDefaultAccount(): Promise<Account> {
@@ -395,18 +396,18 @@ export async function getFaucet(): Promise<Account> {
   return REACHY_RICH_P;
 }
 
-export const newTestAccount = async (startingBalance: any) => {
-  const account = await createAccount();
+export const newTestAccount = async (startingBalance: any, label: string) => {
+  const account = await createAccount(label);
   debug(`new account: ${account.networkAccount.address}`);
   await fundFromFaucet(account, startingBalance);
   return account;
 };
 
-export const createAccount = async () => {
+export const createAccount = async (label: string) => {
   // Create account without any starting balance
   const networkAccount = makeAccount();
   debug(`createAccount: ${networkAccount.address}`);
-  return await connectAccount(networkAccount);
+  return await connectAccount(networkAccount, label);
 }
 
 export function getNetworkTime() {

--- a/js/stdlib/ts/shared.ts
+++ b/js/stdlib/ts/shared.ts
@@ -41,14 +41,14 @@ export type IContract<ContractInfo, Digest, RawAddress, ConnectorTy extends AnyB
   getInfo: () => Promise<ContractInfo>,
   creationTime: () => Promise<BigNumber>,
   sendrecv: (
-    label: string, funcNum: number, evt_cnt: number, hasLastTime: (BigNumber | false),
+    funcNum: number, evt_cnt: number, hasLastTime: (BigNumber | false),
     tys: Array<ConnectorTy>,
     args: Array<any>, value: BigNumber, out_tys: Array<ConnectorTy>,
     onlyIf: boolean, soloSend: boolean,
     timeout_delay: BigNumber | false, sim_p: (fake: IRecv<RawAddress>) => Promise<ISimRes<Digest, RawAddress>>,
   ) => Promise<IRecv<RawAddress>>,
   recv: (
-    label: string, okNum: number, ok_cnt: number, out_tys: Array<ConnectorTy>,
+    okNum: number, ok_cnt: number, out_tys: Array<ConnectorTy>,
     waitIfNotPresent: boolean,
     timeout_delay: BigNumber | false,
   ) => Promise<IRecv<RawAddress>>,


### PR DESCRIPTION
Have the frontend provide the labels to use for debugging instead of generating them from the Participant name. If a label is not provided it will default to the first 4 digits of the address