### PR TITLE
Add Support for Lifting Interact Function Calls With `Null` Range

### DIFF
--- a/docs-src/ref-programs-step.scrbl
+++ b/docs-src/ref-programs-step.scrbl
@@ -40,6 +40,14 @@ is a @tech{valid} program where @reachin{Alice}'s @tech{local state} includes th
 
 is an @tech{invalid} program, because @reachin{Bob} does not know @reachin{x}.
 
+The shorthand @reachin{PART.interact.METHOD(EXPR_0, ..., EXPR_n)} is available for calling an @reachin{interact} function
+from outside of an @reachin{only} block. Such functions must return @reachin{Null}; therefore, they are only useful
+if they produce side-effects, such as logging on the @tech{frontend}. For example, the
+function @reachin{log} in the @tech{participant interact interface} of @reachin{Alice} may be called via:
+
+@reach{
+  Alice.interact.log(x); }
+
 @(hrule)
 
 @(mint-define! '("each"))

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -273,6 +273,7 @@ data SLForm
   | SLForm_each
   | SLForm_EachAns [(SLPart, Maybe SLVar)] SrcLoc SLCloEnv JSExpression
   | SLForm_Part_Only SLPart (Maybe SLVar)
+  | SLForm_liftInteract SLPart (Maybe SLVar) String
   | SLForm_Part_ToConsensus
       { slptc_at :: SrcLoc
       , slptc_whos :: S.Set SLPart

--- a/hs/test-examples/features/lifted_interact.rsh
+++ b/hs/test-examples/features/lifted_interact.rsh
@@ -1,0 +1,9 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [Participant('A', { log: Fun([UInt], Null) })],
+    (A) => {
+      A.interact.log(5);
+    });

--- a/hs/test-examples/features/lifted_interact.txt
+++ b/hs/test-examples/features/lifted_interact.txt
@@ -1,0 +1,6 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+  Verifying when ONLY "A" is honest
+Checked 3 theorems; No failures!

--- a/hs/test-examples/nl-eval-errors/lifted_interact_non_null_fun.rsh
+++ b/hs/test-examples/nl-eval-errors/lifted_interact_non_null_fun.rsh
@@ -1,0 +1,9 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [Participant('A', { f: Fun([], UInt) })],
+    (A) => {
+      A.interact.f();
+    });

--- a/hs/test-examples/nl-eval-errors/lifted_interact_non_null_fun.txt
+++ b/hs/test-examples/nl-eval-errors/lifted_interact_non_null_fun.txt
@@ -1,0 +1,1 @@
+reachc: error: ./lifted_interact_non_null_fun.rsh:8:19:application: Invalid block result type. Expected Null, got UInt

--- a/hs/test-examples/nl-eval-errors/lifted_interact_nonfun.rsh
+++ b/hs/test-examples/nl-eval-errors/lifted_interact_nonfun.rsh
@@ -1,0 +1,9 @@
+'reach 0.1';
+
+export const main =
+  Reach.App(
+    {},
+    [Participant('A', { x: UInt })],
+    (A) => {
+      require(A.interact.x == 5);
+    });

--- a/hs/test-examples/nl-eval-errors/lifted_interact_nonfun.txt
+++ b/hs/test-examples/nl-eval-errors/lifted_interact_nonfun.txt
@@ -1,0 +1,1 @@
+reachc: error: ./lifted_interact_nonfun.rsh:8:28:application: Value cannot exist at runtime: <form: SLForm_liftInteract>


### PR DESCRIPTION
Add a form to convert the following

```javascript
Alice.interact.f(1, 2, 3);
```

into

```javascript
Alice.only(() => {
  interact.f(1, 2, 3);
});
```


This shorthand only works if the `interact` field is a function with a `null` range. In `evalAsEnv`, I grab the `Participant`'s interact object and wrap the values in `SLForm_liftInteract`, which will handle executing the function calls inside an `only`
