### PR TITLE
Protect Against Solidity Keywords in Structs/Objects

### DIFF
--- a/docs-src/ref-programs-compute.scrbl
+++ b/docs-src/ref-programs-compute.scrbl
@@ -989,6 +989,8 @@ Structs may be converted into a corresponding @tech{tuple} or @tech{object} via 
   assert(Struct.toObject(p2).y == 2);
 }
 
+The names of elements may be restricted to avoid conflicting with reserved words of the specified @tech{connectors}.
+
 @subsection{Field reference}
 
 @reach{

--- a/hs/src/Reach/Connector/ETH_Solidity.hs
+++ b/hs/src/Reach/Connector/ETH_Solidity.hs
@@ -35,6 +35,7 @@ import System.Exit
 import System.FilePath
 import System.IO.Temp
 import System.Process
+import Data.Bifunctor (Bifunctor(first))
 
 --- Debugging tools
 
@@ -471,7 +472,7 @@ solLargeArg' dv la =
       where
         go i a = one (".elem" <> pretty i) <$> solArg a
     DLLA_Obj m ->
-      solLargeArg' dv $ DLLA_Struct $ M.toAscList m
+      solLargeArg' dv $ DLLA_Struct $ map (first ("_" <>)) $ M.toAscList m
     DLLA_Data _ vn vv -> do
       t <- solType $ largeArgTypeOf la
       vv' <- solArg vv
@@ -516,7 +517,7 @@ solExpr sp = \case
     return $ ae' <> ".elem" <> pretty i <> sp
   DLE_ObjectRef _ oe f -> do
     oe' <- solArg oe
-    return $ oe' <> "." <> pretty f <> sp
+    return $ oe' <> "._" <> pretty f <> sp
   DLE_Interact {} -> impossible "consensus interact"
   DLE_Digest _ args -> do
     args' <- mapM solArg args
@@ -1066,7 +1067,7 @@ solDefineType t = case t of
     let ats' = (flip zip) ats $ map (("elem" ++) . show) ([0 ..] :: [Int])
     addMap =<< doStruct ats'
   T_Object tm -> do
-    addMap =<< (doStruct $ M.toAscList tm)
+    addMap =<< (doStruct $ map (first ("_" <>)) $ M.toAscList tm)
   T_Data tm -> do
     tmn <- mapM solType tm
     --- XXX Try to use bytes and abi.decode; Why not right away? The

--- a/hs/src/Reach/Connector/ETH_Solidity.hs
+++ b/hs/src/Reach/Connector/ETH_Solidity.hs
@@ -36,6 +36,7 @@ import System.FilePath
 import System.IO.Temp
 import System.Process
 import Data.Bifunctor (Bifunctor(first))
+import Data.String (IsString)
 
 --- Debugging tools
 
@@ -195,6 +196,9 @@ vsToType :: [DLVar] -> DLType
 vsToType vs = T_Struct $ map go_ty vs
   where
     go_ty v = (show (solRawVar v), varType v)
+
+objPrefix :: (Semigroup a, IsString a) => a -> a
+objPrefix = ("_" <>)
 
 --- Compiler
 
@@ -472,7 +476,7 @@ solLargeArg' dv la =
       where
         go i a = one (".elem" <> pretty i) <$> solArg a
     DLLA_Obj m ->
-      solLargeArg' dv $ DLLA_Struct $ map (first ("_" <>)) $ M.toAscList m
+      solLargeArg' dv $ DLLA_Struct $ map (first objPrefix) $ M.toAscList m
     DLLA_Data _ vn vv -> do
       t <- solType $ largeArgTypeOf la
       vv' <- solArg vv
@@ -517,7 +521,7 @@ solExpr sp = \case
     return $ ae' <> ".elem" <> pretty i <> sp
   DLE_ObjectRef _ oe f -> do
     oe' <- solArg oe
-    return $ oe' <> "._" <> pretty f <> sp
+    return $ oe' <> "." <> objPrefix (pretty f) <> sp
   DLE_Interact {} -> impossible "consensus interact"
   DLE_Digest _ args -> do
     args' <- mapM solArg args
@@ -1067,7 +1071,7 @@ solDefineType t = case t of
     let ats' = (flip zip) ats $ map (("elem" ++) . show) ([0 ..] :: [Int])
     addMap =<< doStruct ats'
   T_Object tm -> do
-    addMap =<< (doStruct $ map (first ("_" <>)) $ M.toAscList tm)
+    addMap =<< (doStruct $ map (first objPrefix) $ M.toAscList tm)
   T_Data tm -> do
     tmn <- mapM solType tm
     --- XXX Try to use bytes and abi.decode; Why not right away? The

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -2194,6 +2194,7 @@ evalPrim p sargs =
         verifyStructId r s = do
           at <- withAt id
           connectors <- readDlo dlo_connectors
+          -- XXX extend `Connector` to convey this info we're checking
           when ("ETH" `elem` connectors && s `elem` map show solReservedNames) $
             expect_thrown at $ Err_Sol_Reserved s
           bool (expect_ $ Err_Struct_Key_Invalid s) (return s) $ matched $ s ?=~ r

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -2191,7 +2191,11 @@ evalPrim p sargs =
       kts <- mapM go as
       retV $ (lvl, SLV_Type $ ST_Struct kts)
       where
-        verifyStructId r s =
+        verifyStructId r s = do
+          at <- withAt id
+          connectors <- readDlo dlo_connectors
+          when ("ETH" `elem` connectors && s `elem` map show solReservedNames) $
+            expect_thrown at $ Err_Sol_Reserved s
           bool (expect_ $ Err_Struct_Key_Invalid s) (return s) $ matched $ s ?=~ r
     SLPrim_Struct_fromTuple ts -> do
       tv <- one_arg

--- a/hs/src/Reach/Eval/Error.hs
+++ b/hs/src/Reach/Eval/Error.hs
@@ -140,6 +140,7 @@ data EvalError
   | Err_View_CannotExpose SLValTy
   | Err_View_UDFun
   | Err_Part_DuplicatePart SLPart
+  | Err_Sol_Reserved String
   deriving (Eq, Generic)
 
 --- FIXME I think most of these things should be in Pretty
@@ -534,5 +535,7 @@ instance Show EvalError where
       "Value cannot be exposed to view: " <> show_sv sv
     Err_View_UDFun ->
       "View functions cannot have unconstrained domains."
+    Err_Sol_Reserved field ->
+      "`" <> field <> "` is not a valid field name because it is reserved in Solidity."
     where
       displayPrim = drop (length ("SLPrim_" :: String)) . conNameOf

--- a/hs/src/Reach/Eval/Types.hs
+++ b/hs/src/Reach/Eval/Types.hs
@@ -102,7 +102,7 @@ data TransferType
 instance Show TransferType where
   show k = drop 3 $ conNameOf k
 
-data SolReservedNames
+data SolReservedName
   = SOL_address
   | SOL_after
   | SOL_alias
@@ -151,8 +151,8 @@ data SolReservedNames
   | SOL_virtual
   deriving (Bounded, Enum, Eq, Generic)
 
-instance Show SolReservedNames where
+instance Show SolReservedName where
   show k = drop 4 $ conNameOf k
 
-solReservedNames :: [SolReservedNames]
+solReservedNames :: [SolReservedName]
 solReservedNames = enumFrom minBound

--- a/hs/src/Reach/Eval/Types.hs
+++ b/hs/src/Reach/Eval/Types.hs
@@ -101,3 +101,58 @@ data TransferType
 
 instance Show TransferType where
   show k = drop 3 $ conNameOf k
+
+data SolReservedNames
+  = SOL_address
+  | SOL_after
+  | SOL_alias
+  | SOL_anonymous
+  | SOL_apply
+  | SOL_auto
+  | SOL_case
+  | SOL_constant
+  | SOL_copyof
+  | SOL_default
+  | SOL_define
+  | SOL_external
+  | SOL_final
+  | SOL_immutable
+  | SOL_implements
+  | SOL_in
+  | SOL_indexed
+  | SOL_inline
+  | SOL_internal
+  | SOL_let
+  | SOL_macro
+  | SOL_match
+  | SOL_mutable
+  | SOL_null
+  | SOL_of
+  | SOL_override
+  | SOL_partial
+  | SOL_payable
+  | SOL_private
+  | SOL_promise
+  | SOL_public
+  | SOL_pure
+  | SOL_reference
+  | SOL_relocatable
+  | SOL_sealed
+  | SOL_sizeof
+  | SOL_static
+  | SOL_super
+  | SOL_supports
+  | SOL_switch
+  | SOL_this
+  | SOL_typedef
+  | SOL_typeof
+  | SOL_unchecked
+  | SOL_view
+  | SOL_virtual
+  deriving (Bounded, Enum, Eq, Generic)
+
+instance Show SolReservedNames where
+  show k = drop 4 $ conNameOf k
+
+solReservedNames :: [SolReservedNames]
+solReservedNames = enumFrom minBound

--- a/hs/test-examples/features/sol_identifier_obj_key.rsh
+++ b/hs/test-examples/features/sol_identifier_obj_key.rsh
@@ -1,0 +1,21 @@
+'reach 0.1';
+
+const TypeWithSolKwd = Object({
+  address: Address
+});
+
+export const main = Reach.App(() => {
+  const A = Participant('A', {
+    get: Fun([], TypeWithSolKwd),
+    show: Fun([Address], Null) });
+  deploy();
+  A.only(() => {
+    const o = declassify(interact.get());
+    assume(o.address == A);
+  });
+  A.publish(o);
+  const a = o.address;
+  require(a == A);
+  commit();
+  A.interact.show(o.address);
+});

--- a/hs/test-examples/features/sol_identifier_obj_key.txt
+++ b/hs/test-examples/features/sol_identifier_obj_key.txt
@@ -1,0 +1,6 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+  Verifying when ONLY "A" is honest
+Checked 5 theorems; No failures!

--- a/hs/test-examples/nl-eval-errors/Err_Sol_Reserved.rsh
+++ b/hs/test-examples/nl-eval-errors/Err_Sol_Reserved.rsh
@@ -1,0 +1,19 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const A = Participant('A', {
+    get: Fun([], Struct([
+      ['super', Address]
+    ])),
+    show: Fun([Address], Null) });
+  deploy();
+  A.only(() => {
+    const o = declassify(interact.get());
+    assume(o.super == A);
+  });
+  A.publish(o);
+  const a = o.super;
+  require(a == A);
+  commit();
+  A.interact.show(o.super);
+});

--- a/hs/test-examples/nl-eval-errors/Err_Sol_Reserved.txt
+++ b/hs/test-examples/nl-eval-errors/Err_Sol_Reserved.txt
@@ -1,0 +1,1 @@
+reachc: error: ./Err_Sol_Reserved.rsh:5:24:application: `super` is not a valid field name because it is reserved in Solidity.

--- a/js/stdlib/ts/ETH_like_compiled.ts
+++ b/js/stdlib/ts/ETH_like_compiled.ts
@@ -227,6 +227,7 @@ const T_Object = <T>(
     }
     return obj;
   })(),
+  // CBR -> Net . ETH object fields are prefaced with "_"
   munge: (bv: CBR_Object): any => {
     const obj: {
       [key: string]: any
@@ -234,7 +235,7 @@ const T_Object = <T>(
     let none: boolean = true;
     for (const prop in co) {
       none = false;
-      obj[prop] = co[prop].munge(bv[prop]);
+      obj["_" + prop] = co[prop].munge(bv[prop]);
     }
     if ( none ) {
       return false;
@@ -247,7 +248,7 @@ const T_Object = <T>(
       [key: string]: CBR_Val
     } = {};
     for (const prop in co) {
-      obj[prop] = co[prop].unmunge(bv[prop]);
+      obj[prop] = co[prop].unmunge(bv["_" + prop]);
     }
     return V_Object(co)(obj);
   },


### PR DESCRIPTION
* Check `Struct` names against a list of reserved words
* Have `Object`s preface field names with `_` . `munge/unmunge` adds/removes the `_` appropriately