### PR TITLE
Lifted Interact: Make `this` = Originator of Consensus Transfer

### DIFF
--- a/examples/interact-this/.dockerignore
+++ b/examples/interact-this/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/examples/interact-this/.gitignore
+++ b/examples/interact-this/.gitignore
@@ -1,0 +1,2 @@
+build/
+node_modules/

--- a/examples/interact-this/index.mjs
+++ b/examples/interact-this/index.mjs
@@ -1,0 +1,31 @@
+import {loadStdlib} from '@reach-sh/stdlib';
+import * as backend from './build/index.main.mjs';
+import assert from 'assert';
+
+(async () => {
+  const stdlib = await loadStdlib();
+  const startingBalance = stdlib.parseCurrency(100);
+
+  const alice = await stdlib.newTestAccount(startingBalance);
+  const bob = await stdlib.newTestAccount(startingBalance);
+
+  const ctcAlice = alice.deploy(backend);
+  const ctcBob = bob.attach(backend, ctcAlice.getInfo());
+
+  const addrs = {
+    'Alice': alice.getAddress(),
+    'Bob': bob.getAddress(),
+  };
+  console.log(`Alice address: ${addrs['Alice']}`);
+  console.log(`Bob address: ${addrs['Bob']}`);
+
+  await Promise.all([
+    backend.Alice(ctcAlice, {}),
+    backend.Bob(ctcBob, {
+      show: (a) => {
+        console.log(`Bob sees Alice's address`, a);
+        assert(a == addrs['Alice'], "Did not receive Alice's address");
+      },
+    }),
+  ]);
+})();

--- a/examples/interact-this/index.rsh
+++ b/examples/interact-this/index.rsh
@@ -1,0 +1,20 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const Alice = Participant('Alice', {});
+  const Bob   = Participant('Bob', { show: Fun(true, Null) });
+  deploy();
+
+  Alice.publish();
+  commit();
+
+  Bob.only(() => assume(this != Alice));
+  Bob.publish();
+  require(Bob != Alice);
+  commit();
+
+  Alice.publish();
+  Bob.interact.show(this);
+
+  commit();
+});

--- a/examples/interact-this/index.txt
+++ b/examples/interact-this/index.txt
@@ -1,0 +1,7 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+  Verifying when ONLY "Alice" is honest
+  Verifying when ONLY "Bob" is honest
+Checked 9 theorems; No failures!

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -42,7 +42,7 @@ import Safe (atMay)
 import Text.ParserCombinators.Parsec.Number (numberValue)
 import Text.RE.TDFA (RE, compileRegex, matched, (?=~))
 import Reach.Texty (pretty)
-import Data.Sequence (mapWithIndex)
+import Data.Sequence (mapWithIndex, fromList)
 import Data.List (intercalate)
 import qualified Data.Text as T
 
@@ -1357,15 +1357,22 @@ evalForm f args = do
       x <- one_arg
       env <- ask >>= sco_to_cloenv . e_sco
       return $ public $ SLV_Form $ SLForm_EachAns [(who, mv)] at env x
-    SLForm_liftInteract who mv field -> do
-      at <- withAt id
-      clo_env <- ask >>= sco_to_cloenv . e_sco
-      let params = JSParenthesizedArrowParameterList JSNoAnnot JSLNil JSNoAnnot
-      let dot  = JSMemberDot (JSIdentifier JSNoAnnot "interact") JSNoAnnot (JSIdentifier JSNoAnnot field)
-      let call = JSCallExpression dot JSNoAnnot (toJSCL args) JSNoAnnot
+    SLForm_liftInteract _ msv field -> do
+      let who = fromMaybe (impossible "lifted interact: participant unbound") msv
+      annot <- at2a <$> withAt id
+      -- Enclose the generated `only` with a closure that binds all the arguments to the interact call,
+      -- which allows `this` to point to the originator of the consensus transfer instead of `who`.
+      let param_ids = toList $ mapWithIndex (\ i _ -> JSIdentifier annot $ "liftedInteractArg" <> show i) $ fromList args
+      let no_params = JSParenthesizedArrowParameterList annot JSLNil annot
+      let dot  = JSMemberDot (JSIdentifier annot "interact") annot (JSIdentifier annot field)
+      let call = JSCallExpression dot annot (toJSCL param_ids) annot
       let stmt = JSExpressionStatement call JSSemiAuto
-      let only_thunk = JSArrowExpression params JSNoAnnot stmt
-      return $ public $ SLV_Form $ SLForm_EachAns [(who, mv)] at clo_env only_thunk
+      let only_thunk = JSArrowExpression no_params annot stmt
+      let only_mem  = JSMemberDot (JSIdentifier annot who) annot (JSIdentifier annot "only")
+      let only_stmt = JSExpressionStatement (JSCallExpression only_mem annot (toJSCL [only_thunk]) annot) JSSemiAuto
+      let params = JSParenthesizedArrowParameterList annot (toJSCL param_ids) annot
+      let fun = JSArrowExpression params annot only_stmt
+      evalExpr $ JSCallExpression fun annot (toJSCL args) annot
     SLForm_fork -> do
       zero_args
       at <- withAt id

--- a/hs/test-examples/nl-eval-errors/lifted_interact_non_null_fun.txt
+++ b/hs/test-examples/nl-eval-errors/lifted_interact_non_null_fun.txt
@@ -1,1 +1,3 @@
 reachc: error: ./lifted_interact_non_null_fun.rsh:8:19:application: Invalid block result type. Expected Null, got UInt
+Trace:
+  in [unknown function] from (./lifted_interact_non_null_fun.rsh:8:19:function exp) at (./lifted_interact_non_null_fun.rsh:8:19:application)


### PR DESCRIPTION
```javascript
A.publish();
B.interact.show(this);
```
should pass `show` `A`'s address, not `B`'s.

To handle this, I just wrapped the generated `only` in a closure that is immediately applied:

```javascript
A.publish();
((a1) =>
  B.only(() => interact.show(a1)); )(this);

```