### PR TITLE
NOT A REAL PR (yet): CFX ugly impl vs classy impl 

### DIFF
--- a/js/js-deps/package.json
+++ b/js/js-deps/package.json
@@ -20,6 +20,7 @@
     "ethers": "^5.0.32",
     "express": "^4.17.1",
     "hi-base32": "^0.5.0",
+    "js-conflux-sdk": "^1.5.15",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "^4.0.3",

--- a/js/stdlib/package.mo.json
+++ b/js/stdlib/package.mo.json
@@ -20,6 +20,7 @@
     "ethers": "^5.0.32",
     "express": "^4.17.1",
     "hi-base32": "^0.5.0",
+    "js-conflux-sdk": "^1.5.15",
     "wait-port": "^0.2.9"
   },
   "repository": {

--- a/js/stdlib/ts/CFX.ts
+++ b/js/stdlib/ts/CFX.ts
@@ -1,0 +1,1264 @@
+import * as ethers from './cfxers'; // Not Actually Ethers
+import * as real_ethers from 'ethers';
+
+import cfxsdk from 'js-conflux-sdk';
+const { Conflux } = cfxsdk;
+
+// ****************************************************************************
+// standard library for Javascript users
+// ****************************************************************************
+
+import Timeout from 'await-timeout';
+// import ethers, { Signer } from 'ethers';
+// import http from 'http';
+// import url from 'url';
+// import waitPort from 'wait-port';
+// import {window, process} from './shim';
+// import { ConnectorMode, getConnectorMode } from './ConnectorMode';
+import {
+  add,
+  assert,
+  bigNumberify,
+  debug,
+  eq,
+  ge,
+  // getDEBUG, // XXX
+  lt,
+  CurrencyAmount,
+  IAccount,
+  IContract,
+  IRecv,
+  OnProgress,
+  // WPArgs, // XXX
+  makeRandom,
+  argsSplit,
+} from './shared';
+import {
+  memoizeThunk, // replaceableThunk // XXX
+} from './shared_impl';
+export * from './shared';
+import {
+  AnyETH_Ty,
+  Token,
+  PayAmt,
+  stdlib as compiledEthStdlib,
+  typeDefs as ethTypeDefs,
+} from './ETH_compiled';
+
+// ****************************************************************************
+// Type Definitions
+// ****************************************************************************
+type BigNumber = real_ethers.BigNumber; // XXX
+
+type Provider = ethers.providers.Provider;
+type TransactionReceipt = ethers.providers.TransactionReceipt;
+type Wallet = ethers.Wallet;
+type Log = ethers.providers.Log;
+
+// Note: if you want your programs to exit fail
+// on unhandled promise rejection, use:
+// node --unhandled-rejections=strict
+
+type DeployMode = 'DM_firstMsg' | 'DM_constructor';
+type Backend = {_Connectors: {ETH: {
+  ABI: string,
+  Bytecode: string,
+  deployMode: DeployMode
+}}};
+
+
+// TODO: a wrapper obj with smart constructor?
+type Address = string;
+
+/*
+type NetworkAccount = {
+  address?: Address, // required for receivers & deployers
+  getAddress?: () => Promise<Address>, // or this for receivers & deployers
+  sendTransaction?: (...xs: any) => any, // required for senders
+  getBalance?: (...xs: any) => any, // TODO: better type
+} | Wallet | Signer; // required to deploy/attach
+*/
+
+type ContractInfo = {
+  address: Address,
+  creation_block: number,
+  creator: Address,
+  transactionHash?: Hash,
+  init?: ContractInitInfo,
+};
+
+type Digest = string // XXX
+type Recv = IRecv<Address>
+type Contract = IContract<ContractInfo, Digest, Address, Token, AnyETH_Ty>;
+type Account = IAccount<NetworkAccount, Backend, Contract, ContractInfo>
+  | any /* union in this field: { setGasLimit: (ngl:any) => void } */;
+
+// For when you init the contract with the 1st message
+type ContractInitInfo = {
+  args: Array<any>,
+  value: BigNumber,
+};
+
+// For either deployment case
+type ContractInitInfo2 = {
+  argsMay: Maybe<Array<any>>,
+  value: BigNumber,
+};
+
+type AccountTransferable = Account | {
+  networkAccount: NetworkAccount,
+}
+
+
+// ****************************************************************************
+// Helpers
+// ****************************************************************************
+
+// Given a func that takes an optional arg, and a Maybe arg:
+// f: (arg?: X) => Y
+// arg: Maybe<X>
+//
+// You can apply the function like this:
+// f(...argMay)
+type Some<T> = [T];
+type None = [];
+type Maybe<T> = None | Some<T>;
+function isNone<T>(m: Maybe<T>): m is None {
+  return m.length === 0;
+}
+function isSome<T>(m: Maybe<T>): m is Some<T> {
+  return !isNone(m);
+}
+const Some = <T>(m: T): Some<T> => [m];
+const None: None = [];
+void(isSome);
+
+/*
+const connectorMode: ConnectorMode = getConnectorMode();
+
+// Certain functions either behave differently,
+// or are only available on an "isolated" network.
+// Note: ETH-browser is NOT considered isolated.
+const isIsolatedNetwork: boolean =
+  connectorMode.startsWith('ETH-test-dockerized') ||
+  // @ts-ignore
+  process.env['REACH_ISOLATED_NETWORK'];
+
+type NetworkDesc =
+  {type: 'uri', uri: string, network: string} |
+  {type: 'window'} |
+  {type: 'skip'}
+
+const networkDesc: NetworkDesc =
+  (connectorMode == 'ETH-test-dockerized-geth' ||
+   connectorMode == 'ETH-live') ? {
+  type: 'uri',
+  uri: process.env.ETH_NODE_URI || 'http://localhost:8545',
+  network: process.env.ETH_NODE_NETWORK || 'unspecified',
+} : connectorMode == 'ETH-browser' ? {
+  type: 'window',
+} : {
+  type: 'skip',
+};
+
+const protocolPort = {
+  'https:': 443,
+  'http:': 80,
+};
+
+const getPortConnection = memoizeThunk(async () => {
+  debug('getPortConnection');
+  if (networkDesc.type != 'uri') { return; }
+  const { hostname, port, protocol } = url.parse(networkDesc.uri);
+  if (!(protocol === 'http:' || protocol === 'https:')) {
+    throw Error(`Unsupported protocol ${protocol}`);
+  }
+  const args: WPArgs = {
+    host: hostname || undefined,
+    port: (port && parseInt(port, 10)) || protocolPort[protocol],
+    output: 'silent',
+    timeout: 1000 * 60 * 1,
+  }
+  debug('waitPort');
+  if (getDEBUG()) {
+    console.log(args)
+  }
+  await waitPort(args);
+  debug('waitPort complete');
+});
+
+// XXX: doesn't even retry, just returns the first attempt
+const doHealthcheck = async (): Promise<void> => {
+  debug('doHealthcheck');
+  if (networkDesc.type != 'uri') { return; }
+  const uriObj = url.parse(networkDesc.uri);
+
+  // XXX the code below only supports http
+  if (uriObj.protocol !== 'http:') { return; }
+
+  await new Promise((resolve, reject) => {
+    const data = JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'web3_clientVersion',
+      params: [],
+      id: 67,
+    });
+    debug('Sending health check request...');
+    const opts = {
+      ...uriObj,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': data.length,
+      },
+    };
+    const req = http.request(opts, (res) => {
+      debug(`statusCode: ${res.statusCode}`);
+      res.on('data', (d) => {
+        debug('rpc health check succeeded');
+        if (getDEBUG()) {
+          process.stdout.write(d);
+        }
+        resolve({ res, d });
+      });
+    });
+    req.on('error', (e) => {
+      console.log('rpc health check failed');
+      console.log(e);
+      reject(e);
+    });
+    req.write(data);
+    debug('attached all the handlers...');
+    req.end();
+    debug('req.end...');
+  });
+};
+
+const getDevnet = memoizeThunk(async (): Promise<void> => {
+  await getPortConnection();
+  return await doHealthcheck();
+});
+
+*/
+
+/** @description convenience function for drilling down to the actual address */
+const getAddr = async (acc: AccountTransferable): Promise<Address> => {
+  if (!acc.networkAccount) throw Error(`Expected acc.networkAccount`);
+  // TODO better type design here
+  // @ts-ignore
+  if (acc.networkAccount.address) {
+    // @ts-ignore
+    return acc.networkAccount.address;
+  }
+  if (acc.networkAccount.getAddress) {
+    return await acc.networkAccount.getAddress();
+  }
+  throw Error(`Expected acc.networkAccount.address or acc.networkAccount.getAddress`);
+}
+
+type Hash = string;
+
+const rejectInvalidReceiptFor = async (txHash: Hash, r?: TransactionReceipt): Promise<TransactionReceipt> =>
+  new Promise((resolve, reject) =>
+    !r ? reject(`No receipt for txHash: ${txHash}`) :
+    r.transactionHash !== txHash ? reject(`Bad txHash; ${txHash} !== ${r.transactionHash}`) :
+    !r.status ? reject(`Transaction: ${txHash} was reverted by EVM\n${r}`) :
+    resolve(r));
+
+const fetchAndRejectInvalidReceiptFor = async (txHash: Hash) => {
+  const provider = await getProvider();
+  const r = await provider.getTransactionReceipt(txHash);
+  return await rejectInvalidReceiptFor(txHash, r);
+};
+
+/*
+const [getProvider, setProvider] = replaceableThunk(async (): Promise<Provider> => {
+  if (networkDesc.type == 'uri') {
+    await getDevnet();
+    const provider = new ethers.providers.JsonRpcProvider(networkDesc.uri);
+    provider.pollingInterval = 500; // ms
+    return provider;
+  } else if (networkDesc.type == 'window') {
+    if (window.ethereum) {
+      const provider = new ethers.providers.Web3Provider(window.ethereum);
+      // The proper way to ask MetaMask to enable itself is eth_requestAccounts
+      // https://eips.ethereum.org/EIPS/eip-1102
+      await provider.send('eth_requestAccounts', []);
+      return provider;
+    } else {
+      throw Error(`window.ethereum is not defined`);
+    }
+  } else {
+    // This lib was imported, but not for its net connection.
+    throw Error(`Using stdlib/ETH is incompatible with REACH_CONNECTOR_MODE=${connectorMode}`);
+  }
+});
+*/
+
+const getNetworkTimeNumber = async (): Promise<number> => {
+  const provider = await getProvider();
+  return await provider.getBlockNumber();
+};
+
+const fastForwardTo = async (targetTime: BigNumber, onProgress?: OnProgress): Promise<BigNumber> => {
+  // console.log(`>>> FFWD TO: ${targetTime}`);
+  const onProg: OnProgress = onProgress || (() => {});
+  requireIsolatedNetwork('fastForwardTo');
+  let currentTime;
+  while (lt(currentTime = await getNetworkTime(), targetTime)) {
+    onProg({ currentTime, targetTime });
+    await stepTime();
+  }
+  // Also report progress at completion time
+  onProg({ currentTime, targetTime });
+  // console.log(`<<< FFWD TO: ${targetTime} complete. It's ${currentTime}`);
+  return currentTime;
+};
+
+const requireIsolatedNetwork = (label: string): void => {
+  if (!isIsolatedNetwork) {
+    throw Error(`Invalid operation ${label} in REACH_CONNECTOR_MODE=${connectorMode}`);
+  }
+};
+
+const initOrDefaultArgs = (init?: ContractInitInfo): ContractInitInfo2 => ({
+  argsMay: init ? Some(init.args) : None,
+  value: init ? init.value : bigNumberify(0),
+});
+
+// onProgress callback is optional, it will be given an obj
+// {currentTime, targetTime}
+const actuallyWaitUntilTime = async (targetTime: BigNumber, onProgress?: OnProgress): Promise<BigNumber> => {
+  const onProg: OnProgress = onProgress || (() => {});
+  const provider = await getProvider();
+  return await new Promise((resolve) => {
+    const onBlock = async (currentTimeNum: number | BigNumber) => {
+      const currentTime = bigNumberify(currentTimeNum)
+      // Does not block on the progress fn if it is async
+      onProg({ currentTime, targetTime });
+      if (ge(currentTime, targetTime)) {
+        provider.off('block', onBlock);
+        resolve(currentTime);
+      }
+    };
+    provider.on('block', onBlock);
+
+    // Also "re-emit" the current block
+    // Note: this sometimes causes the starting block
+    // to be processed twice, which should be harmless.
+    getNetworkTime().then(onBlock);
+  });
+};
+
+const getDummyAccount = memoizeThunk(async (): Promise<Account> => {
+  const provider = await getProvider();
+  const networkAccount = ethers.Wallet.createRandom().connect(provider);
+  const acc = await connectAccount(networkAccount);
+  return acc;
+});
+
+const stepTime = async (): Promise<TransactionReceipt> => {
+  requireIsolatedNetwork('stepTime');
+  const faucet = await getFaucet();
+  const acc = await getDummyAccount();
+  return await transfer(faucet, acc, parseCurrency(0));
+};
+
+// ****************************************************************************
+// Common Interface Exports
+// ****************************************************************************
+
+export const { digest } = compiledEthStdlib;
+// XXX Do not use ETH-style addressEq
+export const addressEq = (a1: string, a2: string) => a1 == a2;
+
+export const { T_Null, T_Bool, T_UInt, T_Tuple, T_Array, T_Object, T_Data, T_Bytes, T_Digest, T_Struct } = ethTypeDefs;
+export const T_Address = {
+  ...ethTypeDefs.T_Address,
+  // XXX Do not canonicalize CFX addresses as though they were ETH addresses
+  canonicalize: (uv: unknown): string => uv as string,
+}
+const typeDefs = {
+  ...ethTypeDefs,
+  T_Address,
+}
+
+const compiledStdlib = {
+  ...compiledEthStdlib,
+  typeDefs,
+  addressEq,
+};
+
+export const { randomUInt, hasRandom } = makeRandom(32);
+
+// export {setProvider};
+
+export const balanceOf = async (acc: Account): Promise<BigNumber> => {
+  const { networkAccount } = acc;
+  if (!networkAccount) throw Error(`acc.networkAccount missing. Got: ${acc}`);
+
+  if (networkAccount.getBalance) {
+    return bigNumberify(await networkAccount.getBalance());
+  }
+
+  const addr = await getAddr(acc);
+  if (addr) {
+    const provider = await getProvider();
+    return bigNumberify(await provider.getBalance(addr));
+  }
+  throw Error(`address missing. Got: ${networkAccount}`);
+};
+
+/** @description Arg order follows "src before dst" convention */
+export const transfer = async (
+  from: AccountTransferable,
+  to: AccountTransferable,
+  value: any
+): Promise<any> => {
+  const sender = from.networkAccount;
+  const receiver = getAddr(to);
+  const txn = { to: receiver, value: bigNumberify(value) };
+
+  if (!sender || !sender.sendTransaction)
+    throw Error(`Expected from.networkAccount.sendTransaction: ${from}`);
+
+  debug(`sender.sendTransaction(${JSON.stringify(txn)})`);
+  const r = await (await sender.sendTransaction(txn)).wait();
+
+  assert(r !== null);
+
+  return fetchAndRejectInvalidReceiptFor(r.transactionHash);
+};
+
+
+export const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> => {
+  // @ts-ignore // TODO
+  if (networkAccount.getAddress && !networkAccount.address) {
+    // @ts-ignore
+    networkAccount.address = await getAddr({networkAccount});
+  }
+
+  // XXX networkAccount MUST be a Wallet or Signer to deploy/attach
+  const provider = await getProvider();
+  const address = await getAddr({networkAccount});
+  if (!address) { throw Error(`Expected networkAccount.address: ${networkAccount}`); }
+  const shad = address.substring(7, 11); // XXX
+  let label = shad;
+  // const shad = address.substring(2, 6);
+
+  const iam = (some_addr: Address): Address => {
+    if (some_addr == address) {
+      return address;
+    } else {
+      throw Error(`I should be ${some_addr}, but am ${address}`);
+    }
+  };
+
+  const selfAddress = (): Address => {
+    return address;
+  }
+
+  let gasLimit:BigNumber;
+  const setGasLimit = (ngl:any): void => {
+    gasLimit = bigNumberify(ngl); };
+
+  const deploy = (bin: Backend): Contract => {
+    if (!ethers.Signer.isSigner(networkAccount)) {
+      throw Error(`Signer required to deploy, ${networkAccount}`);
+    }
+
+    const {infoP, resolveInfo} = (() => {
+      let resolveInfo = (info: ContractInfo) => { void(info); };
+      const infoP = new Promise<ContractInfo>(resolve => {
+        resolveInfo = resolve;
+      });
+      return {infoP, resolveInfo};
+    })();
+
+    const performDeploy = (
+      init?: ContractInitInfo
+    ): Contract => {
+      debug(`${shad}: performDeploy with ${JSON.stringify(init)}`);
+      const { argsMay, value } = initOrDefaultArgs(init);
+
+      const { ABI, Bytecode } = bin._Connectors.ETH;
+      debug(`${shad}: making contract factory`);
+      const factory = new ethers.ContractFactory(ABI, Bytecode, networkAccount);
+
+      (async () => {
+        debug(`${shad}: deploying factory`);
+        const contract = await factory.deploy(...argsMay, { value, gasLimit });
+        debug(`${shad}: deploying factory; done: ${contract.address}`);
+        debug(`${shad}: waiting for receipt: ${contract.deployTransaction.hash}`);
+        const deploy_r = await contract.deployTransaction.wait();
+        debug(`${shad}: got receipt; ${deploy_r.blockNumber}`);
+        if (!contract.address) throw Error(`impossible: address is undefined`);
+        const info: ContractInfo = {
+          address: contract.address,
+          creation_block: deploy_r.blockNumber,
+          creator: address,
+          transactionHash: deploy_r.transactionHash,
+          init,
+        };
+        resolveInfo(info);
+      })();
+      return attach(bin, infoP);
+    };
+
+    const attachDeferDeploy = (): Contract => {
+      // impl starts with a shim that deploys on first sendrecv,
+      // then replaces itself with the real impl once deployed.
+      let impl: Contract = {
+        recv: async (...args) => {
+          void(args);
+          throw Error(`Cannot recv yet; contract is not actually deployed`);
+        },
+        wait: async (...args) => {
+          // Wait times are relative to contract events
+          // Wait without an initial contract event is nonsense
+          void(args);
+          throw Error(`Cannot wait yet; contract is not actually deployed`);
+        },
+        sendrecv: async (
+          funcNum: number, evt_cnt: number,
+          hasLastTime: (BigNumber | false),
+          tys: Array<AnyETH_Ty>,
+          args: Array<any>, pay: PayAmt, out_tys: Array<AnyETH_Ty>,
+          onlyIf: boolean, soloSend: boolean,
+          timeout_delay: BigNumber | false, sim_p: any,
+        ): Promise<Recv> => {
+          debug(shad, ':', label, 'sendrecv m', funcNum, '(deferred deploy)');
+          void(evt_cnt);
+          void(sim_p);
+          // TODO: munge/unmunge roundtrip?
+          void(hasLastTime);
+          void(tys);
+          void(out_tys);
+          const [ value, toks ] = pay;
+          void(toks); // XXX
+
+          // The following must be true for the first sendrecv.
+          try {
+            assert(onlyIf, true);
+            assert(soloSend, true);
+            assert(eq(funcNum, 1));
+            assert(!timeout_delay);
+          } catch (e) {
+            throw Error(`impossible: Deferred deploy sendrecv assumptions violated.\n${e}`);
+          }
+
+          // shim impl is replaced with real impl
+          impl = performDeploy({args: [[0], args], value});
+          await infoP; // Wait for the deploy to actually happen.
+
+          // simulated recv
+          return await impl.recv(funcNum, evt_cnt, out_tys, false,timeout_delay);
+        },
+        getInfo: async () => {
+          // Danger: deadlock possible
+          return await infoP;
+        },
+        creationTime: (async () => bigNumberify((await infoP).creation_block)),
+        // iam/selfAddress don't make sense to check before ctc deploy, but are harmless.
+        iam,
+        selfAddress,
+        stdlib: compiledStdlib,
+      };
+      // Return a wrapper around the impl. This obj and its fields do not mutate,
+      // but the fields are closures around a mutating ref to impl.
+      return {
+        sendrecv: (...args) => impl.sendrecv(...args),
+        recv: (...args) => impl.recv(...args),
+        wait: (...args) => impl.wait(...args),
+        getInfo: (...args) => impl.getInfo(...args),
+        creationTime: (...args) => impl.creationTime(...args),
+        iam: (...args) => impl.iam(...args),
+        selfAddress: (...args) => impl.selfAddress(...args),
+        stdlib: compiledStdlib,
+      }
+    }
+
+    switch (bin._Connectors.ETH.deployMode) {
+      case 'DM_firstMsg':
+        return attachDeferDeploy();
+      case 'DM_constructor':
+        return performDeploy();
+      default:
+        throw Error(`Unrecognized deployMode: ${bin._Connectors.ETH.deployMode}`);
+    };
+  };
+
+  const attach = (
+    bin: Backend,
+    infoP: ContractInfo | Promise<ContractInfo>,
+  ): Contract => {
+    // unofficially: infoP can also be Contract
+    // This should be considered deprecated
+    // TODO: remove at next Reach version bump?
+    // @ts-ignore
+    if (infoP.getInfo) {
+      console.log(
+        `Calling attach with another Contract is deprecated.`
+        + ` Please replace accBob.attach(backend, ctcAlice)`
+        + ` with accBob.attach(bin, ctcAlice.getInfo())`
+      );
+      // @ts-ignore
+      infoP = infoP.getInfo();
+    }
+
+    const ABI = JSON.parse(bin._Connectors.ETH.ABI);
+
+    // Attached state
+    const {getLastBlock, setLastBlock} = (() => {
+      let lastBlock: number | null = null;
+      const setLastBlock = (n: number): void => {
+        debug(`lastBlock from ${lastBlock} to ${n}`);
+        lastBlock = n;
+      };
+      const getLastBlock = async (): Promise<number> => {
+        if (typeof lastBlock === 'number') { return lastBlock; }
+        const info = await infoP;
+        setLastBlock(info.creation_block);
+        return info.creation_block;
+      }
+      return {getLastBlock, setLastBlock};
+    })();
+
+    const updateLast = (o: {blockNumber?: number}): void => {
+      if (!o.blockNumber) {
+        console.log(o);
+        throw Error(`Expected blockNumber in ${Object.keys(o)}`);
+      }
+      setLastBlock(o.blockNumber);
+    };
+
+    const getC = (() => {
+      let _ethersC: ethers.Contract | null = null;
+      return async () => {
+        if (_ethersC) { return _ethersC; }
+        const info = await infoP;
+        await verifyContract(info, bin);
+        debug(`${shad}: contract verified`);
+        if (!ethers.Signer.isSigner(networkAccount)) {
+          throw Error(`networkAccount must be a Signer (read: Wallet). ${networkAccount}`);
+        }
+        _ethersC = new ethers.Contract(info.address, ABI, networkAccount);
+        return _ethersC;
+      }
+    })();
+
+    const callC = async (
+      funcName: string, arg: any, value: BigNumber,
+    ): Promise<{wait: () => Promise<TransactionReceipt>}> => {
+      return (await getC())[funcName](arg, { value, gasLimit });
+    };
+
+    const getEventData = async (
+      ok_evt: string, ok_e: Log
+    ): Promise<Array<any>> => {
+      const ethersC = await getC();
+      const ok_args_abi = ethersC.interface.getEvent(ok_evt).inputs;
+      const { args } = ethersC.interface.parseLog(ok_e);
+      return ok_args_abi.map((a: any) => args[a.name]);
+    };
+
+    const getLogs = async (
+      fromBlock: number, toBlock: number, ok_evt: string,
+    ): Promise<Array<Log>> => {
+      if ( fromBlock > toBlock ) { return []; }
+      const ethersC = await getC();
+      if (!ethersC.address) throw Error(`Impossible, address is undefined`);
+      return await provider.getLogs({
+        fromBlock,
+        toBlock,
+        address: ethersC.address,
+        topics: [ethersC.interface.getEventTopic(ok_evt)],
+      });
+    }
+
+    const getInfo = async () => await infoP;
+
+    const sendrecv_impl = async (
+      funcNum: number, evt_cnt: number,
+      hasLastTime: (BigNumber | false), tys: Array<AnyETH_Ty>,
+      args: Array<any>, pay: PayAmt, out_tys: Array<AnyETH_Ty>,
+      onlyIf: boolean, soloSend: boolean,
+      timeout_delay: BigNumber | false,
+    ): Promise<Recv> => {
+      void(hasLastTime);
+      const [ value, tok ] = pay;
+      void(tok); // XXX
+
+      const doRecv = async (waitIfNotPresent: boolean): Promise<Recv> =>
+        await recv_impl(funcNum, out_tys, waitIfNotPresent, timeout_delay);
+      if ( ! onlyIf ) {
+        return await doRecv(true);
+      }
+
+      const funcName = `m${funcNum}`;
+      if (tys.length !== args.length) {
+        throw Error(`tys.length (${tys.length}) !== args.length (${args.length})`);
+      }
+
+      debug(`${shad}: ${label} send ${funcName} ${timeout_delay} --- SEND --- ARGS ${JSON.stringify(args)}`);
+      const [ args_svs, args_msg ] = argsSplit(args, evt_cnt );
+      const [ tys_svs, tys_msg ] = argsSplit(tys, evt_cnt);
+      // @ts-ignore XXX
+      const arg_ty = T_Tuple([T_Tuple(tys_svs), T_Tuple(tys_msg)]);
+      const arg = arg_ty.munge([args_svs, args_msg]);
+
+      debug(`${shad}: ${label} send ${funcName} ${timeout_delay} --- START --- ${JSON.stringify(arg)}`);
+      const lastBlock = await getLastBlock();
+      let block_send_attempt = lastBlock;
+      let block_repeat_count = 0;
+      while (!timeout_delay || lt(block_send_attempt, add(lastBlock, timeout_delay))) {
+        let r_maybe: TransactionReceipt | null = null;
+
+        debug(`${shad}: ${label} send ${funcName} ${timeout_delay} --- TRY`);
+        try {
+          debug(`${shad}: ${label} send ${funcName} ${timeout_delay} --- SEND ARG --- ${JSON.stringify(arg)} --- ${JSON.stringify(value)}`);
+
+          const r_fn = await callC(funcName, arg, value);
+          debug(`${shad}: ${label} send ${funcName} ${timeout_delay} --- POST CALL`);
+
+          r_maybe = await r_fn.wait();
+          debug(`${shad}: ${label} send ${funcName} ${timeout_delay} --- POST WAIT`);
+
+          assert(r_maybe !== null);
+          const ok_r = await fetchAndRejectInvalidReceiptFor(r_maybe.transactionHash);
+          debug(`${shad}: ${label} send ${funcName} ${timeout_delay} --- OKAY`);
+
+          // XXX It might be a little dangerous to rely on the polling to just work
+
+          // It may be the case that the next line could speed things up?
+          // last_block = ok_r.blockNumber;
+          // XXX ^ but do not globally mutate lastBlock.
+          // wait relies on lastBlock to refer to the last ctc event
+          void(ok_r);
+
+        } catch (e) {
+
+          if ( ! soloSend ) {
+          debug(`${shad}: ${label} send ${funcName} ${timeout_delay} --- SKIPPING (${e})`);
+          } else {
+          debug(`${shad}: ${label} send ${funcName} ${timeout_delay} --- ERROR: ${e.stack}`);
+
+          // XXX What should we do...? If we fail, but there's no timeout delay... then we should just die
+          await Timeout.set(1);
+          const current_block = await getNetworkTimeNumber();
+          if (current_block == block_send_attempt) {
+            block_repeat_count++;
+          }
+          block_send_attempt = current_block;
+          // XXX for debugging it's best to just let the first error throw
+          if ( /* timeout_delay && */ block_repeat_count > -1 /* 32 */) {
+            if (e.code === 'UNPREDICTABLE_GAS_LIMIT') {
+              let error = e;
+              while (error.error) { error = error.error; }
+              console.log(`impossible: The message you are trying to send appears to be invalid.`);
+              console.log(error);
+            }
+            console.log(`args:`);
+            console.log(arg);
+            throw Error(`${shad}: ${label} send ${funcName} ${timeout_delay} --- REPEAT @ ${block_send_attempt} x ${block_repeat_count}`);
+          }
+          debug(`${shad}: ${label} send ${funcName} ${timeout_delay} --- TRY FAIL --- ${lastBlock} ${current_block} ${block_repeat_count} ${block_send_attempt}`);
+          continue;
+          }
+        }
+
+        return await doRecv(false);
+      }
+
+      // XXX If we were trying to join, but we got sniped, then we'll
+      // think that there is a timeout and then we'll wait forever for
+      // the timeout message.
+
+      debug(`${shad}: ${label} send ${funcName} ${timeout_delay} --- FAIL/TIMEOUT`);
+      return {didTimeout: true};
+    };
+
+    const sendrecv = async (
+      funcNum: number, evt_cnt: number, hasLastTime: (BigNumber | false),
+      tys: Array<AnyETH_Ty>,
+      args: Array<any>, pay: PayAmt, out_tys: Array<AnyETH_Ty>,
+      onlyIf: boolean, soloSend: boolean,
+      timeout_delay: BigNumber | false, sim_p: any,
+    ): Promise<Recv> => {
+      void(sim_p);
+      return await sendrecv_impl(funcNum, evt_cnt, hasLastTime, tys, args, pay, out_tys, onlyIf, soloSend, timeout_delay);
+    }
+
+    // https://docs.ethers.io/ethers.js/html/api-contract.html#configuring-events
+    const recv_impl = async (
+      okNum: number, out_tys: Array<AnyETH_Ty>,
+      waitIfNotPresent: boolean,
+      timeout_delay: BigNumber | false,
+    ): Promise<Recv> => {
+      const isFirstMsgDeploy = (okNum == 1) && (bin._Connectors.ETH.deployMode == 'DM_firstMsg');
+      const lastBlock = await getLastBlock();
+      const ok_evt = `e${okNum}`;
+      debug(`${shad}: ${label} recv ${ok_evt} ${timeout_delay} --- START`);
+
+      // look after the last block
+      const block_poll_start_init: number =
+        lastBlock + (isFirstMsgDeploy ? 0 : 1);
+      let block_poll_start: number = block_poll_start_init;
+      let block_poll_end = block_poll_start;
+      while (!timeout_delay || lt(block_poll_start, add(lastBlock, timeout_delay))) {
+        debug(`${shad}: ${label} recv ${ok_evt} --- GET ${block_poll_start} ${block_poll_end}`);
+        const es = await getLogs(block_poll_start, block_poll_end, ok_evt);
+        if (es.length == 0) {
+          debug(`${shad}: ${label} recv ${ok_evt} ${timeout_delay} --- RETRY`);
+          block_poll_start = block_poll_end;
+
+          await Timeout.set(1);
+          block_poll_end = await getNetworkTimeNumber();
+          if ( waitIfNotPresent && block_poll_start == block_poll_end ) {
+            await waitUntilTime(bigNumberify(block_poll_end + 1));
+          }
+          if ( block_poll_start <= lastBlock ) {
+            block_poll_start = block_poll_start_init; }
+
+          continue;
+        } else {
+          debug(`${shad}: ${label} recv ${ok_evt} ${timeout_delay} --- OKAY`);
+
+          const ok_e = es[0];
+          const ok_r = await fetchAndRejectInvalidReceiptFor(ok_e.transactionHash);
+          void(ok_r);
+          const ok_t = await provider.getTransaction(ok_e.transactionHash);
+          // The .gas field doesn't exist on this anymore, apparently?
+          // debug(`${ok_evt} gas was ${ok_t.gas} ${ok_t.gasPrice}`);
+
+          if (ok_t.blockNumber) {
+            assert(ok_t.blockNumber == ok_r.blockNumber,
+              'recept & transaction block numbers should match');
+            if (ok_e.blockNumber) {
+              assert(ok_t.blockNumber == ok_e.blockNumber,
+                'event & transaction block numbers should match');
+            }
+          } else {
+            // XXX For some reason ok_t sometimes doesn't have blockNumber
+            // console.log(`WARNING: no blockNumber on transaction.`);
+            // console.log(ok_t);
+          }
+
+          debug(`${shad}: ${label} recv ${ok_evt} --- AT ${ok_r.blockNumber}`);
+          updateLast(ok_r);
+          const ok_ed = await getEventData(ok_evt, ok_e);
+          debug(`${shad}: ${label} recv ${ok_evt} --- DATA -- ${JSON.stringify(ok_ed)}`);
+          const ok_vals = ok_ed[0][1];
+
+          debug(`${shad}: ${label} recv ${ok_evt} --- MSG -- ${JSON.stringify(ok_vals)}`);
+          const data = T_Tuple(out_tys).unmunge(ok_vals);
+
+          const getOutput = async (o_lab:String, o_ctc:any): Promise<any> => {
+            let dhead = `${shad}: ${label} recv ${ok_evt} --- getOutput: ${o_lab} ${JSON.stringify(o_ctc)}`;
+            debug(`${dhead}`);
+            const oe_evt = `oe_${o_lab}`;
+            const theBlock = ok_r.blockNumber;
+            dhead = `${dhead} oe(${JSON.stringify(oe_evt)})`;
+            const oe_e = (await getLogs(theBlock, theBlock, oe_evt))[0];
+            dhead = `${dhead} log(${JSON.stringify(oe_e)})`;
+            debug(`${dhead}`);
+            const oe_ed = (await getEventData(oe_evt, oe_e))[0];
+            dhead = `${dhead} data(${JSON.stringify(oe_ed)})`;
+            debug(`${dhead}`);
+            const oe_edu = o_ctc.unmunge(oe_ed);
+            dhead = `${dhead} unmunge(${JSON.stringify(oe_edu)})`;
+            debug(`${dhead}`);
+            return oe_edu;
+          };
+
+
+          debug(`${shad}: ${label} recv ${ok_evt} ${timeout_delay} --- OKAY --- ${JSON.stringify(ok_vals)}`);
+          return { didTimeout: false,
+                   time: bigNumberify(ok_r.blockNumber),
+                   data, getOutput,
+                   from: ok_t.from };
+
+        }
+      }
+
+      debug(`${shad}: ${label} recv ${ok_evt} ${timeout_delay} --- TIMEOUT`);
+      return {didTimeout: true} ;
+    };
+
+    const recv = async (
+      okNum: number, ok_cnt: number, out_tys: Array<AnyETH_Ty>,
+      waitIfNotPresent: boolean, timeout_delay: BigNumber | false,
+    ): Promise<Recv> => {
+      void(ok_cnt);
+      return await recv_impl(okNum, out_tys, waitIfNotPresent, timeout_delay);
+    };
+
+    const wait = async (delta: BigNumber) => {
+      const lastBlock = await getLastBlock();
+      // Don't wait from current time, wait from last_block
+      debug(`=====Waiting ${delta} from ${lastBlock}: ${address}`);
+      const p = await waitUntilTime(add(lastBlock, delta));
+      debug(`=====Done waiting ${delta} from ${lastBlock}: ${address}`);
+      return p;
+    }
+
+    const creationTime = (async () => bigNumberify((await getInfo()).creation_block));
+
+    // Note: wait is the local one not the global one of the same name.
+    return { getInfo, creationTime, sendrecv, recv, wait, iam, selfAddress, stdlib: compiledStdlib };
+  };
+
+  return { deploy, attach, networkAccount, setGasLimit, getAddress: selfAddress, stdlib: compiledStdlib };
+};
+
+export const newAccountFromSecret = async (secret: string): Promise<Account> => {
+  const provider = await getProvider();
+  const networkAccount = (new ethers.Wallet(secret)).connect(provider);
+  const acc = await connectAccount(networkAccount);
+  return acc;
+};
+
+export const newAccountFromMnemonic = async (phrase: string): Promise<Account> => {
+  const provider = await getProvider();
+  const networkAccount = ethers.Wallet.fromMnemonic(phrase).connect(provider);
+  const acc = await connectAccount(networkAccount);
+  return acc;
+};
+
+/*
+export const getDefaultAccount = memoizeThunk(async (): Promise<Account> => {
+  debug(`getDefaultAccount`);
+  if (isIsolatedNetwork || networkDesc.type == 'window') {
+    const provider = await getProvider();
+    // TODO: teach ts what the specialized type of provider is in this branch
+    // @ts-ignore
+    const signer: Signer = provider.getSigner();
+    return await connectAccount(signer);
+  }
+  throw Error(`Default account not available for REACH_CONNECTOR_MODE=${connectorMode}`);
+});
+
+// TODO: Should users be able to access this directly?
+// TODO: define a faucet on Ropsten & other testnets?
+export const [getFaucet, setFaucet] = replaceableThunk(async (): Promise<Account> => {
+  // XXX this may break if users call setProvider?
+  if (isIsolatedNetwork) {
+    // On isolated networks, the default account is assumed to be the faucet.
+    // Furthermore, it is assumed that the faucet Signer is "unlocked",
+    // so no further secrets need be provided in order to access its funds.
+    // This is true of reach-provided devnets.
+    // TODO: allow the user to set the faucet via mnemnonic.
+    return await getDefaultAccount();
+  } else if (networkDesc.type === 'window') {
+    // @ts-ignore // 0x539 = 1337
+    if (window.ethereum.chainId === '0xNaN' || window.ethereum.chainId == '0x539') {
+      // XXX this is a hacky way of checking if we're on a devnet
+      // XXX only localhost:8545 is supported
+      const p = new ethers.providers.JsonRpcProvider('http://localhost:8545');
+      return await connectAccount(p.getSigner());
+    }
+  }
+  throw Error(`getFaucet not supported in this context.`)
+});
+*/
+
+export const createAccount = async () => {
+  debug(`createAccount with 0 balance.`);
+  const provider = await getProvider();
+  const networkAccount = ethers.Wallet.createRandom().connect(provider);
+  return await connectAccount(networkAccount);
+}
+
+export const fundFromFaucet = async (account: AccountTransferable, value: any) => {
+  const faucet = await getFaucet();
+  await transfer(faucet, account, value);
+};
+
+export const newTestAccount = async (startingBalance: any): Promise<Account> => {
+  debug(`newTestAccount(${startingBalance})`);
+  requireIsolatedNetwork('newTestAccount');
+  const acc = await createAccount();
+  const to = await getAddr(acc);
+
+  try {
+    debug(`newTestAccount awaiting transfer: ${to}`);
+    await fundFromFaucet(acc, startingBalance);
+    debug(`newTestAccount got transfer: ${JSON.stringify(to)}`);
+    return acc;
+  } catch (e) {
+    console.log(`newTestAccount: Trouble with account ${to}`);
+    throw e;
+  }
+};
+
+export const getNetworkTime = async (): Promise<BigNumber> => {
+  return bigNumberify(await getNetworkTimeNumber());
+};
+
+// onProgress callback is optional, it will be given an obj
+// {currentTime, targetTime}
+export const wait = async (delta: BigNumber, onProgress?: OnProgress): Promise<BigNumber> => {
+  const now = await getNetworkTime();
+  return await waitUntilTime(add(now, delta), onProgress);
+};
+
+// onProgress callback is optional, it will be given an obj
+// {currentTime, targetTime}
+export const waitUntilTime = async (targetTime: BigNumber, onProgress?: OnProgress): Promise<BigNumber> => {
+  targetTime = bigNumberify(targetTime);
+  if (isIsolatedNetwork) {
+    return await fastForwardTo(targetTime, onProgress);
+  } else {
+    return await actuallyWaitUntilTime(targetTime, onProgress);
+  }
+};
+
+/* XXX
+// Check the contract info and the associated deployed bytecode;
+// Verify that:
+// * it matches the bytecode you are expecting.
+// * it was deployed at exactly creation_block.
+// Throws an Error if any verifications fail
+export const verifyContract = async (ctcInfo: ContractInfo, backend: Backend): Promise<true> => {
+  const { ABI, Bytecode } = backend._Connectors.ETH;
+  const { address, creation_block, init, creator } = ctcInfo;
+  const { argsMay, value } = initOrDefaultArgs(init);
+  const factory = new ethers.ContractFactory(ABI, Bytecode);
+  debug(`verifyContract: ${address}`)
+  debug(JSON.stringify(ctcInfo));
+
+  const provider = await getProvider();
+  const now = await getNetworkTimeNumber();
+
+  const {chainId} = await provider.getNetwork();
+  // TODO: allow user to specify lenient verification? (for chains we don't know about)
+  const lenient = [
+    152709604825713, // https://kovan2.arbitrum.io/rpc
+    // XXX ^ this will probably change over time
+  ].includes(chainId);
+  if (lenient) {
+    debug(`verifyContract: using lenient contract verification for chainId=${chainId}`);
+  }
+
+  const deployEvent = isNone(argsMay) ? 'e0' : 'e1';
+  debug(`verifyContract: checking logs for ${deployEvent}...`);
+  // https://docs.ethers.io/v5/api/providers/provider/#Provider-getLogs
+  // "Keep in mind that many backends will discard old events"
+  // TODO: find another way to validate creation block if much time has passed?
+  const logs = await provider.getLogs({
+    fromBlock: creation_block,
+    toBlock: now,
+    address: address,
+    topics: [factory.interface.getEventTopic(deployEvent)],
+  });
+  if (logs.length < 1) {
+    throw Error(`Contract was claimed to be deployed at ${creation_block},`
+     + ` but the current block is ${now} and it hasn't been deployed yet.`
+    );
+  }
+
+  const log = logs[0];
+  if (log.blockNumber !== creation_block) {
+    throw Error(
+      `Contract was deployed at blockNumber ${log.blockNumber},`
+      + ` but was claimed to be deployed at ${creation_block}.`
+    );
+  }
+
+  debug(`verifyContract: checking code...`)
+  // https://docs.ethers.io/v5/api/providers/provider/#Provider-getCode
+  // We can safely getCode at the current block;
+  // Reach programs don't change their ETH code over time.
+  const actual = await provider.getCode(address);
+
+  // XXX should this also pass {value}, like factory.deploy() does?
+  const deployData = factory.getDeployTransaction(...argsMay).data;
+  if (typeof deployData !== 'string') {
+    // TODO: could also be Ethers.utils.bytes, apparently? Or undefined... why?
+    throw Error(`Impossible: deployData is not string ${deployData}`);
+  }
+  if (!deployData.startsWith(backend._Connectors.ETH.Bytecode)) {
+    throw Error(`Impossible: contract with args is not prefixed by backend Bytecode`);
+  }
+
+  // FIXME this is based on empirical observation, feels hacky
+  // deployData looks like this: [init][setup][body][teardown]
+  // actual looks like this:     [init][body]
+  // XXX the labels "init", "setup", and "teardown" are probably misleading
+  // FIXME: for 0-arg contract deploys, it appears that:
+  // * "init" is of length 13
+  // * "setup" is not consistent in content, but is of length 156
+  // * "teardown" is of length 0
+  // FIXME: for n-arg contract deploys, it appears that:
+  // * "init" is of length 13
+  // * "setup" is of length >= 0 (and probably >= 156)
+  // * "teardown" is of length >= 0
+  const initLen = 13;
+  const setupLen = 156;
+  const expected = deployData.slice(0, initLen) + deployData.slice(initLen + setupLen);
+
+  if (expected.length <= 0) {
+    throw Error(`Impossible: contract expectation is empty`);
+  }
+
+  if (actual !== expected) {
+    // FIXME: Empirical observation says that 0-arg contract deploys
+    // should === expected. However, this is fragile (?), so it's ok
+    // to only pass the next check.
+
+    // FIXME: the 13-char header is also fragile, but we're just
+    // running with that assumption for now.
+
+    const deployNoInit = deployData.slice(initLen);
+    const actualNoInit = actual.slice(initLen);
+    if (actualNoInit.length === 0 || !deployNoInit.includes(actualNoInit)) {
+      // FIXME: this display is not so helful for the n-arg contract deploy case.
+      const displayLen = 60;
+      console.log('--------------------------------------------');
+      console.log('expected start: ' + expected.slice(0, displayLen));
+      console.log('actual   start: ' + actual.slice(0, displayLen));
+      console.log('--------------------------------------------');
+      console.log('expected   end: ' + expected.slice(expected.length - displayLen));
+      console.log('actual     end: ' + actual.slice(actual.length - displayLen));
+      console.log('--------------------------------------------');
+      console.log('expected   len: ' + expected.length);
+      console.log('actual     len: ' + actual.length);
+      console.log('--------------------------------------------');
+      throw Error(`Contract bytecode does not match expected bytecode.`);
+    }
+  }
+
+  // It's tedious to write the next sections w/ lenience, so just skip them.
+  // Checking balance & storage at certain old block #s is not supported by some backends.
+  if (lenient) return true;
+
+  debug(`verifyContract: checking balance...`);
+  const bal = await provider.getBalance(address, creation_block);
+  // bal is allowed to exceed expectations, for example,
+  // if someone spuriously transferred extra money to the contract
+  if (!ge(bal, value)) {
+    console.log('bal expected: ' + value);
+    console.log('bal actual  : ' + bal);
+    throw Error(`Contract initial balance does not match expected initial balance`);
+  }
+
+  debug(`verifyContract: checking contract storage...`);
+  if (isNone(argsMay)) {
+    const st = await provider.getStorageAt(address, 0, creation_block);
+    const expectedSt =
+      // @ts-ignore XXX
+      digest(T_Tuple([T_UInt, T_UInt]),
+            [T_UInt.canonicalize(0),
+             T_UInt.canonicalize(creation_block)]);
+    if (st !== expectedSt) {
+      console.log('st expected: ' + expectedSt);
+      console.log('st actual  : ' + st);
+      throw Error(`Contract initial state does not match expected initial state.`);
+    }
+  } else {
+    // TODO: figure out freeVars using creator and args
+    void(creator);
+    // const expectedSt = keccak256(1, creation_block, ...freeVars)
+    // if st !== expectedSt throw Error
+  }
+
+  return true;
+};
+*/
+
+// /** @description the display name of the standard unit of currency for the network */
+// export const standardUnit = 'ETH';
+
+// /** @description the display name of the atomic (smallest) unit of currency for the network */
+// export const atomicUnit = 'WEI';
+
+/**
+ * @description  Parse currency by network
+ * @param amt  value in the {@link standardUnit} for the network.
+ * @returns  the amount in the {@link atomicUnit} of the network.
+ * @example  parseCurrency(100).toString() // => '100000000000000000000'
+ */
+ export function parseCurrency(amt: CurrencyAmount): BigNumber {
+  return bigNumberify(ethers.utils.parseUnits(amt.toString(), 'ether'));
+}
+
+export const minimumBalance: BigNumber =
+  parseCurrency(0);
+
+/**
+ * @description  Format currency by network
+ * @param amt  the amount in the {@link atomicUnit} of the network.
+ * @param decimals  up to how many decimal places to display in the {@link standardUnit}.
+ *   Trailing zeroes will be omitted. Excess decimal places will be truncated. (not rounded)
+ *   This argument defaults to maximum precision.
+ * @returns  a string representation of that amount in the {@link standardUnit} for that network.
+ * @example  formatCurrency(bigNumberify('100000000000000000000')); // => '100'
+ */
+ export function formatCurrency(amt: any, decimals: number = 18): string {
+  // Recall that 1 WEI = 10e18 ETH
+  if (!(Number.isInteger(decimals) && 0 <= decimals)) {
+    throw Error(`Expected decimals to be a nonnegative integer, but got ${decimals}.`);
+  }
+  // Truncate
+  decimals = Math.min(decimals, 18);
+  const decimalsToForget = 18 - decimals;
+  const divAmt = bigNumberify(amt)
+    .div(bigNumberify(10).pow(decimalsToForget));
+  const amtStr = ethers.utils.formatUnits(divAmt, decimals)
+  // If the str ends with .0, chop it off
+  if (amtStr.slice(amtStr.length - 2) == ".0") {
+    return amtStr.slice(0, amtStr.length - 2);
+  } else {
+    return amtStr;
+  }
+}
+
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// Everything past here is noticeably modified from the ETH stdlib
+
+const cfxers = ethers;
+export {cfxers};
+export const conflux = new Conflux({
+  url: process.env.CFX_NODE_URI || 'http://localhost:12537',
+  // logger: console,
+  networkId: (process.env.CFX_NETWORK_ID && parseInt(process.env.CFX_NETWORK_ID)) || 999,
+});
+
+type NetworkAccount = Wallet;
+
+let _faucet: Account;
+export function setFaucet(acc: Account) {
+  _faucet = acc;
+}
+
+export async function getFaucet() {
+  return _faucet;
+}
+
+let _provider: Provider;
+export function setProvider(p: Provider) {
+  _provider = p;
+}
+
+export async function getProvider() {
+  if (!_provider) {
+    _provider = new cfxers.providers.Provider(conflux);
+  }
+  return _provider;
+}
+
+/** @description the display name of the standard unit of currency for the network */
+export const standardUnit = 'CFX';
+
+/** @description the display name of the atomic (smallest) unit of currency for the network */
+export const atomicUnit = 'Drip';
+
+const connectorMode: string = 'CFX'; // XXX
+const isIsolatedNetwork: boolean = true; // XXX
+
+async function verifyContract(...args: any): Promise<true> {
+  // TODO
+  void(args);
+  return true;
+}

--- a/js/stdlib/ts/CFX.ts
+++ b/js/stdlib/ts/CFX.ts
@@ -44,6 +44,7 @@ import {
   stdlib as compiledEthStdlib,
   typeDefs as ethTypeDefs,
 } from './ETH_compiled';
+import { ConnectorMode } from './ConnectorMode';
 
 // ****************************************************************************
 // Type Definitions
@@ -1254,7 +1255,7 @@ export const standardUnit = 'CFX';
 /** @description the display name of the atomic (smallest) unit of currency for the network */
 export const atomicUnit = 'Drip';
 
-const connectorMode: string = 'CFX'; // XXX
+export const connectorMode: ConnectorMode = 'CFX-experimental'; // XXX
 const isIsolatedNetwork: boolean = true; // XXX
 
 async function verifyContract(...args: any): Promise<true> {

--- a/js/stdlib/ts/ConnectorMode.ts
+++ b/js/stdlib/ts/ConnectorMode.ts
@@ -1,5 +1,5 @@
 import {process} from './shim';
-export type Connector = 'ETH' | 'ALGO';
+export type Connector = 'ETH' | 'ALGO' | 'CFX';
 
 export type ConnectorMode =
   'ETH-test-dockerized-geth' |
@@ -7,7 +7,8 @@ export type ConnectorMode =
   'ETH-browser' |
   'ALGO-test-dockerized-algod' |
   'ALGO-live' |
-  'ALGO-browser';
+  'ALGO-browser' |
+  'CFX-experimental';
 
 // Order is significant, earlier = default for shared prefix
 // e.g. ETH defaults to ETH-test-dockerized-geth
@@ -18,10 +19,11 @@ const knownConnectorModes: Array<ConnectorMode> = [
   'ALGO-test-dockerized-algod',
   'ALGO-live',
   'ALGO-browser',
+  'CFX-experimental',
 ];
 
 function isKnownConnector(s: string): s is Connector {
-  return (s === 'ETH' || s === 'ALGO');
+  return (s === 'ETH' || s === 'ALGO' || s === 'CFX');
 }
 
 const connectorModeDefaults: {[key: string]: ConnectorMode} = {};

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -344,8 +344,9 @@ export class ECtc extends Addressed implements ICtc<AnyETH_Ty> {
           }
         } else {
           // XXX For some reason ok_t sometimes doesn't have blockNumber
-          console.log(`WARNING: no blockNumber on transaction.`);
-          console.log(ok_t);
+          // console.log(`WARNING: no blockNumber on transaction.`);
+          // console.log(ok_t);
+          // ^ Disabled warning b/c this always happens on CFX
         }
 
         stdlib.debug(attacher.shad, ':', attacher.label, 'recv', ok_evt, `--- AT`, ok_r.blockNumber);

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -1,78 +1,66 @@
-import * as cfxsdk from 'js-conflux-sdk';
+import cfxsdk from 'js-conflux-sdk';
 import * as cfxers from './cfxers';
-import {TypeDefs} from './classy_TypeDefs';
-import {CFX_TypeDefs} from './classy_TypeDefs_ETH_like';
-// import {BigNumber} from 'ethers';
-
-export interface ReachStdlib_Opts {
-  readonly REACH_DEBUG?: boolean
-  readonly REACH_CONNECTOR_MODE?: string
-}
-
-export interface ETH_Like_Opts extends ReachStdlib_Opts {
-  readonly ethers?: any
-  readonly provider?: any
-}
-
-export interface CFX_Opts extends ETH_Like_Opts {
-  readonly CFX_DEBUG?: boolean
-  readonly CFX_NODE_URI?: string
-  readonly CFX_NETWORK_ID?: string | number
-}
-
-export abstract class ReachStdlib {
-  abstract readonly typeDefs: TypeDefs
-  abstract readonly standardUnit: string
-
-  readonly opts: ReachStdlib_Opts;
-
-  constructor(opts: ReachStdlib_Opts = {}) {
-    opts = {
-      REACH_DEBUG: false,
-      REACH_CONNECTOR_MODE: 'ETH',
-      ...opts,
-    }
-    this.opts = opts;
-  }
-
-  /** @deprecated */
-  setDEBUG(b: boolean) {
-    if (typeof b !== 'boolean') throw Error(`setDEBUG expects a boolean, got: '${b}'`);
-    // XXX We are turning a blind eye to mutation for now,
-    // but later should delete setDEBUG and only set it via the opts.
-    // @ts-ignore
-    this.opts.REACH_DEBUG = b;
-  }
-
-}
+import { ReachStdlib } from './classy_shared';
+import { CFX_Opts, ETH_Like_Opts } from './classy_opts';
+import {CFX_TypeDefs} from './classy_TypeDefs_CFX';
+import {ETH_TypeDef} from './classy_TypeDefs_ETH_like';
+import ethers from 'ethers';
 
 export abstract class ETH_Like<Provider> extends ReachStdlib {
   readonly ethers: any
   readonly provider: Provider
   readonly opts: ETH_Like_Opts
-
   constructor(opts: ETH_Like_Opts = {}) {
     super(opts);
-
     if (!opts.ethers) throw Error(`impossible: ethers is missing`);
     if (!opts.provider) throw Error(`impossible: provider is missing`);
-
     this.ethers = opts.ethers;
     this.provider = opts.provider;
     this.opts = super.opts;
   }
+  prepForDigest(t: ETH_TypeDef<unknown, unknown>, v: unknown): string|[] {
+    // Note: abiCoder.encode doesn't correctly handle an empty tuple type
+    if (t.paramType === 'tuple()') {
+      if (Array.isArray(v) && v.length === 0) {
+        return [];
+      } else {
+        throw Error(`impossible: digest tuple() with non-empty array: ${JSON.stringify(v)}`);
+      }
+    }
+    return ethers.utils.defaultAbiCoder.encode([t.paramType], [t.munge(v)])
+  }
+  tokenEq(a: unknown, b: unknown): boolean {
+    const {T_Token} = this.typeDefs;
+    return this.bytesEq(T_Token.canonicalize(a), T_Token.canonicalize(b));
+  }
+  async getProvider(): Promise<Provider> {
+    // TODO: wait-port
+    return this.provider;
+  }
+  async connectAccount(networkAccount: unknown): Promise<unknown> {
+    void(networkAccount);
+    return {};
+  }
+  async newAccountFromSecret(secret: string): Promise<unknown> {
+    const provider = await this.getProvider();
+    const networkAccount = (new this.ethers.Wallet(secret)).connect(provider);
+    const acc = await this.connectAccount(networkAccount);
+    return acc;
+  }
+}
 
+export function parseNetworkId(opts: CFX_Opts) {
+  return opts.networkId
+    || (opts.CFX_NETWORK_ID && parseInt(opts.CFX_NETWORK_ID.toString()))
+    || CFX.DEFAULT_CFX_NETWORK_ID;
 }
 
 export class CFX extends ETH_Like<cfxers.providers.Provider> {
   static readonly DEFAULT_CFX_NODE_URI = 'http://localhost:12537';
   static readonly DEFAULT_CFX_NETWORK_ID = 999;
-
   readonly opts: CFX_Opts;
-
   readonly standardUnit = 'CFX';
-  readonly typeDefs: CFX_TypeDefs = new CFX_TypeDefs();
-
+  readonly typeDefs: CFX_TypeDefs;
   constructor(opts: CFX_Opts = {}) {
     super({
       ethers: cfxers,
@@ -80,15 +68,17 @@ export class CFX extends ETH_Like<cfxers.providers.Provider> {
         new cfxsdk.Conflux({
           url: opts.CFX_NODE_URI || CFX.DEFAULT_CFX_NODE_URI,
           logger: opts.CFX_DEBUG ? console : undefined,
-          networkId: (opts.CFX_NETWORK_ID && parseInt(opts.CFX_NETWORK_ID.toString()))
-            || CFX.DEFAULT_CFX_NETWORK_ID,
+          networkId: parseNetworkId(opts),
         }),
       ),
       ...opts,
     });
-    this.opts = super.opts;
+    this.opts = {
+      networkId: parseNetworkId(opts),
+      ...super.opts,
+    };
+    this.typeDefs = new CFX_TypeDefs(this.opts);
   }
-
 }
 
 // const cfx = new CFX();

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -1,0 +1,131 @@
+import * as cfxsdk from 'js-conflux-sdk';
+import * as cfxers from './cfxers';
+import {BigNumber} from 'ethers';
+
+// idk why VSCode says this is a parse error
+export abstract class Nonsense { }
+
+export abstract class TypeDef {
+}
+
+export abstract class TypeDefs {
+  abstract readonly T_UInt: TypeDef
+  abstract readonly T_Address: TypeDef
+}
+
+export abstract class ETH_TypeDef<T> extends TypeDef {
+  abstract canonicalize(uv: unknown): T
+}
+
+class ETH_T_UInt extends ETH_TypeDef<BigNumber> {
+  canonicalize(uv: unknown): BigNumber {
+    // XXX
+    return uv as BigNumber;
+  }
+}
+
+class ETH_T_Address extends ETH_TypeDef<string> {
+  canonicalize(uv: unknown): string {
+    // XXX
+    return uv as string;
+  }
+}
+
+class CFX_T_Address extends ETH_TypeDef<string> {
+  canonicalize(uv: unknown): string {
+    // XXX
+    return uv as string;
+  }
+}
+
+export abstract class ETH_Like_TypeDefs extends TypeDefs {
+  readonly T_UInt = new ETH_T_UInt()
+}
+
+export class ETH_TypeDefs extends ETH_Like_TypeDefs {
+  readonly T_Address: ETH_TypeDef<string> = new ETH_T_Address();
+}
+
+export class CFX_TypeDefs extends ETH_Like_TypeDefs {
+  readonly T_Address: ETH_TypeDef<string> = new CFX_T_Address();
+}
+
+export abstract class ReachStdlib {
+  abstract readonly typeDefs: TypeDefs
+  abstract readonly standardUnit: string
+
+  readonly opts: ReachStdlib_Opts;
+
+  constructor(opts: ReachStdlib_Opts = {}) {
+    opts = {
+      REACH_DEBUG: false,
+      REACH_CONNECTOR_MODE: 'ETH',
+      ...opts,
+    }
+    this.opts = opts;
+  }
+}
+
+export abstract class ETH_Like<Provider> extends ReachStdlib {
+  readonly ethers: any
+  readonly provider: Provider
+  readonly opts: ETH_Like_Opts
+
+  constructor(opts: ETH_Like_Opts = {}) {
+    super(opts);
+
+    if (!opts.ethers) throw Error(`impossible: ethers is missing`);
+    if (!opts.provider) throw Error(`impossible: provider is missing`);
+
+    this.ethers = opts.ethers;
+    this.provider = opts.provider;
+    this.opts = super.opts;
+  }
+
+}
+
+export interface ReachStdlib_Opts {
+  REACH_DEBUG?: boolean
+  REACH_CONNECTOR_MODE?: string
+}
+
+export interface ETH_Like_Opts extends ReachStdlib_Opts{
+  ethers?: any
+  provider?: any
+}
+
+export interface CFX_Opts extends ETH_Like_Opts {
+  CFX_DEBUG?: boolean
+  CFX_NODE_URI?: string
+  CFX_NETWORK_ID?: string | number
+}
+
+export class CFX extends ETH_Like<cfxers.providers.Provider> {
+  static readonly DEFAULT_CFX_NODE_URI = 'http://localhost:12537';
+  static readonly DEFAULT_CFX_NETWORK_ID = 999;
+
+  readonly opts: CFX_Opts;
+
+  readonly standardUnit = 'CFX';
+  readonly typeDefs: CFX_TypeDefs = new CFX_TypeDefs();
+
+  constructor(opts: CFX_Opts = {}) {
+    super({
+      ethers: cfxers,
+      provider: new cfxers.providers.Provider(
+        new cfxsdk.Conflux({
+          url: opts.CFX_NODE_URI || CFX.DEFAULT_CFX_NODE_URI,
+          logger: opts.CFX_DEBUG ? console : undefined,
+          networkId: (opts.CFX_NETWORK_ID && parseInt(opts.CFX_NETWORK_ID.toString()))
+            || CFX.DEFAULT_CFX_NETWORK_ID,
+        }),
+      ),
+      ...opts,
+    });
+    this.opts = super.opts;
+    // this.conflux = this.provider.conflux;
+  }
+
+}
+
+const cfx = new CFX();

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -1,53 +1,23 @@
 import * as cfxsdk from 'js-conflux-sdk';
 import * as cfxers from './cfxers';
-import {BigNumber} from 'ethers';
+import {TypeDefs} from './classy_TypeDefs';
+import {CFX_TypeDefs} from './classy_TypeDefs_ETH_like';
+// import {BigNumber} from 'ethers';
 
-// idk why VSCode says this is a parse error
-export abstract class Nonsense { }
-
-export abstract class TypeDef {
+export interface ReachStdlib_Opts {
+  readonly REACH_DEBUG?: boolean
+  readonly REACH_CONNECTOR_MODE?: string
 }
 
-export abstract class TypeDefs {
-  abstract readonly T_UInt: TypeDef
-  abstract readonly T_Address: TypeDef
+export interface ETH_Like_Opts extends ReachStdlib_Opts {
+  readonly ethers?: any
+  readonly provider?: any
 }
 
-export abstract class ETH_TypeDef<T> extends TypeDef {
-  abstract canonicalize(uv: unknown): T
-}
-
-class ETH_T_UInt extends ETH_TypeDef<BigNumber> {
-  canonicalize(uv: unknown): BigNumber {
-    // XXX
-    return uv as BigNumber;
-  }
-}
-
-class ETH_T_Address extends ETH_TypeDef<string> {
-  canonicalize(uv: unknown): string {
-    // XXX
-    return uv as string;
-  }
-}
-
-class CFX_T_Address extends ETH_TypeDef<string> {
-  canonicalize(uv: unknown): string {
-    // XXX
-    return uv as string;
-  }
-}
-
-export abstract class ETH_Like_TypeDefs extends TypeDefs {
-  readonly T_UInt = new ETH_T_UInt()
-}
-
-export class ETH_TypeDefs extends ETH_Like_TypeDefs {
-  readonly T_Address: ETH_TypeDef<string> = new ETH_T_Address();
-}
-
-export class CFX_TypeDefs extends ETH_Like_TypeDefs {
-  readonly T_Address: ETH_TypeDef<string> = new CFX_T_Address();
+export interface CFX_Opts extends ETH_Like_Opts {
+  readonly CFX_DEBUG?: boolean
+  readonly CFX_NODE_URI?: string
+  readonly CFX_NETWORK_ID?: string | number
 }
 
 export abstract class ReachStdlib {
@@ -64,6 +34,16 @@ export abstract class ReachStdlib {
     }
     this.opts = opts;
   }
+
+  /** @deprecated */
+  setDEBUG(b: boolean) {
+    if (typeof b !== 'boolean') throw Error(`setDEBUG expects a boolean, got: '${b}'`);
+    // XXX We are turning a blind eye to mutation for now,
+    // but later should delete setDEBUG and only set it via the opts.
+    // @ts-ignore
+    this.opts.REACH_DEBUG = b;
+  }
+
 }
 
 export abstract class ETH_Like<Provider> extends ReachStdlib {
@@ -82,22 +62,6 @@ export abstract class ETH_Like<Provider> extends ReachStdlib {
     this.opts = super.opts;
   }
 
-}
-
-export interface ReachStdlib_Opts {
-  REACH_DEBUG?: boolean
-  REACH_CONNECTOR_MODE?: string
-}
-
-export interface ETH_Like_Opts extends ReachStdlib_Opts{
-  ethers?: any
-  provider?: any
-}
-
-export interface CFX_Opts extends ETH_Like_Opts {
-  CFX_DEBUG?: boolean
-  CFX_NODE_URI?: string
-  CFX_NETWORK_ID?: string | number
 }
 
 export class CFX extends ETH_Like<cfxers.providers.Provider> {
@@ -123,9 +87,8 @@ export class CFX extends ETH_Like<cfxers.providers.Provider> {
       ...opts,
     });
     this.opts = super.opts;
-    // this.conflux = this.provider.conflux;
   }
 
 }
 
-const cfx = new CFX();
+// const cfx = new CFX();

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -1,23 +1,498 @@
 import cfxsdk from 'js-conflux-sdk';
+import real_ethers from 'ethers';
 import * as cfxers from './cfxers';
-import { ReachStdlib } from './classy_shared';
+import { ReachStdlib, IAcc, ICtc, ICtcInfo, Backend, Token } from './classy_shared';
 import { CFX_Opts, ETH_Like_Opts } from './classy_opts';
-import {CFX_TypeDefs} from './classy_TypeDefs_CFX';
-import {ETH_TypeDef} from './classy_TypeDefs_ETH_like';
-import ethers from 'ethers';
+import { CFX_TypeDefs } from './classy_TypeDefs_CFX';
+import { ETH_TypeDef } from './classy_TypeDefs_ETH_like';
+import { CurrencyAmount, IRecv, OnProgress } from './shared';
+import { ConnectorMode, getConnectorMode } from './ConnectorMode';
+import Timeout from 'await-timeout';
 
-export abstract class ETH_Like<Provider> extends ReachStdlib {
+type BigNumber = real_ethers.BigNumber;
+const BigNumber = real_ethers.BigNumber;
+type AnyETH_Ty = ETH_TypeDef<unknown, unknown>;
+type Address = string
+type Recv = IRecv<Address>
+type PayAmt = [BigNumber, [BigNumber, Token][]]
+
+const ERC20_ABI = [
+  { "constant": false,
+    "inputs": [ { "name": "_spender",
+                  "type": "address" },
+                { "name": "_value",
+                  "type": "uint256" } ],
+    "name": "approve",
+    "outputs": [ { "name": "",
+                   "type": "bool" } ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function" },
+  { "constant": true,
+    "inputs": [ { "name": "account",
+                  "type": "address" } ],
+    "name": "balanceOf",
+    "outputs": [ { "name": "",
+                   "type": "uint256" } ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function" },
+  { "constant": false,
+    "inputs": [ { "name": "_recipient",
+                  "type": "address" },
+                { "name": "_amount",
+                  "type": "uint256" } ],
+    "name": "transfer",
+    "outputs": [ { "name": "",
+                   "type": "bool" } ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function" }
+];
+
+export const argsSlice = <T>(args: Array<T>, cnt: number): Array<T> =>
+  cnt == 0 ? [] : args.slice(-1 * cnt);
+
+export const argsSplit = <T>(args: Array<T>, cnt: number): [ Array<T>, Array<T> ] =>
+  cnt == 0 ? [args, []] : [ args.slice(0, args.length - cnt), args.slice(-1 * cnt) ];
+
+
+// Given a func that takes an optional arg, and a Maybe arg:
+// f: (arg?: X) => Y
+// arg: Maybe<X>
+//
+// You can apply the function like this:
+// f(...argMay)
+type Some<T> = [T];
+type None = [];
+type Maybe<T> = None | Some<T>;
+function isNone<T>(m: Maybe<T>): m is None {
+  return m.length === 0;
+}
+function isSome<T>(m: Maybe<T>): m is Some<T> {
+  return !isNone(m);
+}
+const Some = <T>(m: T): Some<T> => [m];
+const None: None = [];
+void(isSome);
+
+// For when you init the contract with the 1st message
+type ContractInitInfo = {
+  args: Array<any>,
+  value: BigNumber,
+};
+
+// For either deployment case
+type ContractInitInfo2 = {
+  argsMay: Maybe<Array<any>>,
+  value: BigNumber,
+};
+
+const initOrDefaultArgs = (init?: ContractInitInfo): ContractInitInfo2 => ({
+  argsMay: init ? Some(init.args) : None,
+  value: init ? init.value : BigNumber.from(0),
+});
+
+export interface IECtcInfo extends ICtcInfo {
+  address: string
+  creation_block: number
+  transactionHash: string
+  init?: ContractInitInfo
+}
+
+export class Addressed {
+  readonly stdlib: ETH_Like<IProvider, INetAcc>; // TODO: CompiledStdlib?
+  readonly address: string
+  constructor(address: string, stdlib: ETH_Like<IProvider, INetAcc>) {
+    this.stdlib = stdlib;
+    this.address = address;
+  }
+  iam(some_addr: string): string {
+    // TODO: is it better to use addressEq here?
+    // If so, then which one should be returned?
+    // const {stdlib, address} = this;
+    // if (stdlib.addressEq(some_addr, address)) {
+    const {address} = this;
+    if (some_addr === address) {
+      return some_addr;
+    } else {
+      throw Error(`I should be ${some_addr}, but am ${address}`);
+    }
+  }
+  /** @deprecated just use acc.address */
+  getAddress() {
+    return this.address;
+  }
+}
+
+export class ECtc extends Addressed implements ICtc<AnyETH_Ty> {
+  readonly stdlib: ETH_Like<IProvider, INetAcc>
+  readonly attacher: EAcc
+  private readonly _infoP: Promise<IECtcInfo>|IECtcInfo
+  private _lastBlock?: number
+  readonly bin: Backend
+  private _ethersC?: EthersContract;
+  readonly ABI: object
+
+  constructor(attacher: EAcc, bin: Backend, infoP: Promise<IECtcInfo>|IECtcInfo, stdlib: ETH_Like<IProvider, INetAcc>) {
+    super(attacher.address, stdlib);
+    // TODO: only use the compiled stdlib portion?
+    this.attacher = attacher;
+    this.bin = bin;
+    this.ABI = JSON.parse(bin._Connectors.ETH.ABI);
+    this.stdlib = stdlib;
+    this._infoP = infoP;
+  }
+  async getInfo(): Promise<IECtcInfo> {
+    return await this._infoP;
+  }
+  async creationTime(): Promise<BigNumber> {
+    return this.stdlib.bigNumberify((await this.getInfo()).creation_block);
+  }
+  // TODO:
+  // The name of this is weird when it's on a ctc,
+  // since it's not the ctc's address, it's the attacher's
+  selfAddress() { return this.address; }
+  async wait(delta: BigNumber): Promise<BigNumber> {
+    const {stdlib, address} = this;
+    const lastBlock = await this._getLastBlock();
+    // Don't wait from current time, wait from last_block
+    stdlib.debug('=====Waiting', delta, 'from', lastBlock, ':', address);
+    const p = await this._waitUntilTime(stdlib.add(lastBlock, delta));
+    stdlib.debug('=====Done waiting', delta, 'from', lastBlock, ':', address);
+    return p;
+  }
+  async _getLastBlock(): Promise<number> {
+    if (this._lastBlock === undefined) {
+      const info = await this.getInfo();
+      this._lastBlock = info.creation_block;
+      this.stdlib.debug(`lastBlock initialized to`, this._lastBlock);
+    }
+    return this._lastBlock;
+  }
+  setLastBlock(n: number): void {
+    this.stdlib.debug(`lastBlock from`, this._lastBlock, `to`, n);
+    this._lastBlock = n;
+  }
+  async _waitUntilTime(targetTime: BigNumber, onProgress?: OnProgress): Promise<BigNumber> {
+    const {stdlib} = this;
+    targetTime = stdlib.bigNumberify(targetTime);
+    if (stdlib.isIsolatedNetwork) {
+      return await stdlib.fastForwardTo(targetTime, onProgress);
+    } else {
+      return await stdlib.actuallyWaitUntilTime(targetTime, onProgress);
+    }
+  }
+  async sendrecv(
+    funcNum: number, evt_cnt: number, hasLastTime: (BigNumber | false),
+    tys: Array<AnyETH_Ty>,
+    args: Array<any>, pay: PayAmt, out_tys: Array<AnyETH_Ty>,
+    onlyIf: boolean, soloSend: boolean,
+    timeout_delay: BigNumber | false, sim_p: any,
+  ): Promise<Recv> {
+    void(sim_p);
+    return await this._sendrecv_impl(funcNum, evt_cnt, hasLastTime, tys, args, pay, out_tys, onlyIf, soloSend, timeout_delay);
+  }
+  async recv(
+    okNum: number, ok_cnt: number, out_tys: Array<AnyETH_Ty>,
+    waitIfNotPresent: boolean, timeout_delay: BigNumber | false,
+  ): Promise<Recv> {
+    void(ok_cnt);
+    return await this._recv_impl(okNum, out_tys, waitIfNotPresent, timeout_delay);
+  }
+  // private helpers
+  private async _sendrecv_impl(
+    funcNum: number, evt_cnt: number,
+    hasLastTime: (BigNumber | false), tys: Array<AnyETH_Ty>,
+    args: Array<any>, pay: PayAmt, out_tys: Array<AnyETH_Ty>,
+    onlyIf: boolean, soloSend: boolean,
+    timeout_delay: BigNumber | false,
+  ): Promise<Recv> {
+    const {stdlib} = this;
+    const {T_Tuple} = stdlib.typeDefs;
+    void(hasLastTime);
+    const doRecv = async (waitIfNotPresent: boolean): Promise<Recv> =>
+      await this._recv_impl(funcNum, out_tys, waitIfNotPresent, timeout_delay);
+    if ( ! onlyIf ) {
+      return await doRecv(true);
+    }
+
+    const funcName = `m${funcNum}`;
+    if (tys.length !== args.length) {
+      throw Error(`tys.length (${tys.length}) !== args.length (${args.length})`);
+    }
+
+    const dhead = [this.attacher.shad, this.attacher.label, 'send', funcName, timeout_delay, 'SEND'];
+    stdlib.debug([...dhead, 'ARGS', args]);
+    const [ args_svs, args_msg ] = argsSplit(args, evt_cnt );
+    const [ tys_svs, tys_msg ] = argsSplit(tys, evt_cnt);
+    // TODO: correct specialized typing on T_Tuple args for ETH_like stdlib
+    const arg_ty = T_Tuple([T_Tuple(tys_svs), T_Tuple(tys_msg)]) as unknown as AnyETH_Ty;
+    const arg = arg_ty.munge([args_svs, args_msg]);
+
+    stdlib.debug([...dhead, 'START', arg]);
+    const lastBlock = await this._getLastBlock();
+    let block_send_attempt = lastBlock;
+    let block_repeat_count = 0;
+    while (!timeout_delay || stdlib.lt(block_send_attempt, stdlib.add(lastBlock, timeout_delay))) {
+      stdlib.debug([...dhead, 'TRY']);
+      try {
+        stdlib.debug([...dhead, 'ARG', arg, pay]);
+        await this._callC(dhead, funcName, arg, pay);
+      } catch (e) {
+        if ( ! soloSend ) {
+          stdlib.debug([...dhead, `SKIPPING`, e]);
+        } else {
+          stdlib.debug([...dhead, `ERROR`, e.stack]);
+
+          // XXX What should we do...? If we fail, but there's no timeout delay... then we should just die
+          await Timeout.set(1);
+          const current_block = await stdlib.getNetworkTimeNumber();
+          if (current_block == block_send_attempt) {
+            block_repeat_count++;
+          }
+          block_send_attempt = current_block;
+          if ( /* timeout_delay && */ block_repeat_count > 32) {
+            if (e.code === 'UNPREDICTABLE_GAS_LIMIT') {
+              let error = e;
+              while (error.error) { error = error.error; }
+              console.log(`impossible: The message you are trying to send appears to be invalid.`);
+              console.log(error);
+            }
+            console.log(`args:`);
+            console.log(arg);
+            throw Error(`${dhead} REPEAT @ ${block_send_attempt} x ${block_repeat_count}`);
+          }
+          stdlib.debug([...dhead, `TRY FAIL`, lastBlock, current_block, block_repeat_count, block_send_attempt]);
+          continue;
+        }
+      }
+
+      return await doRecv(false);
+    }
+    // XXX If we were trying to join, but we got sniped, then we'll
+    // think that there is a timeout and then we'll wait forever for
+    // the timeout message.
+
+    stdlib.debug([...dhead, `FAIL/TIMEOUT`]);
+    return {didTimeout: true};
+  }
+  private async _recv_impl(
+    okNum: number, out_tys: Array<AnyETH_Ty>,
+    waitIfNotPresent: boolean,
+    timeout_delay: BigNumber | false,
+  ): Promise<Recv> {
+    // XXX
+    void(okNum);
+    void(out_tys);
+    void(waitIfNotPresent);
+    void(timeout_delay);
+    throw Error(`TODO _recv_impl`);
+  }
+  private async _callC(
+    dhead: any, funcName: string, arg: any, pay: PayAmt,
+  ): Promise<void> {
+    const {stdlib, attacher} = this;
+    const {ethers} = stdlib;
+    const [ value, toks ] = pay;
+    const ethersC = await this._getC();
+    const zero = stdlib.bigNumberify(0);
+    const actualCall = async () =>
+      await stdlib.doCall({...dhead, kind:'reach'}, ethersC, funcName, [arg], value, attacher.gasLimit);
+    const callTok = async (tok:Token, amt:BigNumber) => {
+      const tokCtc = new ethers.Contract(tok, ERC20_ABI, attacher.networkAccount);
+      const tokBalance = await tokCtc["balanceOf"](this.address);
+      stdlib.debug({...dhead, kind:'token'}, 'balanceOf', tokBalance);
+      stdlib.assert(tokBalance >= amt, `local account token balance insufficient: ${tokBalance} < ${amt}`);
+      await stdlib.doCall({...dhead, kind:'token'}, tokCtc, "approve", [ethersC.address, amt], zero, attacher.gasLimit); }
+    const maybePayTok = async (i:number) => {
+      if ( i < toks.length ) {
+        const [amt, tok] = toks[i];
+        await callTok(tok, amt);
+        try {
+          await maybePayTok(i+1);
+        } catch (e) {
+          await callTok(tok, zero);
+          throw e;
+        }
+      } else {
+        await actualCall();
+      }
+    }
+    await maybePayTok(0);
+  }
+  private async _getC(): Promise<EthersContract> {
+    const {stdlib, attacher} = this;
+    const {ethers} = stdlib;
+    const {networkAccount} = attacher;
+    if (this._ethersC === undefined) {
+      const info = await this.getInfo();
+      await stdlib.verifyContract(info, this.bin);
+      stdlib.debug(attacher.shad, `: contract verified`);
+      if (!ethers.Signer.isSigner(attacher.networkAccount)) {
+        throw Error(`networkAccount must be a Signer (read: Wallet). ${networkAccount}`);
+      }
+      const c: EthersContract = new ethers.Contract(info.address, this.ABI, networkAccount);
+      this._ethersC = c;
+    }
+    return this._ethersC;
+  }
+}
+
+interface EthersContract {
+  address: string
+}
+export class EAcc implements IAcc<AnyETH_Ty> {
+  readonly stdlib: ETH_Like<IProvider, INetAcc>
+  readonly provider: IProvider
+  readonly networkAccount: INetAcc
+  readonly address: string
+  readonly shad: string
+  label: string // writeable, but XXX make it readonly, configurable via constructor
+  gasLimit?: BigNumber // writeable, but XXX make it readonly, configurable via constructor
+  constructor(networkAccount: INetAcc, address: string, provider: IProvider, stdlib: ETH_Like<IProvider, INetAcc>) {
+    this.networkAccount = networkAccount;
+    this.address = address;
+    this.shad = address.substring(2, 6);
+    this.label = this.shad;
+    this.provider = provider;
+    // TODO: only use the compiled stdlib portion?
+    this.stdlib = stdlib;
+  }
+  iam(some_addr: string): string {
+    // TODO: is it better to use addressEq here?
+    // If so, then which one should be returned?
+    // const {stdlib, address} = this;
+    // if (stdlib.addressEq(some_addr, address)) {
+    const {address} = this;
+    if (some_addr === address) {
+      return some_addr;
+    } else {
+      throw Error(`I should be ${some_addr}, but am ${address}`);
+    }
+  }
+  /** @deprecated just use acc.address */
+  getAddress(): string { return this.address; }
+  // TODO: deprecate this, just construct it w/ correct label
+  setDebugLabel(newLabel: string): this {
+    this.label = newLabel;
+    return this;
+  }
+  deploy(bin: Backend): ECtc {
+    const {stdlib, networkAccount, shad, gasLimit} = this;
+    const {ethers} = stdlib;
+    if (!ethers.Signer.isSigner(networkAccount)) {
+      throw Error(`Signer required to deploy, ${networkAccount}`);
+    }
+
+    const {infoP, resolveInfo} = (() => {
+      let resolveInfo = (info: IECtcInfo) => { void(info); };
+      const infoP = new Promise<IECtcInfo>(resolve => {
+        resolveInfo = resolve;
+      });
+      return {infoP, resolveInfo};
+    })();
+
+    const performDeploy = (
+      init?: ContractInitInfo
+    ): ECtc => {
+      stdlib.debug(shad, ': performDeploy with', init);
+      const { argsMay, value } = initOrDefaultArgs(init);
+
+      const { ABI, Bytecode } = bin._Connectors.ETH;
+      stdlib.debug(shad, ': making contract factory');
+      const factory = new ethers.ContractFactory(ABI, Bytecode, networkAccount);
+
+      (async () => {
+        stdlib.debug(shad, `: deploying factory`);
+        const contract = await factory.deploy(...argsMay, { value, gasLimit });
+        stdlib.debug(shad, `: deploying factory; done:`, contract.address);
+        stdlib.debug(shad, `: waiting for receipt:`, contract.deployTransaction.hash);
+        const deploy_r = await contract.deployTransaction.wait();
+        stdlib.debug(shad, `: got receipt;`, deploy_r.blockNumber);
+        const info: IECtcInfo = {
+          address: contract.address,
+          creation_block: deploy_r.blockNumber,
+          transactionHash: deploy_r.transactionHash,
+          init,
+        };
+        resolveInfo(info);
+      })();
+
+      return this.attach(bin, infoP);
+    }
+
+    return performDeploy();
+    // const info = {creation_block: 0, address: 'TODO'};
+    // return new ECtc(this, bin, info, this.stdlib);
+  }
+  attach(bin: Backend, info: Promise<IECtcInfo>|IECtcInfo): ECtc {
+    return new ECtc(this, bin, info, this.stdlib);
+  }
+  // XXX make configurable via constructor
+  setGasLimit(ngl: unknown): void {
+    this.gasLimit = this.stdlib.bigNumberify(ngl);
+  }
+}
+
+export interface INetAcc {
+  address?: string
+  getAddress?(): string|Promise<string>
+  sendTransaction(...args: any): Promise<{wait: () => Promise<IReceipt>}>
+}
+
+export interface IReceipt {
+  transactionHash: string
+  status?: unknown
+}
+
+export interface IProvider {
+  on(evt: string, onBlock: (currentTimeNum: number | BigNumber) => unknown): void
+  off(evt: string, onBlock: (currentTimeNum: number | BigNumber) => unknown): void
+  getBlockNumber(): Promise<number>
+  getTransactionReceipt(txHash: string): Promise<IReceipt>
+}
+
+export abstract class ETH_Like<
+  Provider extends IProvider,
+  NetAcc extends INetAcc,
+  > extends ReachStdlib<AnyETH_Ty> {
+  private readonly faucetP: Promise<EAcc>
+  private readonly _provider: Provider
+  private _dummyAccount?: EAcc
+  // TODO: figure out how to type ethers
   readonly ethers: any
-  readonly provider: Provider
+
+  readonly isIsolatedNetwork: boolean
+  readonly connectorMode: ConnectorMode
   readonly opts: ETH_Like_Opts
   constructor(opts: ETH_Like_Opts = {}) {
     super(opts);
     if (!opts.ethers) throw Error(`impossible: ethers is missing`);
     if (!opts.provider) throw Error(`impossible: provider is missing`);
     this.ethers = opts.ethers;
-    this.provider = opts.provider;
+    this._provider = opts.provider;
     this.opts = super.opts;
+
+    // TODO: not use getConnectorMode() here
+    // instead, only inspect opts
+    this.connectorMode = getConnectorMode();
+    this.isIsolatedNetwork =
+      this.connectorMode.startsWith('ETH-test-dockerized')
+        || (process.env['REACH_ISOLATED_NETWORK'] ? true : false);
+
+    // TODO: move to ReachStdlib
+    if (opts.REACH_FAUCET_SECRET) {
+      this.faucetP = this.newAccountFromSecret(opts.REACH_FAUCET_SECRET);
+    } else if (opts.REACH_FAUCET_MNEMONIC) {
+      this.faucetP = this.newAccountFromMnemonic(opts.REACH_FAUCET_MNEMONIC);
+    } else {
+      this.faucetP = this._getDefaultFaucet();
+    }
   }
+  abstract _getDefaultFaucet(): Promise<EAcc>
+  abstract verifyContract(ctcInfo: IECtcInfo, backend: Backend): Promise<true>
+
   prepForDigest(t: ETH_TypeDef<unknown, unknown>, v: unknown): string|[] {
     // Note: abiCoder.encode doesn't correctly handle an empty tuple type
     if (t.paramType === 'tuple()') {
@@ -27,7 +502,8 @@ export abstract class ETH_Like<Provider> extends ReachStdlib {
         throw Error(`impossible: digest tuple() with non-empty array: ${JSON.stringify(v)}`);
       }
     }
-    return ethers.utils.defaultAbiCoder.encode([t.paramType], [t.munge(v)])
+    // XXX use this.ethers in case this needs overridden?
+    return real_ethers.utils.defaultAbiCoder.encode([t.paramType], [t.munge(v)])
   }
   tokenEq(a: unknown, b: unknown): boolean {
     const {T_Token} = this.typeDefs;
@@ -35,17 +511,212 @@ export abstract class ETH_Like<Provider> extends ReachStdlib {
   }
   async getProvider(): Promise<Provider> {
     // TODO: wait-port
-    return this.provider;
+    return this._provider;
   }
-  async connectAccount(networkAccount: unknown): Promise<unknown> {
-    void(networkAccount);
-    return {};
+  requireIsolatedNetwork(label: string) {
+    if (!this.isIsolatedNetwork) {
+      throw Error(`Invalid operation ${label} in REACH_CONNECTOR_MODE=${this.connectorMode}`);
+    }
   }
-  async newAccountFromSecret(secret: string): Promise<unknown> {
+
+  // Accounts
+  async connectAccount(networkAccount: NetAcc): Promise<EAcc> {
     const provider = await this.getProvider();
-    const networkAccount = (new this.ethers.Wallet(secret)).connect(provider);
+    const address = networkAccount.address
+      || (networkAccount.getAddress && await networkAccount.getAddress());
+    if (!address) throw Error(`No address found on networkAccount: ${JSON.stringify(networkAccount)}`);
+    return new EAcc(networkAccount, address, provider, this);
+  }
+  async newAccountFromSecret(secret: string): Promise<EAcc> {
+    const provider = await this.getProvider();
+    const networkAccount = new this.ethers.Wallet(secret).connect(provider) as NetAcc;
     const acc = await this.connectAccount(networkAccount);
     return acc;
+  }
+  async newAccountFromMnemonic(mnemonic: string): Promise<EAcc> {
+    const provider = await this.getProvider();
+    const networkAccount = new this.ethers.Wallet.fromMnemonic(mnemonic).connect(provider) as NetAcc;
+    const acc = this.connectAccount(networkAccount);
+    return acc;
+  }
+  async getFaucet(): Promise<EAcc> {
+    return await this.faucetP;
+  }
+  async getDefaultAccount(): Promise<EAcc> {
+    throw Error(`TODO: getDefaultAccount`);
+  }
+  async transfer(from: EAcc, to: EAcc, value: unknown, token?: unknown): Promise<IReceipt> {
+    const sender = from.networkAccount;
+    const receiver = to.address;
+    const valueb = this.bigNumberify(value);
+
+    const dhead = {kind:'transfer'};
+    if ( ! token ) {
+      const txn = { to: receiver, value: valueb };
+      this.debug('sender.sendTransaction(', txn, ')');
+      return await this.doTxn(dhead, sender.sendTransaction(txn));
+    } else {
+      const tokCtc = new this.ethers.Contract(token, ERC20_ABI, sender);
+      return await this.doCall(dhead, tokCtc, "transfer", [receiver, valueb], this.bigNumberify(0), undefined);
+    }
+  }
+  async createAccount(): Promise<EAcc> {
+    this.debug(`createAccount with 0 balance.`);
+    const provider = await this.getProvider();
+    const networkAccount = this.ethers.Wallet.createRandom().connect(provider);
+    return await this.connectAccount(networkAccount);
+  }
+  // TODO: move these to ReachStdlib?
+  async fundFromFaucet(acc: EAcc, value: unknown, token?: unknown): Promise<unknown> {
+    const faucet = await this.getFaucet();
+    return await this.transfer(faucet, acc, value, token);
+  }
+  async newTestAccount(startingBalance: unknown): Promise<EAcc> {
+    this.debug('newTestAccount(', startingBalance, ')');
+    this.requireIsolatedNetwork('newTestAccount');
+    const acc = await this.createAccount();
+    const to = acc.address;
+
+    try {
+      this.debug('newTestAccount awaiting transfer:', to);
+      await this.fundFromFaucet(acc, startingBalance);
+      this.debug('newTestAccount got transfer:', to);
+      return acc;
+    } catch (e) {
+      console.log(`newTestAccount: Trouble with account ${to}`);
+      throw e;
+    }
+  }
+
+  // Currency
+  formatCurrency(amt: unknown, decimals: number = 18): string {
+    // Recall that 1 WEI = 10e18 ETH
+    if (!(Number.isInteger(decimals) && 0 <= decimals)) {
+      throw Error(`Expected decimals to be a nonnegative integer, but got ${decimals}.`);
+    }
+    // Truncate
+    decimals = Math.min(decimals, 18);
+    const decimalsToForget = 18 - decimals;
+    const divAmt = this.bigNumberify(amt)
+      .div(this.bigNumberify(10).pow(decimalsToForget));
+    const amtStr = real_ethers.utils.formatUnits(divAmt, decimals)
+    // If the str ends with .0, chop it off
+    if (amtStr.slice(amtStr.length - 2) == ".0") {
+      return amtStr.slice(0, amtStr.length - 2);
+    } else {
+      return amtStr;
+    }
+  }
+  parseCurrency(amt: CurrencyAmount): real_ethers.BigNumber {
+    return this.bigNumberify(real_ethers.utils.parseUnits(amt.toString(), 'ether'));
+  }
+
+  // "public" helper methods
+  async getNetworkTime(): Promise<BigNumber> {
+    return this.bigNumberify(await this.getNetworkTimeNumber());
+  }
+  async fastForwardTo(targetTime: BigNumber, onProgress?: OnProgress): Promise<BigNumber> {
+    // console.log(`>>> FFWD TO: ${targetTime}`);
+    const onProg: OnProgress = onProgress || (() => {});
+    this.requireIsolatedNetwork('fastForwardTo');
+    let currentTime;
+    while (this.lt(currentTime = await this.getNetworkTime(), targetTime)) {
+      onProg({ currentTime, targetTime });
+      await this.stepTime();
+    }
+    // Also report progress at completion time
+    onProg({ currentTime, targetTime });
+    // console.log(`<<< FFWD TO: ${targetTime} complete. It's ${currentTime}`);
+    return currentTime;
+  }
+  async actuallyWaitUntilTime(targetTime: BigNumber, onProgress?: OnProgress): Promise<BigNumber> {
+    const onProg: OnProgress = onProgress || (() => {});
+    const provider = await this.getProvider();
+    return await new Promise((resolve) => {
+      const onBlock = async (currentTimeNum: number | BigNumber) => {
+        const currentTime = this.bigNumberify(currentTimeNum)
+        // Does not block on the progress fn if it is async
+        onProg({ currentTime, targetTime });
+        if (this.ge(currentTime, targetTime)) {
+          provider.off('block', onBlock);
+          resolve(currentTime);
+        }
+      };
+      provider.on('block', onBlock);
+
+      // Also "re-emit" the current block
+      // Note: this sometimes causes the starting block
+      // to be processed twice, which should be harmless.
+      this.getNetworkTime().then(onBlock);
+    });
+  }
+
+  // "private" helper methods
+  async getDummyAccount() {
+    if (this._dummyAccount === undefined) {
+      const provider = await this.getProvider();
+      const networkAccount = this.ethers.Wallet.createRandom().connect(provider) as NetAcc;
+      const acc = await this.connectAccount(networkAccount);
+      this._dummyAccount = acc;
+    }
+    return this._dummyAccount;
+  }
+  async stepTime(): Promise<IReceipt> {
+    this.requireIsolatedNetwork('stepTime');
+    const faucet = await this.getFaucet();
+    const acc = await this.getDummyAccount();
+    return await this.transfer(faucet, acc, this.parseCurrency(0));
+  }
+  async getNetworkTimeNumber(): Promise<number> {
+    const provider = await this.getProvider();
+    return await provider.getBlockNumber();
+  }
+  private async doTxn(
+    dhead: object,
+    tp: Promise<{wait: () => Promise<IReceipt>}>,
+  ): Promise<IReceipt> {
+    this.debug({...dhead, step: `pre call`});
+    const rt = await tp;
+    this.debug({...dhead, rt, step: `pre wait`});
+    const rm = await rt.wait();
+    this.debug({...dhead, rt, rm, step: `pre receipt`});
+    this.assert(rm !== null, `receipt wait null`);
+    const ro = await this.fetchAndRejectInvalidReceiptFor(rm.transactionHash);
+    this.debug({...dhead, rt, rm, ro, step: `post receipt`});
+    // ro's blockNumber might be interesting
+    return ro;
+  }
+
+  private async fetchAndRejectInvalidReceiptFor(txHash: string) {
+    const provider = await this.getProvider();
+    const r = await provider.getTransactionReceipt(txHash);
+    return await this.rejectInvalidReceiptFor(txHash, r);
+  }
+
+  // TODO: rewrite with async/await
+  private async rejectInvalidReceiptFor(txHash: string, r?: IReceipt): Promise<IReceipt> {
+    return new Promise((resolve, reject) =>
+      !r ? reject(`No receipt for txHash: ${txHash}`) :
+      r.transactionHash !== txHash ? reject(`Bad txHash; ${txHash} !== ${r.transactionHash}`) :
+      !r.status ? reject(`Transaction: ${txHash} was reverted by EVM\n${r}`) :
+      resolve(r)
+    );
+  }
+
+  async doCall(
+    dhead: object,
+    ctc: any, // ethers.Contract
+    funcName: string,
+    args: Array<any>,
+    value: real_ethers.BigNumber,
+    gasLimit?: real_ethers.BigNumber,
+  ): Promise<IReceipt> {
+    const dpre = { ...dhead, funcName, args, value };
+    this.debug({...dpre, step: `pre call`});
+    return await this.doTxn(
+      dpre,
+      ctc[funcName](...args, { value, gasLimit },
+    ));
   }
 }
 
@@ -55,12 +726,17 @@ export function parseNetworkId(opts: CFX_Opts) {
     || CFX.DEFAULT_CFX_NETWORK_ID;
 }
 
-export class CFX extends ETH_Like<cfxers.providers.Provider> {
+export class CFX extends ETH_Like<cfxers.providers.Provider, cfxers.Wallet> {
   static readonly DEFAULT_CFX_NODE_URI = 'http://localhost:12537';
   static readonly DEFAULT_CFX_NETWORK_ID = 999;
+  // XXX update this once reachsh/cfx-devnet exists
+  static readonly DEFAULT_FAUCET_SECRET = '0x96dc79489f01220ba3f8a7f8a1aaa6741af44e965d21f155a2b2a851e20e1458';
   readonly opts: CFX_Opts;
   readonly standardUnit = 'CFX';
+  readonly atomicUnit = 'Drip';
   readonly typeDefs: CFX_TypeDefs;
+  readonly connectorMode: ConnectorMode;
+  readonly isIsolatedNetwork: boolean;
   constructor(opts: CFX_Opts = {}) {
     super({
       ethers: cfxers,
@@ -78,6 +754,17 @@ export class CFX extends ETH_Like<cfxers.providers.Provider> {
       ...super.opts,
     };
     this.typeDefs = new CFX_TypeDefs(this.opts);
+    // XXX support more connector modes
+    this.connectorMode = 'CFX-experimental';
+    // XXX support non-isolated CFX networks
+    this.isIsolatedNetwork = true;
+  }
+  async _getDefaultFaucet(): Promise<EAcc> {
+    return await this.newAccountFromSecret(CFX.DEFAULT_FAUCET_SECRET);
+  }
+  async verifyContract(...args: any): Promise<true> {
+    void(args); // XXX CFX verifyContract
+    return true;
   }
 }
 

--- a/js/stdlib/ts/cfxers.ts
+++ b/js/stdlib/ts/cfxers.ts
@@ -1,0 +1,231 @@
+import cfxsdk from 'js-conflux-sdk';
+import ethers from 'ethers';
+import * as providers from './cfxers_providers';
+const { BigNumber, utils } = ethers;
+export { BigNumber, utils, providers }
+
+// This file immitates the ethers.js API
+
+// Recursively stringify BigNumbers
+function unbn(arg: any): any {
+  if (!arg) return arg;
+  if (arg._isBigNumber) return arg.toString();
+  if (Array.isArray(arg)) return arg.map(unbn);
+  if (typeof arg === 'string') return arg;
+  if (Object.keys(arg).length > 0) {
+    const newArg: {[k: string]: any} = {};
+    for (const k of Object.keys(arg)) {
+      newArg[k] = unbn(arg[k]);
+    }
+    return newArg;
+  }
+  return arg;
+}
+
+export class Signer {
+  static isSigner(x: any) {
+    // XXX
+    return x instanceof Wallet;
+  }
+}
+
+interface IContract {
+  [key: string]: any
+}
+
+// compare to ethers.Contract
+export class Contract implements IContract {
+  [k: string]: any
+  _abi: any[]
+  _wallet: Wallet
+  _receiptP?: Promise<any>
+  _contract: cfxsdk.Contract
+  address?: string
+  deployTransaction: {
+    hash?: string,
+    wait: () => Promise<{
+      blockNumber: number,
+      transactionHash: string,
+    }>,
+  }
+
+  // const ok_args_abi = ethersC.interface.getEvent(ok_evt).inputs;
+  // const { args } = ethersC.interface.parseLog(ok_e);
+  // return ok_args_abi.map((a: any) => args[a.name]);
+  interface: ethers.utils.Interface
+  // {
+  //   getEventTopic: (name: string) => string, // ?
+  //   getEvent: (name: string) => {inputs: {name: string}[]},
+  //   parseLog: (log: Log) => {args: {[k: string]: any}},
+  // }
+
+  constructor(address: string|undefined, abi: string|any[], wallet: Wallet, receiptP?: Promise<any>) {
+    this.address = address;
+    this._abi = (typeof abi === 'string') ? JSON.parse(abi) : abi;
+    this._wallet = wallet;
+    this._receiptP = receiptP;
+    // @ts-ignore // ???
+    this._contract = this._wallet.provider.conflux.Contract({
+      abi: this._abi, address: this.address,
+    });
+    const self = this;
+    this.deployTransaction = {
+      hash: undefined,
+      wait: async () => {
+        if (!receiptP) {
+          throw Error(`No receipt promise to wait on`);
+        }
+        const receipt = await self._receiptP;
+        self.address = receipt.contractCreated;
+        self.deployTransaction.hash = receipt.transactionHash;
+        return providers.ethifyOkReceipt(receipt);
+      },
+    }
+    for (const item of this._abi) {
+      if (item.type === 'function') {
+        if (item.name[0] !== '_' && item.name !== 'address' && item.name !== 'deployTransaction' && item.name !== 'interface') {
+          this[item.name] = this._makeHandler(item);
+        }
+      }
+    }
+    this.interface = new ethers.utils.Interface(this._abi);
+  }
+
+  _makeHandler(abiFn: any): any {
+    const from = this._wallet.getAddress();
+    const self = this;
+    // return (await getC())[funcName](arg, { value, gasLimit });
+    // const r_fn = await callC(funcName, arg, value);
+    // r_fn.wait()
+    // const ok_r = await fetchAndRejectInvalidReceiptFor(r_maybe.transactionHash);
+    return async (arg: any, txn: any) => {
+      arg = unbn(arg);
+      // XXX user-configurable gas limit
+      // const gas = '50000';
+      txn = {from, ...txn, value: txn.value.toString()};
+      // @ts-ignore
+      const transactionReceipt = await self._contract[abiFn.name](arg).sendTransaction(txn).executed();
+      const { transactionHash } = transactionReceipt;
+      return {
+        // XXX not sure what the distinction is supposed to be here
+        wait: async () => {
+          return {
+            transactionHash
+          };
+        }
+      };
+    }
+  }
+}
+
+export class ContractFactory {
+  abi: any[]
+  bytecode: string
+  wallet: Wallet
+
+  constructor(abi: string|any[], bytecode: string, wallet: Wallet) {
+    this.abi = (typeof abi === 'string') ? JSON.parse(abi) : abi;
+    this.bytecode = bytecode;
+    this.wallet = wallet;
+  }
+
+  deploy(...deployArgs: any): Contract {
+    const [argsOrTxn, txnIfArgs]: any[] = deployArgs;
+    const [args, txn]: [any[], {value?: ethers.BigNumber, gasLimit?: undefined}] = txnIfArgs
+      ? [ argsOrTxn, txnIfArgs ]
+      : [ [], argsOrTxn ];
+    const {abi, bytecode, wallet} = this;
+    wallet._requireConnected();
+    if (!wallet.provider) throw Error(`Impossible: provider is undefined`);
+    const {conflux} = wallet.provider;
+    const contract = conflux.Contract({abi, bytecode});
+    const from = wallet.getAddress();
+    const value = (txn.value || BigNumber.from(0)).toString();
+    if (args.length > 0) {
+      throw Error(`ctc args not yet supported`)
+    }
+
+    // XXX gasLimit
+    const receiptP = contract.constructor()
+      .sendTransaction({from, value})
+      .executed();
+
+    return new Contract(undefined, abi, wallet, receiptP);
+  }
+}
+
+export class Wallet {
+  privateKey?: string;
+  account?: cfxsdk.Account;
+  provider?: providers.Provider;
+
+  constructor(privateKey?: string, provider?: providers.Provider) {
+    this.privateKey = privateKey;
+    if (provider) {
+      this.connect(provider);
+    }
+  }
+
+  connect(provider: providers.Provider) {
+    if (this.provider) {
+      throw Error(`Wallet already connected`);
+    }
+    this.provider = provider;
+    if (this.privateKey) {
+      this.account = this.provider.conflux.wallet.addPrivateKey(this.privateKey);
+    } else {
+      this.account = this.provider.conflux.wallet.addRandom();
+    }
+    return this;
+  }
+
+  _requireConnected() {
+    if (!this.provider) {
+      throw Error(`Wallet has no Provider, please call .connect()`);
+    }
+    if (!this.account) {
+      throw Error(`Wallet has no Account, please call .connect()`);
+    }
+  }
+
+  getAddress(): string {
+    this._requireConnected();
+    if (!this.account) throw Error(`Impossible: account is undefined`);
+    return this.account.toString()
+  }
+
+  async sendTransaction(txn: any): Promise<{
+    transactionHash: string,
+    wait: () => Promise<{transactionHash: string,
+  }>}> {
+    this._requireConnected();
+    if (!this.provider) throw Error(`Impossible: provider is undefined`);
+    const from = this.getAddress();
+    txn = {from, ...txn, value: txn.value.toString()};
+    // This is weird but whatever
+    if (txn.to instanceof Promise) {
+      txn.to = await txn.to;
+    }
+    const transactionHashP = this.provider.conflux.sendTransaction(txn);
+    const transactionHash = await transactionHashP;
+    return {
+      transactionHash,
+      wait: async () => {
+        // see: https://github.com/Conflux-Chain/js-conflux-sdk/blob/master/docs/how_to_send_tx.md#transactions-stage
+        // @ts-ignore
+        await transactionHashP.executed();
+        return {transactionHash};
+      },
+    }
+  }
+
+  static createRandom(): Wallet {
+    return new Wallet();
+  }
+
+  static fromMnemonic(mnemonic: string): Wallet {
+    // TODO
+    void(mnemonic);
+    throw Error(`Account 'from mnemonic' not supported on Conflux, please use secret key`);
+  }
+}

--- a/js/stdlib/ts/cfxers.ts
+++ b/js/stdlib/ts/cfxers.ts
@@ -199,8 +199,11 @@ export class Wallet {
 
   async sendTransaction(txn: any): Promise<{
     transactionHash: string,
-    wait: () => Promise<{transactionHash: string,
-  }>}> {
+    wait: () => Promise<{
+      from: string
+      transactionHash: string
+    }>
+  }> {
     this._requireConnected();
     if (!this.provider) throw Error(`Impossible: provider is undefined`);
     const from = this.getAddress();
@@ -217,7 +220,7 @@ export class Wallet {
         // see: https://github.com/Conflux-Chain/js-conflux-sdk/blob/master/docs/how_to_send_tx.md#transactions-stage
         // @ts-ignore
         await transactionHashP.executed();
-        return {transactionHash};
+        return {from, transactionHash};
       },
     }
   }

--- a/js/stdlib/ts/cfxers.ts
+++ b/js/stdlib/ts/cfxers.ts
@@ -4,6 +4,9 @@ import * as providers from './cfxers_providers';
 const { BigNumber, utils } = ethers;
 export { BigNumber, utils, providers }
 
+// XXX Convenience export, may want to rethink
+export { cfxsdk };
+
 // This file immitates the ethers.js API
 
 // Recursively stringify BigNumbers

--- a/js/stdlib/ts/cfxers_providers.ts
+++ b/js/stdlib/ts/cfxers_providers.ts
@@ -1,0 +1,91 @@
+import cfxsdk from 'js-conflux-sdk';
+import ethers from 'ethers';
+import Timeout from 'await-timeout';
+
+type BigNumber = ethers.BigNumber;
+type EpochNumber = cfxsdk.EpochNumber;
+type Conflux = cfxsdk.Conflux;
+
+export function ethifyOkReceipt(receipt: any): any {
+  if (receipt.outcomeStatus !== 0) {
+    throw Error(`Receipt outcomeStatus is nonzero: ${receipt.outcomeStatus}`);
+  }
+  return {
+    blockNumber: receipt.epochNumber,
+    status: 'ok',
+    ...receipt,
+  };
+}
+
+export function ethifyTxn(txn: any): any {
+  if (txn.status !== 0) {
+    throw Error(`Txn status is not 0: ${txn.status}`);
+  }
+  // It would appear that no eth-ification is actully necessary at this moment.
+  // It might be nice to have blockNumber on here,
+  // but it's not required.
+  // Accomplishing that would require another API call...
+  return txn;
+}
+
+// XXX bi: BigInt
+function bi2bn(bi: any): BigNumber {
+  return ethers.BigNumber.from(bi.toString());
+}
+
+
+export class Provider {
+  conflux: Conflux;
+  constructor(conflux: Conflux) {
+    this.conflux = conflux;
+  }
+
+  async getBalance(address: string, epochNumber?: EpochNumber): Promise<BigNumber> {
+    return bi2bn(await this.conflux.getBalance(address, epochNumber));
+  }
+
+  async getBlockNumber(): Promise<number> {
+    // Arbitrarily make the user wait.
+    // This is just because we tend to spam this a lot.
+    // It can help to increase this to 1000 or more if you need to debug.
+    await Timeout.set(50);
+    // TODO: 'latest_state' seems to work well; is there a better choice?
+    return await this.conflux.getEpochNumber('latest_state');
+  }
+
+  async getTransactionReceipt(transactionHash: string): Promise<any> {
+    const r = await this.conflux.getTransactionReceipt(transactionHash);
+    return ethifyOkReceipt(r);
+  }
+
+  on(...argz: any) {
+    void(argz);
+    throw Error(`on not yet implemented`);
+    // XXX
+  }
+
+  off(...argz: any) {
+    void(argz);
+    throw Error(`off not yet implemented`);
+    // XXX
+  }
+
+  async getLogs(opts: {fromBlock: number, toBlock: number, address: string, topics: string[]}): Promise<any[]> {
+    const cfxOpts = {
+      fromEpoch: opts.fromBlock,
+      toEpoch: opts.toBlock,
+      address: opts.address,
+      topics: opts.topics,
+    };
+    return await this.conflux.getLogs(cfxOpts);
+  }
+
+  async getTransaction(txnHash: string): Promise<any> {
+    // @ts-ignore
+    return ethifyTxn(await this.conflux.getTransactionByHash(txnHash));
+  }
+
+}
+
+export type TransactionReceipt = any; // TODO
+export type Log = any; // TODO

--- a/js/stdlib/ts/classy_TypeDefs.ts
+++ b/js/stdlib/ts/classy_TypeDefs.ts
@@ -1,0 +1,255 @@
+import ethers, {BigNumber} from 'ethers';
+
+export abstract class TypeDef {
+  abstract name: string
+  abstract canonicalize(uv: unknown): unknown
+}
+
+export abstract class TypeDefs {
+  abstract readonly T_Null: A_T_Null
+  abstract readonly T_Bool: A_T_Bool
+  abstract readonly T_UInt: A_T_UInt
+  abstract readonly T_Bytes: (size: number) => A_T_Bytes
+  abstract readonly T_Digest: A_T_Digest
+  abstract readonly T_Address: A_T_Address
+  abstract readonly T_Array: (td: TypeDef, size: number) => A_T_Array
+  abstract readonly T_Tuple: (tds: TypeDef[]) => A_T_Tuple
+  abstract readonly T_Struct: (namedTds: [string, TypeDef][]) => A_T_Struct
+  abstract readonly T_Object: (tdMap: {[key: string]: TypeDef}) => A_T_Object
+  abstract readonly T_Data: (tdMap: {[key: string]: TypeDef}) => A_T_Data
+}
+
+export class A_T_Null extends TypeDef {
+  name = 'Null'
+  canonicalize(uv: unknown): null {
+    // Doesn't check with triple eq; we're being lenient here
+    if (uv != null) {
+      throw Error(`Expected null, but got ${JSON.stringify(uv)}`);
+    }
+    return null;
+  }
+}
+
+export class A_T_Bool extends TypeDef {
+  name = 'Bool'
+  canonicalize(uv: unknown): boolean {
+    if (typeof(uv) !== 'boolean') {
+      throw Error(`Expected boolean, but got ${JSON.stringify(uv)}`);
+    }
+    return uv;
+  }
+}
+
+export class A_T_UInt extends TypeDef {
+  name = 'UInt'
+  canonicalize(uv: unknown): BigNumber {
+    try {
+      const val = ethers.BigNumber.from(uv);
+      return val;
+    } catch (e) {
+      if (typeof(uv) === 'string') {
+        throw Error(`String does not represent a BigNumber. ${JSON.stringify(uv)}`);
+      } else {
+        throw Error(`Expected BigNumber, number, or string, but got ${JSON.stringify(uv)}`);
+      }
+    }
+  }
+}
+
+export class A_T_Bytes extends TypeDef {
+  private readonly _name: string
+  get name() { return this._name }
+
+  readonly len: number
+
+  constructor(len: number) {
+    super();
+    this._name = `Bytes(${len})`;
+    this.len = len;
+  }
+
+  canonicalize(uv: unknown): string {
+    const {len} = this;
+    if (typeof(uv) !== 'string') {
+      throw Error(`Bytes expected string, but got ${JSON.stringify(uv)}`);
+    }
+    const checkLen = (label: string, alen: number, fill: string): string => {
+      if ( uv.length > alen ) {
+        throw Error(`Bytes(${len}) must be a ${label}string less than or equal to ${alen}, but given ${label}string of length ${uv.length}`);
+      }
+      return uv.padEnd(alen, fill);
+    };
+    if ( uv.slice(0,2) === '0x' ) {
+      return checkLen('hex ', len*2+2, '0');
+    } else {
+      return checkLen('', len, '\0');
+    }
+  }
+}
+
+export class A_T_Digest extends TypeDef {
+  name = 'Digest'
+
+  // TODO: check digest length, or something similar?
+  // That's probably best left to connector-specific code.
+  canonicalize(uv: unknown): string {
+    if (typeof uv !== 'string') {
+      throw Error(`${JSON.stringify(uv)} is not a valid digest`);
+    }
+    return uv;
+  }
+}
+
+export class A_T_Address extends TypeDef {
+  name = 'Address'
+  canonicalize(uv: unknown): string {
+    if (typeof uv !== 'string') {
+      throw Error(`Address must be a string, but got: ${JSON.stringify(uv)}`);
+
+    // XXX these do not apply to CFX. move them into ETH/ALGO
+    // } else if (val.slice(0, 2) !== '0x') {
+    //   throw Error(`Address must start with 0x, but got: ${JSON.stringify(val)}`);
+    // } else if (!ethers.utils.isHexString(val)) {
+    //   throw Error(`Address must be a valid hex string, but got: ${JSON.stringify(val)}`);
+
+    }
+
+    return uv;
+  }
+}
+
+export class A_T_Array extends TypeDef {
+  private readonly _name: string
+  get name() { return this._name }
+
+  readonly td: TypeDef
+  readonly size: number
+
+  constructor(td: TypeDef, size: number) {
+    super();
+    this._name = `Array(${td.name}, ${size})`
+    this.td = td;
+    this.size = size;
+  }
+
+  canonicalize(args: unknown): unknown[] {
+    const {size, td} = this;
+    if (!Array.isArray(args)) {
+      throw Error(`Expected an Array, but got ${JSON.stringify(args)}`);
+    }
+    if (size !== args.length) {
+      throw Error(`Expected array of length ${size}, but got ${args.length}`);
+    }
+    const val = args.map((arg) => td.canonicalize(arg));
+    return val;
+  }
+}
+
+export class A_T_Tuple extends TypeDef {
+  private readonly _name: string
+  get name() { return this._name }
+
+  readonly ctcs: TypeDef[]
+
+  constructor(ctcs: TypeDef[]) {
+    super();
+    this.ctcs = ctcs;
+    this._name = `Tuple(${ctcs.map((ctc) => ` ${ctc.name} `)})`;
+  }
+
+  canonicalize(args: unknown): unknown[] {
+    const {ctcs} = this;
+    if (!Array.isArray(args)) {
+      throw Error(`Expected a Tuple, but got ${JSON.stringify(args)}`);
+    }
+    if (ctcs.length != args.length) {
+      throw Error(`Expected tuple of size ${ctcs.length}, but got ${args.length}`);
+    }
+    const val = args.map((arg, i) => ctcs[i].canonicalize(arg));
+    return val;
+  }
+}
+
+export class A_T_Struct extends TypeDef {
+  private readonly _name: string
+  get name() { return this._name }
+
+  readonly namedTds: [string, TypeDef][]
+
+  constructor(namedTds: [string, TypeDef][]) {
+    super();
+    this.namedTds = namedTds;
+    this._name = `Struct([${namedTds.map(([k, td]) => ` [${k}, ${td.name}] `)}])`;
+  }
+
+  canonicalize(arg: unknown): {[key: string]: unknown} {
+    const {namedTds} = this;
+    const obj: {
+      [key: string]: unknown
+    } = {};
+    namedTds.forEach(([k, td], i) => {
+      // TODO: throw error if  `arg` is obj but doesn't have key `k`
+      obj[k] = td.canonicalize(Array.isArray(arg) ? arg[i] : (arg as {[k: string]: unknown})[k]);
+    });
+    return obj;
+  }
+}
+
+export class A_T_Object extends TypeDef {
+  private readonly _name: string
+  get name() { return this._name }
+
+  readonly tdMap: {[key: string]: TypeDef}
+
+  constructor(tdMap: {[key: string]: TypeDef}) {
+    super();
+    this._name = `Object(${Object.keys(tdMap).map((k) => ` ${k}: ${tdMap[k].name} `)})`;
+    this.tdMap = tdMap;
+  }
+
+  canonicalize(uvo: unknown): {[key: string]: unknown} {
+    const {tdMap} = this;
+    if (typeof(uvo) !== 'object') {
+      throw Error(`Expected object, but got ${JSON.stringify(uvo)}`);
+    }
+    // XXX not sure what else TypeScript wants me to check to assert this is the case
+    const vo = uvo as {[key: string]: unknown};
+    const obj: {
+      [key: string]: unknown
+    } = {};
+    for (const prop in tdMap) {
+      // This is dumb but it's how ESLint says to do it
+      // https://eslint.org/docs/rules/no-prototype-builtins
+      if (!{}.hasOwnProperty.call(vo, prop)) {
+        throw Error(`Expected prop ${prop}, but didn't found it in ${Object.keys(vo)}`);
+      }
+      obj[prop] = tdMap[prop].canonicalize(vo[prop]);
+    }
+    return obj;
+  }
+}
+
+export class A_T_Data extends TypeDef {
+  private readonly _name: string
+  get name() { return this._name }
+
+  readonly tdMap: {[key: string]: TypeDef}
+
+  constructor(tdMap: {[key: string]: TypeDef}) {
+    super();
+    this._name = `Data(${Object.keys(tdMap).map((k) => ` ${k}: ${tdMap[k].name} `)})`;
+    this.tdMap = tdMap;
+  }
+
+  canonicalize(io: unknown): [string, unknown] {
+    const {tdMap} = this;
+    if (!(Array.isArray(io) && io.length == 2 && typeof io[0] == 'string')) {
+      throw Error(`Expected an array of length two to represent a data instance, but got ${JSON.stringify(io)}`);
+    }
+    const vn = io[0];
+    if (!{}.hasOwnProperty.call(tdMap, vn)) {
+      throw Error(`Expected a variant in ${Object.keys(tdMap)}, but got ${vn}`);
+    }
+    return [vn, tdMap[vn].canonicalize(io[1])];
+  }
+}

--- a/js/stdlib/ts/classy_TypeDefs.ts
+++ b/js/stdlib/ts/classy_TypeDefs.ts
@@ -43,6 +43,7 @@ export class A_T_Bool extends TypeDef {
 
 export abstract class A_T_UInt extends TypeDef {
   abstract readonly width: number
+  get maxValue(): BigNumber { return ethers.BigNumber.from(2).pow(this.width * 8).sub(1) };
   name = 'UInt'
   canonicalize(uv: unknown): BigNumber {
     try {

--- a/js/stdlib/ts/classy_TypeDefs.ts
+++ b/js/stdlib/ts/classy_TypeDefs.ts
@@ -9,14 +9,15 @@ export abstract class TypeDefs {
   abstract readonly T_Null: A_T_Null
   abstract readonly T_Bool: A_T_Bool
   abstract readonly T_UInt: A_T_UInt
-  abstract readonly T_Bytes: (size: number) => A_T_Bytes
   abstract readonly T_Digest: A_T_Digest
   abstract readonly T_Address: A_T_Address
-  abstract readonly T_Array: (td: TypeDef, size: number) => A_T_Array
-  abstract readonly T_Tuple: (tds: TypeDef[]) => A_T_Tuple
-  abstract readonly T_Struct: (namedTds: [string, TypeDef][]) => A_T_Struct
-  abstract readonly T_Object: (tdMap: {[key: string]: TypeDef}) => A_T_Object
-  abstract readonly T_Data: (tdMap: {[key: string]: TypeDef}) => A_T_Data
+  abstract readonly T_Token: A_T_Token
+  abstract T_Bytes(size: number): A_T_Bytes
+  abstract T_Array(td: TypeDef, size: number): A_T_Array
+  abstract T_Tuple(tds: TypeDef[]): A_T_Tuple
+  abstract T_Struct(namedTds: [string, TypeDef][]): A_T_Struct
+  abstract T_Object(tdMap: {[key: string]: TypeDef}): A_T_Object
+  abstract T_Data(tdMap: {[key: string]: TypeDef}): A_T_Data
 }
 
 export class A_T_Null extends TypeDef {
@@ -40,7 +41,8 @@ export class A_T_Bool extends TypeDef {
   }
 }
 
-export class A_T_UInt extends TypeDef {
+export abstract class A_T_UInt extends TypeDef {
+  abstract readonly width: number
   name = 'UInt'
   canonicalize(uv: unknown): BigNumber {
     try {
@@ -100,22 +102,21 @@ export class A_T_Digest extends TypeDef {
   }
 }
 
-export class A_T_Address extends TypeDef {
-  name = 'Address'
+abstract class StringyTypeDef extends TypeDef {
   canonicalize(uv: unknown): string {
     if (typeof uv !== 'string') {
-      throw Error(`Address must be a string, but got: ${JSON.stringify(uv)}`);
-
-    // XXX these do not apply to CFX. move them into ETH/ALGO
-    // } else if (val.slice(0, 2) !== '0x') {
-    //   throw Error(`Address must start with 0x, but got: ${JSON.stringify(val)}`);
-    // } else if (!ethers.utils.isHexString(val)) {
-    //   throw Error(`Address must be a valid hex string, but got: ${JSON.stringify(val)}`);
-
+      throw Error(`${this.name} must be a string, but got: ${JSON.stringify(uv)}`);
     }
-
     return uv;
   }
+}
+
+export class A_T_Address extends StringyTypeDef {
+  name = 'Address'
+}
+
+export class A_T_Token extends StringyTypeDef {
+  name = 'Token'
 }
 
 export class A_T_Array extends TypeDef {

--- a/js/stdlib/ts/classy_TypeDefs_CFX.ts
+++ b/js/stdlib/ts/classy_TypeDefs_CFX.ts
@@ -5,8 +5,9 @@ import { A_T_Address } from './classy_TypeDefs';
 function assertCfxAddress(s: string, prefix: string) {
   if (!s.startsWith(`${prefix}:`)) throw Error(`Expected address '${s}' to start with prefix '${prefix}'`);
   // +1 for the colon after the prefix
-  const expectedLength = prefix.length + 1 + 42;
-  if (s.length !== expectedLength) throw Error(`Expected address string '${s}' to be length ${expectedLength}, but it was ${s.length}.`);
+  const expectedLength = 42;
+  const unprefixed = s.split(':').slice(-1)[0];
+  if (unprefixed.length !== expectedLength) throw Error(`Expected address string '${s}' to be length ${expectedLength}, but it was ${s.length}.`);
   // TODO: more CFX address verification. Check the chechsum?
 }
 
@@ -19,7 +20,7 @@ export class CFX_T_Address extends ETH_T_Address {
     // TODO: support other networkIds
     // TODO: once we support mainnet & others, it's not just `net${networkId}` anymore
     if (networkId !== 999) throw Error(`XXX netId !== 999`);
-    this.prefix = `net${networkId}`;
+    this.prefix = `NET${networkId}`;
     // TODO: default value based on netId.
     // (requires figuring out a checksum which includes netId)
     // A random address.
@@ -28,7 +29,8 @@ export class CFX_T_Address extends ETH_T_Address {
   // TODO: more checking for correct CFX address format
   // Possibly: conversion from ETH-style address
   canonicalize(uv: string): string {
-    const unwrapped = unwrapAddress(uv) || uv;
+    // TODO: are there better choices re: upper case?
+    const unwrapped = (unwrapAddress(uv) || uv).toUpperCase();
     assertCfxAddress(uv, this.prefix);
     if (typeof unwrapped !== 'string') throw Error(`Expected address, but got ${uv}`);
     return unwrapped;

--- a/js/stdlib/ts/classy_TypeDefs_CFX.ts
+++ b/js/stdlib/ts/classy_TypeDefs_CFX.ts
@@ -1,11 +1,51 @@
-import {ETH_T_Address, unwrapAddress} from './classy_TypeDefs_ETH_like';
+import { ETH_T_Address, ETH_TypeDefs, unwrapAddress } from './classy_TypeDefs_ETH_like';
+import { CFX_Opts } from './classy_opts';
+import { A_T_Address } from './classy_TypeDefs';
+
+function assertCfxAddress(s: string, prefix: string) {
+  if (!s.startsWith(`${prefix}:`)) throw Error(`Expected address '${s}' to start with prefix '${prefix}'`);
+  // +1 for the colon after the prefix
+  const expectedLength = prefix.length + 1 + 42;
+  if (s.length !== expectedLength) throw Error(`Expected address string '${s}' to be length ${expectedLength}, but it was ${s.length}.`);
+  // TODO: more CFX address verification. Check the chechsum?
+}
 
 export class CFX_T_Address extends ETH_T_Address {
+  readonly defaultValue: string
+  prefix: string
+  constructor(opts: CFX_Opts) {
+    super();
+    const {networkId} = opts;
+    // TODO: support other networkIds
+    // TODO: once we support mainnet & others, it's not just `net${networkId}` anymore
+    if (networkId !== 999) throw Error(`XXX netId !== 999`);
+    this.prefix = `net${networkId}`;
+    // TODO: default value based on netId.
+    // (requires figuring out a checksum which includes netId)
+    // A random address.
+    this.defaultValue = `${this.prefix}:aajj5n713r16x9y44re0sxtnbw35km5gbua78nhdz7`
+  }
   // TODO: more checking for correct CFX address format
   // Possibly: conversion from ETH-style address
   canonicalize(uv: string): string {
     const unwrapped = unwrapAddress(uv) || uv;
+    assertCfxAddress(uv, this.prefix);
     if (typeof unwrapped !== 'string') throw Error(`Expected address, but got ${uv}`);
     return unwrapped;
+  }
+}
+
+export class CFX_T_Token extends CFX_T_Address implements A_T_Address {
+  // T_Token on CFX is CFX_T_Address in all but name
+  name = 'Token'
+}
+
+export class CFX_TypeDefs extends ETH_TypeDefs {
+  readonly T_Address: CFX_T_Address
+  readonly T_Token: CFX_T_Token
+  constructor(opts: CFX_Opts) {
+    super();
+    this.T_Address = new CFX_T_Address(opts);
+    this.T_Token = new CFX_T_Token(opts);
   }
 }

--- a/js/stdlib/ts/classy_TypeDefs_CFX.ts
+++ b/js/stdlib/ts/classy_TypeDefs_CFX.ts
@@ -1,0 +1,11 @@
+import {ETH_T_Address, unwrapAddress} from './classy_TypeDefs_ETH_like';
+
+export class CFX_T_Address extends ETH_T_Address {
+  // TODO: more checking for correct CFX address format
+  // Possibly: conversion from ETH-style address
+  canonicalize(uv: string): string {
+    const unwrapped = unwrapAddress(uv) || uv;
+    if (typeof unwrapped !== 'string') throw Error(`Expected address, but got ${uv}`);
+    return unwrapped;
+  }
+}

--- a/js/stdlib/ts/classy_TypeDefs_ETH_like.ts
+++ b/js/stdlib/ts/classy_TypeDefs_ETH_like.ts
@@ -1,0 +1,349 @@
+import ethers, { BigNumber } from 'ethers';
+import * as shared from './shared';
+import {
+  TypeDef,
+  A_T_Null,
+  A_T_Bool,
+  A_T_UInt,
+  A_T_Bytes,
+  A_T_Digest,
+  A_T_Address,
+  A_T_Array,
+  A_T_Tuple,
+  A_T_Struct,
+  A_T_Object,
+  A_T_Data,
+} from './classy_TypeDefs';
+import { labelMaps } from './shared_impl';
+
+export abstract class ETH_TypeDef<BV, NV> extends TypeDef {
+  abstract readonly paramType: string
+  abstract readonly defaultValue: BV
+  abstract canonicalize(uv: unknown): BV
+  abstract munge(bv: BV): NV
+  abstract unmunge(uv: unknown): BV
+}
+
+export class T_Null extends A_T_Null implements ETH_TypeDef<null, false> {
+  paramType = 'bool'
+  defaultValue = null
+  munge(bv: null): false {
+    if (bv !== null) throw Error(`impossible: expected BV of null to be null, but got ${bv}`);
+    return false;
+  }
+  unmunge(uv: unknown): null {
+    if (uv !== false) throw Error(`impossible: expected NV of null to be false, but got ${uv}`);
+    return null;
+  }
+}
+
+export class T_Bool extends A_T_Bool implements ETH_TypeDef<boolean, boolean> {
+  paramType = 'bool'
+  defaultValue = false
+  munge(bv: boolean): boolean {
+    if (typeof bv !== 'boolean') throw Error(`impossible: expected BV of boolean to be boolean, but got ${bv}`);
+    return bv;
+  }
+  unmunge(uv: unknown): boolean {
+    if (typeof uv !== 'boolean') throw Error(`impossible: expected NV of boolean to be boolean, but got ${uv}`);
+    return uv;
+  }
+}
+
+export class T_UInt extends A_T_UInt implements ETH_TypeDef<BigNumber, BigNumber> {
+  paramType = 'uint256'
+  defaultValue = ethers.BigNumber.from(0)
+  munge(bv: BigNumber): BigNumber {
+    if (!bv._isBigNumber) throw Error(`impossible: expected BV of UInt to be BigNumber, but got ${bv}`);
+    return bv;
+  }
+  unmunge(uv: unknown) {
+    return this.canonicalize(uv);
+  }
+}
+
+export class T_Bytes extends A_T_Bytes implements ETH_TypeDef<string, number[]> {
+  private readonly _paramType: string
+  private readonly _defaultValue: string
+  get paramType() { return this._paramType }
+  get defaultValue() { return this._defaultValue }
+  constructor(len: number) {
+    super(len);
+    this._paramType = `uint8[${len}]`;
+    this._defaultValue = ''.padEnd(len, '\0');
+  }
+  munge(bv: string): number[] {
+    return Array.from(ethers.utils.toUtf8Bytes(bv));
+  }
+  unmunge(uv: unknown): string {
+    // TODO: check that it is what we think it is
+    const nv = uv as number[];
+    return this.canonicalize(shared.hexToString(ethers.utils.hexlify(nv)));
+  }
+}
+
+export class T_Digest extends A_T_Digest implements ETH_TypeDef<string, BigNumber> {
+  paramType =  'uint256'
+  defaultValue = ethers.utils.keccak256([])
+  munge(bv: string): BigNumber {
+    if (typeof bv !== 'string') throw Error(`impossible: expected BV of digest to be string, but got ${bv}`);
+    return BigNumber.from(bv)
+  }
+  unmunge(uv: unknown): string {
+    if (!BigNumber.isBigNumber(uv)) throw Error(`impossible: expected NV of digest to be BigNumber, but got ${uv}`);
+    return uv.toHexString()
+  }
+}
+
+export function unwrapAddress(addr: unknown): string {
+  if (typeof addr === 'string') {
+    return addr;
+  }
+  // TODO: check more vigorously so that 'as' cast is not needed
+  const acc = addr as {networkAccount?: {address?: string}, address?: string};
+  if (acc.networkAccount && acc.networkAccount.address) {
+    return (acc.networkAccount.address);
+  } else if (acc.address) {
+    return acc.address;
+  } else {
+    throw Error(`Failed to unwrap address ${addr}`);
+  }
+}
+
+function hexyAddress(addr: unknown): string {
+  if (typeof addr !== 'string') throw Error(`impossible: addr not string: ${addr}`)
+  return (addr.slice(0, 2) === '0x') ? addr : '0x' + addr;
+}
+
+function assertHexyAddress(val: unknown, len: number) {
+  if (typeof val !== 'string') {
+    throw Error(`Address must be a string, but got: ${JSON.stringify(val)}`);
+  } else if (val.slice(0, 2) !== '0x') {
+    throw Error(`Address must start with 0x, but got: ${JSON.stringify(val)}`);
+  } else if (!ethers.utils.isHexString(val)) {
+    throw Error(`Address must be a valid hex string, but got: ${JSON.stringify(val)}`);
+  } else if (val.length !== len) {
+    throw Error(`Address hex string should be length ${len}, but got ${val.length}`);
+  }
+}
+
+export class ETH_T_Address extends A_T_Address implements ETH_TypeDef<string, string> {
+  paramType = 'address'
+  defaultValue = '0x' + Array(40).fill('0').join('')
+  canonicalize(uv: unknown): string {
+    const unwrapped = unwrapAddress(uv) || uv;
+    const val = hexyAddress(unwrapped);
+    assertHexyAddress(val, 42);
+    return val;
+  }
+  munge(bv: string): string {
+    if (typeof bv !== 'string') throw Error(`impossible: expected BV of address to be string, but got ${bv}`);
+    return bv;
+  }
+  unmunge(uv: unknown): string {
+    return this.canonicalize(uv);
+  }
+}
+
+export class T_Array<T> extends A_T_Array implements ETH_TypeDef<T[], unknown[]> {
+  private readonly _defaultValue: T[]
+  private readonly _paramType: string
+  get defaultValue() { return this._defaultValue }
+  get paramType() { return this._paramType }
+  readonly td: ETH_TypeDef<T, unknown>
+  constructor(td: ETH_TypeDef<T, unknown>, size: number) {
+    super(td, size);
+    this._defaultValue = Array(size).fill(td.defaultValue);
+    this._paramType = `${td.paramType}[${size}]`;
+    this.td = td;
+  }
+  // TypeScript, just trust us on this one
+  canonicalize(uv: unknown): T[] {
+    const ret = super.canonicalize(uv);
+    return ret as T[];
+  }
+  munge(bv: T[]): any {
+    if (!Array.isArray(bv)) throw Error(`Expected BV of array to be array, but got ${bv}`);
+    const {size, td} = this;
+    if ( size == 0 ) {
+      return false;
+    } else {
+      return bv.map((arg: T) => td.munge(arg));
+    }
+  }
+  unmunge(uv: unknown): T[] {
+    if (!Array.isArray(uv)) throw Error(`Expected NV of array to be array, but got ${uv}`);
+    const {size, td} = this;
+    if ( size == 0 ) {
+      return [];
+    } else {
+      return this.canonicalize(uv.map((arg: any) => td.unmunge(arg)));
+    }
+  }
+}
+
+export class T_Tuple extends A_T_Tuple implements ETH_TypeDef<unknown[], unknown[]|false> {
+  private readonly _defaultValue: unknown[]
+  private readonly _paramType: string
+  get defaultValue() { return this._defaultValue }
+  get paramType() { return this._paramType }
+  readonly tds: ETH_TypeDef<unknown, unknown>[];
+  constructor(tds: ETH_TypeDef<unknown, unknown>[]) {
+    super(tds);
+    this.tds = tds;
+    this._defaultValue = tds.map(td => td.defaultValue);
+    this._paramType = `tuple(${tds.map((td) => td.paramType).join(',')})`
+  }
+  munge(bv: unknown[]): unknown[]|false {
+    const {tds} = this;
+    if (tds.length == 0 ) {
+      return false;
+    } else {
+      return bv.map((arg, i) => tds[i].munge(arg));
+    }
+  }
+  unmunge(uv: unknown) {
+    if (!Array.isArray(uv)) throw Error(`Expected NV of tuple to be array, but got ${uv}`);
+    const {tds} = this;
+    return this.canonicalize(tds.map((td, i) => td.unmunge(uv[i])));
+  }
+}
+
+export class T_Struct extends A_T_Struct implements ETH_TypeDef<{[key: string]: unknown}, unknown[]|false> {
+  private readonly _defaultValue: {[key: string]: unknown}
+  private readonly _paramType: string
+  get defaultValue() { return this._defaultValue }
+  get paramType() { return this._paramType }
+  readonly namedTds: [string, ETH_TypeDef<unknown, unknown>][]
+  constructor(namedTds: [string, ETH_TypeDef<unknown, unknown>][]) {
+    super(namedTds);
+    this._defaultValue = {};
+    namedTds.forEach(([prop, td]) => {
+      this._defaultValue[prop] = td.defaultValue;
+    });
+    this._paramType = `tuple(${namedTds.map(([k, td]) => { void (k); return td.paramType }).join(',')})`
+    this.namedTds = namedTds;
+  }
+  munge(bv: {[key: string]: unknown}): unknown[]|false {
+    const {namedTds} = this;
+    if (namedTds.length == 0 ) {
+      return false;
+    } else {
+      return namedTds.map(([k, td]) => td.munge(bv[k]));
+    }
+  }
+  unmunge(uv: unknown) {
+    if (!Array.isArray(uv)) throw Error(`Expected NV of tuple to be array, but got ${uv}`);
+    const {namedTds} = this;
+    return this.canonicalize(namedTds.map(([k, td], i: number) => {
+      void (k);
+      return td.unmunge(uv[i]);
+    }));
+  }
+}
+
+export class T_Object extends A_T_Object implements ETH_TypeDef<{[key: string]: unknown}, {[key: string]: unknown}|false> {
+  private readonly _defaultValue: {[key: string]: unknown}
+  private readonly _paramType: string
+  get defaultValue() { return this._defaultValue }
+  get paramType() { return this._paramType }
+  readonly tdMap: {[key: string]: ETH_TypeDef<unknown, unknown>}
+  constructor(tdMap: {[key: string]: ETH_TypeDef<unknown, unknown>}) {
+    super(tdMap);
+    this.tdMap = tdMap;
+    this._defaultValue = {};
+    for (const prop in tdMap) {
+      this._defaultValue[prop] = tdMap[prop].defaultValue;
+    }
+    const {ascLabels} = labelMaps(tdMap);
+    const tupFields = ascLabels.map((label) => `${tdMap[label].paramType} ${label}`).join(',')
+    this._paramType = `tuple(${tupFields})`;
+  }
+  munge(bv: {[key: string]: unknown}): {[key: string]: unknown}|false {
+    const {tdMap} = this;
+    const obj: {
+      [key: string]: any
+    } = {};
+    let none: boolean = true;
+    for (const prop in tdMap) {
+      none = false;
+      obj[prop] = tdMap[prop].munge(bv[prop]);
+    }
+    if ( none ) {
+      return false;
+    } else {
+      return obj;
+    }
+  }
+  unmunge(uv: unknown): {[key: string]: unknown} {
+    const {tdMap} = this;
+    // TODO: more runtime checking that this is a safe cast
+    const bv = uv as {[key: string]: unknown};
+    const obj: {
+      [key: string]: unknown,
+    } = {};
+    for (const prop in tdMap) {
+      obj[prop] = tdMap[prop].unmunge(bv[prop]);
+    }
+    return this.canonicalize(obj);
+  }
+}
+
+export class T_Data extends A_T_Data implements ETH_TypeDef<[string, unknown], unknown[]|false> {
+  private readonly _defaultValue: [string, unknown]
+  private readonly _paramType: string
+  get defaultValue() { return this._defaultValue }
+  get paramType() { return this._paramType }
+  readonly tdMap: {[key: string]: ETH_TypeDef<unknown, unknown>}
+  readonly ascLabels: string[]
+  readonly labelMap: {[key: string]: number}
+  constructor(tdMap: {[key: string]: ETH_TypeDef<unknown, unknown>}) {
+    super(tdMap);
+    const {ascLabels, labelMap} = labelMaps(tdMap);
+    this.tdMap = tdMap;
+    this.ascLabels = ascLabels;
+    this.labelMap = labelMap;
+    const label = ascLabels[0];
+    this._defaultValue = [label, tdMap[label].defaultValue];
+    // See comment on unmunge about field names that we could use but currently don't
+    const optionTys = ascLabels.map((label) => `${tdMap[label].paramType} _${label}`)
+    // TODO: parameterize on the T_UInt, rather than assuming it's always this one?
+    const tupFields = [`${(new T_UInt()).paramType} which`].concat(optionTys).join(',');
+    this._paramType = `tuple(${tupFields})`;
+  }
+  // Data representation in js is a 2-tuple:
+  // [label, val]
+  // where label : string
+  // and val : co[label]
+  //
+  // Data representation in solidity is an N+1-tuple: (actually a struct)
+  // [labelInt, v0, ..., vN]
+  // where labelInt : number, 0 <= labelInt < N
+  // vN : co[ascLabels[i]]
+  //
+  munge([label, v]: [string, unknown]): unknown[] {
+    const {labelMap, ascLabels, tdMap} = this;
+    const i = labelMap[label];
+    const vals = ascLabels.map((label) => {
+      const vco = tdMap[label];
+      return vco.munge(vco.defaultValue);
+    });
+    vals[i] = tdMap[label].munge(v);
+    const ret = [i as unknown];
+    return ret.concat(vals);
+  }
+  // Note: when it comes back from solidity, vs behaves like an N+1-tuple,
+  // but also has secret extra keys you can access,
+  // based on the struct field names.
+  // e.g. Maybe has keys vs["which"], vs["_None"], and vs["_Some"],
+  // corresponding to    vs[0],       vs[1],       and vs[2] respectively.
+  // We don't currently use these, but we could.
+  unmunge(uv: unknown): [string, unknown] {
+    if (!Array.isArray(uv)) throw Error(`impossible: expected NV of Data to be array, but got ${uv}`);
+    const {tdMap, ascLabels} = this;
+    const i = uv[0] as unknown as number;
+    const label = ascLabels[i];
+    const val = uv[i + 1];
+    return this.canonicalize([label, tdMap[label].unmunge(val)]);
+  }
+}

--- a/js/stdlib/ts/classy_TypeDefs_ETH_like.ts
+++ b/js/stdlib/ts/classy_TypeDefs_ETH_like.ts
@@ -214,9 +214,10 @@ export class T_Tuple extends A_T_Tuple implements ETH_TypeDef<unknown[], unknown
     }
   }
   unmunge(uv: unknown) {
-    if (!Array.isArray(uv)) throw Error(`Expected NV of tuple to be array, but got ${uv}`);
+    const uva = uv === false ? [] : uv as unknown[];
+    if (!Array.isArray(uva)) throw Error(`Expected NV of tuple to be array or false, but got ${uv}`);
     const {tds} = this;
-    return this.canonicalize(tds.map((td, i) => td.unmunge(uv[i])));
+    return this.canonicalize(tds.map((td, i) => td.unmunge(uva[i])));
   }
 }
 

--- a/js/stdlib/ts/classy_opts.ts
+++ b/js/stdlib/ts/classy_opts.ts
@@ -1,4 +1,5 @@
 export interface ReachStdlib_Opts {
+  // XXX REACH_DEBUG?: string
   readonly REACH_DEBUG?: boolean
   readonly REACH_CONNECTOR_MODE?: string
   readonly REACH_FAUCET_SECRET?: string
@@ -10,7 +11,12 @@ export interface ETH_Like_Opts extends ReachStdlib_Opts {
   readonly provider?: any
 }
 
+export interface ETH_Opts extends ETH_Like_Opts {
+  readonly ETH_NODE_URI?: string
+}
+
 export interface CFX_Opts extends ETH_Like_Opts {
+  // XXX CFX_DEBUG?: string
   readonly CFX_DEBUG?: boolean
   readonly CFX_NODE_URI?: string
   readonly CFX_NETWORK_ID?: string | number

--- a/js/stdlib/ts/classy_opts.ts
+++ b/js/stdlib/ts/classy_opts.ts
@@ -1,6 +1,8 @@
 export interface ReachStdlib_Opts {
   readonly REACH_DEBUG?: boolean
   readonly REACH_CONNECTOR_MODE?: string
+  readonly REACH_FAUCET_SECRET?: string
+  readonly REACH_FAUCET_MNEMONIC?: string
 }
 
 export interface ETH_Like_Opts extends ReachStdlib_Opts {

--- a/js/stdlib/ts/classy_opts.ts
+++ b/js/stdlib/ts/classy_opts.ts
@@ -1,0 +1,16 @@
+export interface ReachStdlib_Opts {
+  readonly REACH_DEBUG?: boolean
+  readonly REACH_CONNECTOR_MODE?: string
+}
+
+export interface ETH_Like_Opts extends ReachStdlib_Opts {
+  readonly ethers?: any
+  readonly provider?: any
+}
+
+export interface CFX_Opts extends ETH_Like_Opts {
+  readonly CFX_DEBUG?: boolean
+  readonly CFX_NODE_URI?: string
+  readonly CFX_NETWORK_ID?: string | number
+  readonly networkId?: number
+}

--- a/js/stdlib/ts/classy_shared.ts
+++ b/js/stdlib/ts/classy_shared.ts
@@ -1,0 +1,100 @@
+import { ReachStdlib_Opts } from './classy_opts';
+import { TypeDef, TypeDefs } from './classy_TypeDefs';
+import * as shared from './shared';
+import { BigNumber, BytesLike } from 'ethers';
+import { Utf8ErrorFunc } from 'ethers/lib/utils';
+import ethers from 'ethers';
+import crypto from 'crypto';
+const { hexlify } = ethers.utils;
+
+// Helpers
+type num = number | BigNumber
+const byteToHex = (b: number): string => (b & 0xFF).toString(16).padStart(2, '0');
+const byteArrayToHex = (b: any): string => Array.from(b, byteToHex).join('');
+
+export abstract class ReachStdlib {
+  abstract readonly typeDefs: TypeDefs
+  abstract readonly standardUnit: string
+  // TODO: revisit the digest/prepForDigest point of abstraction
+  abstract prepForDigest(t: TypeDef, v: unknown): BytesLike
+  abstract tokenEq(x: unknown, y: unknown): boolean
+
+  readonly opts: ReachStdlib_Opts;
+  constructor(opts: ReachStdlib_Opts = {}) {
+    opts = {
+      REACH_DEBUG: false,
+      REACH_CONNECTOR_MODE: 'ETH',
+      ...opts,
+    }
+    this.opts = opts;
+    // XXX We are turning a blind eye to mutation for now,
+    // but later should delete setDEBUG and only set it via the opts.
+    if (opts.REACH_DEBUG) this.setDEBUG(true);
+  }
+  /** @deprecated */
+  setDEBUG(b: boolean): void { return shared.setDEBUG(b); }
+  /** @deprecated */
+  getDEBUG(): boolean { return shared.getDEBUG(); }
+  debug(...msgs: any): void { shared.debug(...msgs); }
+  assert(cond: unknown, ai: unknown = null): void { return shared.assert(cond, ai); }
+  isBigNumber(x: unknown): x is BigNumber { return shared.isBigNumber(x); }
+  bigNumberify(x: unknown): BigNumber { return shared.bigNumberify(x); }
+  bigNumberToNumber(x: unknown): number { return shared.bigNumberToNumber(x); }
+  checkedBigNumberify(at: string, m: BigNumber, x: unknown): BigNumber { return shared.checkedBigNumberify(at, m, x); }
+  protect(td: TypeDef, v: unknown, ai: unknown = null): unknown { return shared.protect(td, v, ai); }
+  isHex(value: unknown, length?: number): value is string { return shared.isHex(value, length); }
+  hexToString(bytes: BytesLike, onError?: Utf8ErrorFunc): string { return shared.hexToString(bytes, onError); }
+  stringToHex(x: string): string { return shared.stringToHex(x); }
+  // makeDigest(prep: unknown): (t: unknown, v: unknown) => string { return shared.makeDigest(prep); }
+  hexToBigNumber(h: string): BigNumber { return shared.hexToBigNumber(h); }
+  uintToBytes(i: BigNumber): string { return shared.bigNumberToHex(i); }
+  bigNumberToHex(u: num, size: number = 32) { shared.bigNumberToHex(u, size); }
+  bytesEq(x: unknown, y: unknown): boolean { return shared.bytesEq(x, y); }
+  digestEq(x: unknown, y: unknown): boolean { return shared.digestEq(x, y); }
+  makeRandom(width: number): {
+    randomUInt: () => BigNumber,
+    hasRandom: { random: () => BigNumber },
+  } { return shared.makeRandom(width); }
+
+  eq(a: num, b: num): boolean { return shared.eq(a, b); }
+  add(a: num, b: num): BigNumber { return shared.add(a, b); }
+  sub(a: num, b: num): BigNumber { return shared.sub(a, b); }
+  mod(a: num, b: num): BigNumber { return shared.mod(a, b); }
+  mul(a: num, b: num): BigNumber { return shared.mul(a, b); }
+  div(a: num, b: num): BigNumber { return shared.div(a, b); }
+  ge(a: num, b: num): boolean { return shared.ge(a, b); }
+  gt(a: num, b: num): boolean { return shared.gt(a, b); }
+  le(a: num, b: num): boolean { return shared.le(a, b); }
+  lt(a: num, b: num): boolean { return shared.lt(a, b); }
+
+  argsSlice<T>(args: T[], cnt: number): T[] { return shared.argsSlice(args, cnt); }
+  argsSplit<T>(args: T[], cnt: number): [T[], T[]] { return shared.argsSplit(args, cnt); }
+  Array_set<T>(arr: T[], idx: number, elem: T): T[] { return shared.Array_set(arr, idx, elem); }
+  Array_zip<X,Y>(x: X[], y: Y[]): [X,Y][] { return shared.Array_zip(x, y); }
+  mapRef(m: unknown, f: unknown): unknown { return shared.mapRef(m, f); }
+
+  parseFixedPoint(x: { sign: boolean, i: { i: num, scale: num } }): number { return shared.parseFixedPoint(x); }
+  parseInt(x: { sign: boolean, i: num}): number { return shared.parseInt(x); }
+
+  // Different than shared!
+  addressEq(x: unknown, y: unknown): boolean {
+    const {T_Address} = this.typeDefs;
+    return this.bytesEq(T_Address.canonicalize(x), T_Address.canonicalize(y));
+  }
+  digest(t: TypeDef, v: unknown) {
+    // TODO: cleaner impl
+    const args = [t, v];
+    this.debug('digest(', args, ') =>');
+    const kekCat = this.prepForDigest(t, v);
+    this.debug('digest(', args, ') => internal(', hexlify(kekCat), ')');
+    const r = ethers.utils.keccak256(kekCat);
+    this.debug('keccak(', args, ') => internal(', hexlify(kekCat), ') => ', r);
+    return r;
+  }
+  randomUInt(): BigNumber {
+    const {T_UInt} = this.typeDefs;
+    // TODO: abstract away which `crypto.randomBytes` impl is used
+    return this.hexToBigNumber(byteArrayToHex(crypto.randomBytes(T_UInt.width)));
+  }
+  readonly hasRandom = { random: () => this.randomUInt() }
+}

--- a/js/stdlib/ts/classy_shared.ts
+++ b/js/stdlib/ts/classy_shared.ts
@@ -12,12 +12,14 @@ type num = number | BigNumber
 const byteToHex = (b: number): string => (b & 0xFF).toString(16).padStart(2, '0');
 const byteArrayToHex = (b: any): string => Array.from(b, byteToHex).join('');
 
-// TODO
+// TODO: ALGO
+type DeployMode = 'DM_firstMsg' | 'DM_constructor';
 export type Backend = {
   _Connectors: {
     ETH: {
       ABI: string,
       Bytecode: string,
+      deployMode: DeployMode,
     }
   }
 }
@@ -85,6 +87,7 @@ export abstract class ReachStdlib<ConnectorTy extends TypeDef> implements Compil
   abstract fundFromFaucet(acc: IAcc<ConnectorTy>, value: unknown, token?: any): Promise<unknown>
   abstract createAccount(): Promise<IAcc<ConnectorTy>>
   abstract newTestAccount(startingBalance: unknown): Promise<IAcc<ConnectorTy>>
+  abstract balanceOf(acc: IAcc<ConnectorTy>): Promise<BigNumber>
 
   // Currency
   abstract readonly standardUnit: string

--- a/js/stdlib/ts/loader.ts
+++ b/js/stdlib/ts/loader.ts
@@ -1,5 +1,6 @@
 import * as stdlib_ETH from './ETH';
 import * as stdlib_ALGO from './ALGO';
+import * as stdlib_CFX from './CFX';
 import {getConnectorMode, canonicalizeConnectorMode, getConnector} from './ConnectorMode';
 import {process, window} from './shim';
 
@@ -30,6 +31,7 @@ export async function loadStdlib(connectorModeOrEnv?: string | {[key: string]: s
   switch (connector) {
     case 'ETH': stdlib = stdlib_ETH; break;
     case 'ALGO': stdlib = stdlib_ALGO; break;
+    case 'CFX': stdlib = stdlib_CFX; break;
     default: throw Error(`impossible: unknown connector ${connector}`);
   }
   if (connectorModeOrEnv && typeof connectorModeOrEnv !== 'string') {

--- a/js/stdlib/ts/loader.ts
+++ b/js/stdlib/ts/loader.ts
@@ -1,4 +1,4 @@
-import * as stdlib_ETH from './ETH';
+// import * as stdlib_ETH from './ETH';
 import * as stdlib_ALGO from './ALGO';
 // import * as stdlib_CFX from './CFX';
 import * as stdlib_ETH_like from './ETH_like';
@@ -31,7 +31,8 @@ export function loadStdlib(connectorModeOrEnv?: string | {[key: string]: string}
   const env = typeof connectorModeOrEnv !== 'string' ? connectorModeOrEnv : {}
   let stdlib;
   switch (connector) {
-    case 'ETH': stdlib = stdlib_ETH; break;
+    // case 'ETH': stdlib = stdlib_ETH; break;
+    case 'ETH': stdlib = new stdlib_ETH_like.ETH(env); break;
     case 'ALGO': stdlib = stdlib_ALGO; break;
     // case 'CFX': stdlib = stdlib_CFX; break;
     case 'CFX': stdlib = new stdlib_ETH_like.CFX(env); break;

--- a/js/stdlib/ts/loader.ts
+++ b/js/stdlib/ts/loader.ts
@@ -1,6 +1,7 @@
 import * as stdlib_ETH from './ETH';
 import * as stdlib_ALGO from './ALGO';
 import * as stdlib_CFX from './CFX';
+// import * as stdlib_ETH_like from './ETH_like';
 import {getConnectorMode, canonicalizeConnectorMode, getConnector} from './ConnectorMode';
 import {process, window} from './shim';
 
@@ -27,11 +28,13 @@ export async function loadStdlib(connectorModeOrEnv?: string | {[key: string]: s
   }
   const connectorMode = canonicalizeConnectorMode(connectorModeStr);
   const connector = getConnector(connectorMode);
+  // const env = typeof connectorModeOrEnv !== 'string' ? connectorModeOrEnv : {}
   let stdlib;
   switch (connector) {
     case 'ETH': stdlib = stdlib_ETH; break;
     case 'ALGO': stdlib = stdlib_ALGO; break;
     case 'CFX': stdlib = stdlib_CFX; break;
+    // case 'CFX': stdlib = new stdlib_ETH_like.CFX(env); break;
     default: throw Error(`impossible: unknown connector ${connector}`);
   }
   if (connectorModeOrEnv && typeof connectorModeOrEnv !== 'string') {

--- a/js/stdlib/ts/loader.ts
+++ b/js/stdlib/ts/loader.ts
@@ -1,7 +1,7 @@
 import * as stdlib_ETH from './ETH';
 import * as stdlib_ALGO from './ALGO';
-import * as stdlib_CFX from './CFX';
-// import * as stdlib_ETH_like from './ETH_like';
+// import * as stdlib_CFX from './CFX';
+import * as stdlib_ETH_like from './ETH_like';
 import {getConnectorMode, canonicalizeConnectorMode, getConnector} from './ConnectorMode';
 import {process, window} from './shim';
 
@@ -10,10 +10,10 @@ export {getConnectorMode, getConnector};
 // XXX make an interface for Stdlib, return Promise<Stdlib>
 // The connectorMode arg is optional;
 // It will use REACH_CONNECTOR_MODE if 0 args.
-export async function loadStdlib(connectorModeOrEnv?: string | {[key: string]: string}): Promise<any> {
+export function loadStdlib(connectorModeOrEnv?: string | {[key: string]: string}): any {
   if (!connectorModeOrEnv) {
     // @ts-ignore // XXX why doesn't TS understand that Env satisfies {[key: string}: string} ?
-    return await loadStdlib(process.env);
+    return loadStdlib(process.env);
   }
   let connectorModeStr: string;
   if (typeof connectorModeOrEnv === 'string') {
@@ -28,13 +28,13 @@ export async function loadStdlib(connectorModeOrEnv?: string | {[key: string]: s
   }
   const connectorMode = canonicalizeConnectorMode(connectorModeStr);
   const connector = getConnector(connectorMode);
-  // const env = typeof connectorModeOrEnv !== 'string' ? connectorModeOrEnv : {}
+  const env = typeof connectorModeOrEnv !== 'string' ? connectorModeOrEnv : {}
   let stdlib;
   switch (connector) {
     case 'ETH': stdlib = stdlib_ETH; break;
     case 'ALGO': stdlib = stdlib_ALGO; break;
-    case 'CFX': stdlib = stdlib_CFX; break;
-    // case 'CFX': stdlib = new stdlib_ETH_like.CFX(env); break;
+    // case 'CFX': stdlib = stdlib_CFX; break;
+    case 'CFX': stdlib = new stdlib_ETH_like.CFX(env); break;
     default: throw Error(`impossible: unknown connector ${connector}`);
   }
   if (connectorModeOrEnv && typeof connectorModeOrEnv !== 'string') {

--- a/reach
+++ b/reach
@@ -545,7 +545,9 @@ services:
     environment:
       - REACH_DEBUG
       - REACH_CONNECTOR_MODE=CFX-experimental
+      - CFX_DEBUG
       - CFX_NODE_URI=http://host.docker.internal:12537
+      - CFX_NETWORK_ID=999
   ${SERVICE}-: *default-app
   ${SERVICE}: *default-app
 EOF

--- a/reach
+++ b/reach
@@ -195,6 +195,9 @@ ensure_connector_mode () {
     "ALGO-test-dockerized")
       REACH_CONNECTOR_MODE="ALGO-test-dockerized-algod"
       ;;
+    "CFX")
+      REACH_CONNECTOR_MODE="CFX-experimental"
+      ;;
   esac
 
   # ensure it is one of the supported things
@@ -204,6 +207,8 @@ ensure_connector_mode () {
     "ETH-test-dockerized-geth")
       ;;
     "ALGO-test-dockerized-algod")
+      ;;
+    "CFX-experimental")
       ;;
     *)
       fatal_unrecognized_connector_mode
@@ -535,6 +540,12 @@ services:
       - ALGO_PORT=4180
       - ALGO_INDEXER_SERVER=http://algorand-devnet
       - ALGO_INDEXER_PORT=8980
+  ${SERVICE}-CFX-experimental:
+    <<: *app-base
+    environment:
+      - REACH_DEBUG
+      - REACH_CONNECTOR_MODE=CFX-experimental
+      - CFX_NODE_URI=http://host.docker.internal:12537
   ${SERVICE}-: *default-app
   ${SERVICE}: *default-app
 EOF


### PR DESCRIPTION
**NOT A REAL PR (yet)**

About the new source files:

* CFX.ts is the "ugly" copy/pasted impl (deprecated)
* ETH_like.ts is the "classy" impl (proposed)
* cfxers.ts and cfxers_providers.ts are used for both impls
* classy_*.ts are used for the classy impl
* "classy" impl is currently "plugged in" to loader.ts
* haven't deleted any files that these things replace, yet

About the state of this implementation:

* both classy CFX and ETH impls can correctly run examples/overview
  - CFX (for now) still requires that you bring your own devnet & faucet
* some more impl for ETH still needs copying over to support everything ETH is supposed to support (at least: firstMsg deploy mode, browser support)
* some more impl for CFX still needs implementing in cfxers to support "real" CFX (at least: Provider on/off hooks for monitoring the passage of time with real delays on a "real" network)
* attempts to follow the philosophy of "avoid setBLAH, instead just create the thing with BLAH set as desired via constructor opts"
* attempts to follow the philosophy of "don't read env vars deep in the code, instead pass them in as config at the surface level"
* attempts to use `readonly` attributes as much as possible
* attempts to use `private` class methods and leading-underscore naming conventions for private methods, albeit not very consistently yet