### PR TITLE
Adding Default `Reach.App`

### DIFF
--- a/docs-src/ref.scrbl
+++ b/docs-src/ref.scrbl
@@ -50,7 +50,9 @@ and each @exec{EXPORT} is an @tech{export}ed @tech{Reach.App}.
 
 If no @exec{SOURCE} is provided, then @exec{index.rsh} is used.
 
-If no @exec{EXPORT} is provided, then all the exported @tech{Reach.App}s will be compiled.
+If no @exec{EXPORT} is provided, then all the exported @tech{Reach.App}s will be compiled. If there are no
+@tech{Reach.App}s exported, then the program will be compiled as a library, where its exports are available
+to other Reach programs and frontends.
 
 @exec{reach compile} supports the following options:
 

--- a/docs-src/ref.scrbl
+++ b/docs-src/ref.scrbl
@@ -52,7 +52,8 @@ If no @exec{SOURCE} is provided, then @exec{index.rsh} is used.
 
 If no @exec{EXPORT} is provided, then all the exported @tech{Reach.App}s will be compiled. If there are no
 @tech{Reach.App}s exported, then the program will be compiled as a library, where its exports are available
-to other Reach programs and frontends.
+to other Reach programs and frontends. The output name of a library is the same as if it exported a @tech{Reach.App}
+named @tt{default}.
 
 @exec{reach compile} supports the following options:
 

--- a/examples/default-app/.dockerignore
+++ b/examples/default-app/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/examples/default-app/.gitignore
+++ b/examples/default-app/.gitignore
@@ -1,0 +1,2 @@
+build/
+node_modules/

--- a/examples/default-app/index.mjs
+++ b/examples/default-app/index.mjs
@@ -1,22 +1,13 @@
 import {loadStdlib} from '@reach-sh/stdlib';
 import * as backend from './build/index.default.mjs';
 
-const equals = (a, b) => {
-  if (a === b) return true;
-  if (a instanceof Date && b instanceof Date)
-    return a.getTime() === b.getTime();
-  if (!a || !b || (typeof a !== 'object' && typeof b !== 'object'))
-    return a === b;
-  if (a.prototype !== b.prototype) return false;
-  let keys = Object.keys(a);
-  if (keys.length !== Object.keys(b).length) return false;
-  return keys.every(k => equals(a[k], b[k]));
-};
+const assertEq = (l, r) =>
+  console.assert(JSON.stringify(l) === JSON.stringify(r));
 
 (async () => {
   const stdlib = await loadStdlib();
-  const exports = backend.getExports(stdlib);
+  const { winnerIs, ROCK, PAPER, SCISSORS, B_WINS, A_WINS } = backend.getExports(stdlib);
 
-  console.assert(equals(exports.winnerIs(exports.ROCK, exports.PAPER), exports.B_WINS));
-  console.assert(equals(exports.winnerIs(exports.SCISSORS, exports.PAPER), exports.A_WINS));
+  assertEq(winnerIs(ROCK, PAPER), B_WINS);
+  assertEq(winnerIs(SCISSORS, PAPER), A_WINS);
 })();

--- a/examples/default-app/index.mjs
+++ b/examples/default-app/index.mjs
@@ -1,0 +1,22 @@
+import {loadStdlib} from '@reach-sh/stdlib';
+import * as backend from './build/index.default.mjs';
+
+const equals = (a, b) => {
+  if (a === b) return true;
+  if (a instanceof Date && b instanceof Date)
+    return a.getTime() === b.getTime();
+  if (!a || !b || (typeof a !== 'object' && typeof b !== 'object'))
+    return a === b;
+  if (a.prototype !== b.prototype) return false;
+  let keys = Object.keys(a);
+  if (keys.length !== Object.keys(b).length) return false;
+  return keys.every(k => equals(a[k], b[k]));
+};
+
+(async () => {
+  const stdlib = await loadStdlib();
+  const exports = backend.getExports(stdlib);
+
+  console.assert(equals(exports.winnerIs(exports.ROCK, exports.PAPER), exports.B_WINS));
+  console.assert(equals(exports.winnerIs(exports.SCISSORS, exports.PAPER), exports.A_WINS));
+})();

--- a/examples/default-app/index.rsh
+++ b/examples/default-app/index.rsh
@@ -1,0 +1,18 @@
+'reach 0.1';
+
+export const [ isOutcome, B_WINS, DRAW, A_WINS ] = makeEnum(3);
+export const [ isHand, ROCK, PAPER, SCISSORS ] = makeEnum(3);
+
+export const winner = (handA, handB) =>
+      ((handA + (4 - handB)) % 3);
+
+forall(UInt, handA =>
+  forall(UInt, handB =>
+    assert(isOutcome(winner(handA, handB)))));
+
+
+const winnerType = Fun([UInt, UInt], UInt);
+const preCond = ([l, r]) => isHand(l) && isHand(r);
+const postCond = ([l, r], res) => isHand(res) && isOutcome(res);
+
+export const winnerIs = is(winner, Refine(winnerType, preCond, postCond));

--- a/examples/default-app/index.txt
+++ b/examples/default-app/index.txt
@@ -1,0 +1,5 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 6 theorems; No failures!

--- a/hs/src/Reach/Eval.hs
+++ b/hs/src/Reach/Eval.hs
@@ -171,8 +171,7 @@ compileDApp cns exports (SLV_Prim (SLPrim_App_Delay at opts avs top_formals top_
   return $ \dli_maps final ->
     let dli = DLInit {..}
      in DLProg at dlo' sps dli exports dviews final
-compileDApp _ _ _ =
-  expect_ Err_Top_NotApp
+compileDApp _ _ _ = impossible "compileDApp called without a Reach.App"
 
 getExports :: SLLibs -> App DLSExports
 getExports libs = do
@@ -185,9 +184,7 @@ getExports libs = do
 compileBundle_ :: Connectors -> JSBundle -> SLLibs -> SLVar -> App CompiledDApp
 compileBundle_ cns (JSBundle mods) libm main = do
   exports <- getExports libm
-  let exe = case mods of
-        [] -> impossible $ "compileBundle: no files"
-        ((x, _) : _) -> x
+  let exe = getLibExe mods
   let exe_ex = libm M.! exe
   topv <- ensure_public . sss_sls =<< env_lookup LC_CompilerRequired main exe_ex
   compileDApp cns exports topv

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -245,6 +245,18 @@ type SLLibs = (M.Map ReachSource SLEnv)
 
 type SLMod = (ReachSource, [JSModuleItem])
 
+defaultApp :: SLSSVal
+defaultApp =
+  SLSSVal srcloc_builtin Public $
+  SLV_Prim $
+    SLPrim_App_Delay srcloc_builtin mempty [] []
+      (JSStatementBlock JSNoAnnot [] JSNoAnnot JSSemiAuto) (mempty, False)
+
+getLibExe :: [(p, b)] -> p
+getLibExe = \case
+  [] -> impossible "getLibExe: no files"
+  ((x, _) : _) -> x
+
 --- Utilities
 expect_ :: (HasCallStack, Show e, ErrorMessageForJson e, ErrorSuggestions e) => e -> App a
 expect_ e = do

--- a/hs/src/Reach/Eval/Error.hs
+++ b/hs/src/Reach/Eval/Error.hs
@@ -91,7 +91,6 @@ data EvalError
   | Err_TailNotEmpty [JSStatement]
   | Err_ToConsensus_Double ToConsensusMode
   | Err_TopFun_NoName
-  | Err_Top_NotApp
   | Err_While_IllegalInvariant [JSExpression]
   | Err_Only_NotOneClosure SLValTy
   | Err_Each_NotTuple SLValTy
@@ -429,8 +428,6 @@ instance Show EvalError where
       _ -> "Invalid double toConsensus."
     Err_TopFun_NoName ->
       "Invalid function declaration. Top-level functions must be named."
-    Err_Top_NotApp ->
-      "Invalid compilation target. No `Reach.App`s are exported"
     Err_While_IllegalInvariant exprs ->
       "Invalid while loop invariant. Expected 1 expr, but got " <> got
       where

--- a/hs/src/Reach/Eval/Module.hs
+++ b/hs/src/Reach/Eval/Module.hs
@@ -19,9 +19,7 @@ import Reach.Version
 
 findTops :: JSBundle -> SLLibs -> [SLVar]
 findTops (JSBundle mods) libm = do
-  let exe = case mods of
-        [] -> impossible $ "findReachApps: no files"
-        ((x, _) : _) -> x
+  let exe = getLibExe mods
   let exe_ex = libm M.! exe
   mapMaybe (\ (k, v) ->
     case sss_val v of

--- a/hs/test-examples/features/lib_default_app.rsh
+++ b/hs/test-examples/features/lib_default_app.rsh
@@ -9,4 +9,3 @@ export const winner = (handA, handB) =>
 forall(UInt, handA =>
   forall(UInt, handB =>
     assert(isOutcome(winner(handA, handB)))));
-

--- a/hs/test-examples/features/lib_default_app.rsh
+++ b/hs/test-examples/features/lib_default_app.rsh
@@ -1,0 +1,16 @@
+'reach 0.1';
+
+// Used in:
+// * /hs/test-examples/Err_Fun_NamesIllegal.rsh
+export const blah = 0;
+
+// Test assertions for libaries
+export const [ isOutcome, B_WINS, DRAW, A_WINS ] = makeEnum(3);
+
+export const winner = (handA, handB) =>
+      ((handA + (4 - handB)) % 3);
+
+forall(UInt, handA =>
+  forall(UInt, handB =>
+    assert(isOutcome(winner(handA, handB)))));
+

--- a/hs/test-examples/features/lib_default_app.rsh
+++ b/hs/test-examples/features/lib_default_app.rsh
@@ -1,9 +1,5 @@
 'reach 0.1';
 
-// Used in:
-// * /hs/test-examples/Err_Fun_NamesIllegal.rsh
-export const blah = 0;
-
 // Test assertions for libaries
 export const [ isOutcome, B_WINS, DRAW, A_WINS ] = makeEnum(3);
 

--- a/hs/test-examples/features/lib_default_app.txt
+++ b/hs/test-examples/features/lib_default_app.txt
@@ -1,0 +1,5 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 4 theorems; No failures!

--- a/hs/test-examples/nl-eval-errors/Err_Top_NotApp.rsh
+++ b/hs/test-examples/nl-eval-errors/Err_Top_NotApp.rsh
@@ -1,3 +1,0 @@
-'reach 0.1';
-
-export const main = 3;

--- a/hs/test-examples/nl-eval-errors/Err_Top_NotApp.txt
+++ b/hs/test-examples/nl-eval-errors/Err_Top_NotApp.txt
@@ -1,1 +1,0 @@
-reachc: error: <top level>: Invalid compilation target. No `Reach.App`s are exported

--- a/hs/test-examples/nl-eval-errors/sample_lib.rsh
+++ b/hs/test-examples/nl-eval-errors/sample_lib.rsh
@@ -5,4 +5,5 @@
 
 export const blah = 0;
 
+// This example needs to fail
 assert(false);

--- a/hs/test-examples/nl-eval-errors/sample_lib.rsh
+++ b/hs/test-examples/nl-eval-errors/sample_lib.rsh
@@ -4,3 +4,5 @@
 // * /hs/test-examples/Err_Fun_NamesIllegal.rsh
 
 export const blah = 0;
+
+assert(false);

--- a/hs/test-examples/nl-eval-errors/sample_lib.txt
+++ b/hs/test-examples/nl-eval-errors/sample_lib.txt
@@ -4,7 +4,7 @@ Verifying for generic connector
 Verification failed:
   when ALL participants are honest
   of theorem: assert
-  at ./sample_lib.rsh:8:7:application
+  at ./sample_lib.rsh:9:7:application
 
   // Violation witness
 
@@ -15,7 +15,7 @@ Verification failed:
 Verification failed:
   when NO participants are honest
   of theorem: assert
-  at ./sample_lib.rsh:8:7:application
+  at ./sample_lib.rsh:9:7:application
 
   (details omitted on repeat)
 Checked 4 theorems; 2 failures. :'(

--- a/hs/test-examples/nl-eval-errors/sample_lib.txt
+++ b/hs/test-examples/nl-eval-errors/sample_lib.txt
@@ -1,1 +1,21 @@
-reachc: error: <top level>: Invalid compilation target. No `Reach.App`s are exported
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+Verification failed:
+  when ALL participants are honest
+  of theorem: assert
+  at ./sample_lib.rsh:8:7:application
+
+  // Violation witness
+
+  // Theorem formalization
+  assert(false);
+
+  Verifying when NO participants are honest
+Verification failed:
+  when NO participants are honest
+  of theorem: assert
+  at ./sample_lib.rsh:8:7:application
+
+  (details omitted on repeat)
+Checked 4 theorems; 2 failures. :'(

--- a/reach
+++ b/reach
@@ -555,7 +555,7 @@ clean:
 	rm -rf build/*.main.mjs
 
 build/%.main.mjs: %.rsh
-	\$(REACH) compile $^ main
+	\$(REACH) compile $^
 
 .PHONY: build
 build: build/${APP}.main.mjs


### PR DESCRIPTION
By default, if there are no exported `Reach.App`s, the compiler will add:

```javascript
export const default = Reach.App({}, [], () => {})
```

so the App can be verified and compiled for use as a library or `getExports`
