### PR TITLE
Small Reach.Texty refactor

### DIFF
--- a/hs/src/Reach/AST/DLBase.hs
+++ b/hs/src/Reach/AST/DLBase.hs
@@ -295,7 +295,7 @@ render_dasM as = do
 render_objM :: Pretty k => PrettySubst v => M.Map k v -> PrettySubstApp Doc
 render_objM env = do
   ps <- mapM render_p $ M.toAscList env
-  return $ braces $ nest 2 $ hardline <> (concatWith (surround (comma <> hardline)) ps)
+  return $ braces $ nest $ hardline <> (concatWith (surround (comma <> hardline)) ps)
   where
     render_p (k, oa) = do
       o' <- prettySubst oa

--- a/hs/src/Reach/Backend/JS.hs
+++ b/hs/src/Reach/Backend/JS.hs
@@ -78,7 +78,7 @@ jsIf :: Doc -> Doc -> Doc -> Doc
 jsIf cap ttp ftp = jsWhen cap ttp <> hardline <> "else" <+> jsBraces ftp
 
 jsBraces :: Doc -> Doc
-jsBraces body = braces (nest 2 $ hardline <> body)
+jsBraces body = braces (nest $ hardline <> body)
 
 jsObject :: Pretty k => M.Map k Doc -> Doc
 jsObject m = jsBraces $ vsep $ punctuate comma $ map jsObjField $ M.toList m

--- a/hs/src/Reach/Connector/ETH_Solidity.hs
+++ b/hs/src/Reach/Connector/ETH_Solidity.hs
@@ -65,7 +65,7 @@ solNum :: Show n => n -> Doc
 solNum i = pretty $ "uint256(" ++ show i ++ ")"
 
 solBraces :: Doc -> Doc
-solBraces body = braces (nest 2 $ hardline <> body)
+solBraces body = braces (nest $ hardline <> body)
 
 data SolFunctionLike
   = SFL_Constructor

--- a/hs/src/Reach/Pretty.hs
+++ b/hs/src/Reach/Pretty.hs
@@ -6,19 +6,19 @@ import qualified Data.Map.Strict as M
 import Reach.Texty
 
 pform :: Doc -> Doc -> Doc
-pform f xs = group $ parens $ f <+> xs
+pform f xs = parens $ f <+> xs
 
 pform_ :: Doc -> Doc
 pform_ f = pform f mempty
 
 pbrackets :: [Doc] -> Doc
-pbrackets xs = group $ render_nest $ vsep $ punctuate comma xs
+pbrackets xs = render_nest $ vsep $ punctuate comma xs
 
 render_das :: Pretty a => [a] -> Doc
 render_das as = hsep $ punctuate comma $ map pretty as
 
 render_nest :: Doc -> Doc
-render_nest inner = nest 2 $ braces (hardline <> inner <> " ")
+render_nest inner = nest $ braces (hardline <> inner <> " ")
 
 prettyIf :: Pretty c => c -> Doc -> Doc -> Doc
 prettyIf ca t f =
@@ -56,16 +56,16 @@ prettyStop = "exit" <> parens (emptyDoc) <> semi
 prettyMap :: Pretty a => Pretty b => Pretty c => a -> b -> a -> c -> Doc
 prettyMap ans x a f =
   "map" <+> pretty ans <+> "=" <+> "for" <+> parens (pretty a <+> "in" <+> pretty x)
-    <+> braces (nest 2 $ hardline <> pretty f)
+    <+> braces (nest $ hardline <> pretty f)
 
 prettyReduce :: (Pretty a, Pretty b, Pretty c, Pretty d, Pretty e, Pretty f) => a -> b -> c -> d -> e -> f -> Doc
 prettyReduce ans x z b a f =
   "reduce" <+> pretty ans <+> "=" <+> "for" <+> parens (pretty b <+> "=" <+> pretty z <> semi <+> pretty a <+> "in" <+> pretty x)
-    <+> braces (nest 2 $ hardline <> pretty f)
+    <+> braces (nest $ hardline <> pretty f)
 
 prettyToConsensus__ :: (Pretty a, Pretty b, Pretty s, Pretty d, Pretty k2) => M.Map s a -> b -> Maybe (d, k2) -> Doc
 prettyToConsensus__ send recv mtime =
-  "publish" <> parens emptyDoc <> nest 2 (hardline <> mtime' <> send' <> recv')
+  "publish" <> parens emptyDoc <> nest (hardline <> mtime' <> send' <> recv')
   where
     mtime' = prettyTimeout mtime
     send' = prettySends send <> hardline
@@ -91,7 +91,6 @@ prettyToConsensus :: Pretty c => Pretty d => Pretty s => (a -> Doc) -> (b -> Doc
 prettyToConsensus fa fb send (ltv, win, msg, amtv, tv, body) mtime =
   "publish" <> parens emptyDoc
     <> nest
-      2
       (hardline <> mtime'
          <> concatWith (surround hardline) (map go $ M.toList send)
          <> hardline

--- a/hs/src/Reach/Texty.hs
+++ b/hs/src/Reach/Texty.hs
@@ -5,13 +5,12 @@ module Reach.Texty
   , pretty
   , prettyl
   , (<+>)
-  , group --- XXX remove
   , emptyDoc
   , viaShow
   , vsep
   , hcat
   , hsep
-  , nest --- XXX remove int arg
+  , nest
   , concatWith --- XXX remove
   , punctuate
   , enclose
@@ -21,7 +20,7 @@ module Reach.Texty
   , parens
   , braces
   , brackets
-  , hardline --- XXX remove
+  , hardline
   , semi
   , comma
   , space
@@ -44,7 +43,7 @@ data Doc
   | DCat Doc Doc
   | DVSep [Doc]
   | DHSep [Doc]
-  | DNest Integer Doc
+  | DNest Doc
   deriving (Eq)
 
 instance Show Doc where
@@ -63,7 +62,7 @@ render_ = \case
     x_ <- render_ x
     xs_ <- render_ (DHSep xs)
     return $ x_ <> " " <> xs_
-  DNest dn d -> local (dn +) $ render_ d
+  DNest d -> local (2 +) $ render_ d
   DNewline -> do
     n <- ask
     return $ "\n" <> (LT.replicate (fromIntegral n) " ")
@@ -79,7 +78,7 @@ render = runIdentity . flip runReaderT 0 . render_
 
 render_obj :: Pretty k => Pretty v => M.Map k v -> Doc
 render_obj env =
-  braces $ nest 2 $ hardline <> (concatWith (surround (comma <> hardline)) $ map render_p $ M.toAscList env)
+  braces $ nest $ hardline <> (concatWith (surround (comma <> hardline)) $ map render_p $ M.toAscList env)
   where
     render_p (k, oa) = pretty k <+> "=" <+> pretty oa
 
@@ -151,9 +150,6 @@ infixr 6 <+>
 (<+>) :: Doc -> Doc -> Doc
 x <+> y = x <> " " <> y
 
-group :: Doc -> Doc
-group = id
-
 emptyDoc :: Doc
 emptyDoc = mempty
 
@@ -166,7 +162,7 @@ hsep = DHSep
 hcat :: [Doc] -> Doc
 hcat = concatWith (<>)
 
-nest :: Integer -> Doc -> Doc
+nest :: Doc -> Doc
 nest = DNest
 
 concatWith :: Foldable f => (Doc -> Doc -> Doc) -> f Doc -> Doc


### PR DESCRIPTION
I was testing the build tools setup for the haskell code and saw some comments about removing these from the module. The synopsis is
- remove `group`, 
- remove the int arg from `nest` (default 2)