### PR TITLE
Fix link in tutorial 9

### DIFF
--- a/docs-src/tut.scrbl
+++ b/docs-src/tut.scrbl
@@ -1932,7 +1932,7 @@ through any Web UI framework of our choice.
 If we wanted to deploy this application to the world, then we would take the static files that React produces and host them on a Web server.
 These files embed your compiled Reach program, so there's nothing more to do than provide them to the world.
 
-In @seclink["tut-9"]{the next section}, we'll summarize where we've gone and direct you to the next step of your journey to decentralized application mastery.
+In @seclink["tut-10"]{the next section}, we'll summarize where we've gone and direct you to the next step of your journey to decentralized application mastery.
 
 @check:tf["True"]{Reach integrates with all Web interface libraries, like React, Vue, and so on, because Reach frontends are just normal JavaScript programs.}
 


### PR DESCRIPTION
The link "next section" in tut 9 pointed to tut 9 itself. Hotfix