### PR TITLE
examples: faucet-balance

### DIFF
--- a/examples/faucet-balance/.dockerignore
+++ b/examples/faucet-balance/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/examples/faucet-balance/.gitignore
+++ b/examples/faucet-balance/.gitignore
@@ -1,0 +1,2 @@
+build/
+node_modules/

--- a/examples/faucet-balance/index.mjs
+++ b/examples/faucet-balance/index.mjs
@@ -1,0 +1,15 @@
+import {loadStdlib} from '@reach-sh/stdlib';
+import * as backend from './build/index.main.mjs';
+const stdlib = loadStdlib(process.env);
+
+(async () => {
+  const faucet = await stdlib.getFaucet();
+  const balBn = await stdlib.balanceOf(faucet);
+
+  stdlib.assert(stdlib.gt(balBn, 0), `Faucet has funds`);
+
+  const addr = stdlib.formatAddress(faucet);
+  const bal = stdlib.formatCurrency(balBn);
+
+  console.log(`${addr} has ${bal} ${stdlib.standardUnit}`);
+})();

--- a/examples/faucet-balance/index.mjs
+++ b/examples/faucet-balance/index.mjs
@@ -6,10 +6,9 @@ const stdlib = loadStdlib(process.env);
   const faucet = await stdlib.getFaucet();
   const balBn = await stdlib.balanceOf(faucet);
 
-  stdlib.assert(stdlib.gt(balBn, 0), `Faucet has funds`);
-
   const addr = stdlib.formatAddress(faucet);
   const bal = stdlib.formatCurrency(balBn);
-
   console.log(`${addr} has ${bal} ${stdlib.standardUnit}`);
+
+  stdlib.assert(stdlib.gt(balBn, 0), `Faucet has funds`);
 })();

--- a/examples/faucet-balance/index.rsh
+++ b/examples/faucet-balance/index.rsh
@@ -1,0 +1,6 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  deploy();
+  // .rsh unused in this example.
+});

--- a/js/stdlib/ts/CFX_impl.ts
+++ b/js/stdlib/ts/CFX_impl.ts
@@ -105,7 +105,11 @@ const mining_key = '0xc72b8b13c6256b54ce428f6f67725d47194bc4ef97552867d037acd4fe
 const defaultFaucetWallet = new cfxers.Wallet(mining_key);
 
 export const _getDefaultFaucetNetworkAccount = memoizeThunk(async (): Promise<NetworkAccount> => {
-  if (!defaultFaucetWallet.provider) defaultFaucetWallet.connect(await getProvider());
+  if (!defaultFaucetWallet.provider) {
+    const provider = await getProvider();
+    // Async things can cause this state to change...
+    if (!defaultFaucetWallet.provider) defaultFaucetWallet.connect(provider);
+  }
   return defaultFaucetWallet;
 });
 


### PR DESCRIPTION
ALGO `formatCurrency` has been broken since forever, and we sort of ignored it because nobody except the faucet actually has that much ALGO. Well it's fixed now; so you can actually do a pretty display of how much ALGO the faucet has. (It's 10 billion ALGO, in case you were wondering).