### PR TITLE
Fix `match` Case Check

### DIFF
--- a/docs-src/ref-error-codes.scrbl
+++ b/docs-src/ref-error-codes.scrbl
@@ -2043,6 +2043,29 @@ It should be corrected by moving the tail of the @reachin{if} into the @reachin{
     };
 }
 
+@error{RE0118}
+
+This error indicates that a switch case is unreachable. This issue will occur when a @reachin{case} is listed
+after @reachin{default}.
+
+For example, the code below erroneously puts a @reachin{case} after @reachin{default}:
+
+@reach{
+  Maybe(UInt).Some(5).match({
+    default: (() => 0),
+    Some: ((i) => i),
+  });
+}
+
+This error can be corrected by either removing the @reachin{Some} case or placing it before the @reachin{default} case:
+
+@reach{
+  Maybe(UInt).Some(5).match({
+    Some: ((i) => i),
+    default: (() => 0),
+  });
+}
+
 @error{REP0000}
 
 This error indicates that the body of a @reachin{while} loop does not make a publication before the @reachin{continue}

--- a/hs/src/Reach/Eval/Error.hs
+++ b/hs/src/Reach/Eval/Error.hs
@@ -146,6 +146,7 @@ data EvalError
   | Err_TimeArg_NotStatic
   | Err_Return_MustBeTail
   | Err_Return_BothSidesMust
+  | Err_Switch_UnreachableCase SrcLoc SLVar SrcLoc
   deriving (Eq, Generic)
 
 instance HasErrorCode EvalError where
@@ -273,6 +274,7 @@ instance HasErrorCode EvalError where
     Err_TimeArg_NotStatic {} -> 115
     Err_Return_MustBeTail -> 116
     Err_Return_BothSidesMust -> 117
+    Err_Switch_UnreachableCase {} -> 118
 
 --- FIXME I think most of these things should be in Pretty
 
@@ -692,5 +694,7 @@ instance Show EvalError where
       "`return`s must be in tail position"
     Err_Return_BothSidesMust ->
       "If one side of a branch `return`s, the other side must as well"
+    Err_Switch_UnreachableCase cat cs dat ->
+      "The switch case `" <> cs <> "` defined at " <> show cat <> " is unreachable because `default` was used at " <> show dat
     where
       displayPrim = drop (length ("SLPrim_" :: String)) . conNameOf

--- a/hs/t/n/Err_Switch_UnreachableCase.rsh
+++ b/hs/t/n/Err_Switch_UnreachableCase.rsh
@@ -1,0 +1,14 @@
+'reach 0.1';
+
+const Command = Data({
+  Deposit: UInt
+})
+
+export const main = Reach.App(() => {
+  deploy();
+  const x = Command.Deposit(1);
+  const y = x.match({
+    default: (() => 0),
+    Deposit: ((a) => a),
+  });
+})

--- a/hs/t/n/Err_Switch_UnreachableCase.txt
+++ b/hs/t/n/Err_Switch_UnreachableCase.txt
@@ -1,0 +1,11 @@
+reachc: error[RE0118]: The switch case `Deposit` defined at ./Err_Switch_UnreachableCase.rsh:12:12:case is unreachable because `default` was used at ./Err_Switch_UnreachableCase.rsh:11:12:case
+
+ ./Err_Switch_UnreachableCase.rsh:12:12:case
+
+ 12|     Deposit: ((a) => a),
+
+Trace:
+  in [unknown function] from (./Err_Switch_UnreachableCase.rsh:10:20:function exp) at (./Err_Switch_UnreachableCase.rsh:10:20:application)
+
+For further explanation of this error, see: https://docs.reach.sh/RE0118.html
+

--- a/hs/t/y/pr-246.rsh
+++ b/hs/t/y/pr-246.rsh
@@ -1,0 +1,15 @@
+'reach 0.1';
+
+const Command = Data({
+  Deposit: UInt
+})
+
+export const main = Reach.App(() => {
+  deploy();
+  const x = Command.Deposit(1);
+  // Test that `default` does not come first in macro expansion (maintains correct order)
+  const y = x.match({
+    Deposit: ((a) => a),
+    default: (() => 0),
+  });
+})

--- a/hs/t/y/pr-246.txt
+++ b/hs/t/y/pr-246.txt
@@ -1,0 +1,5 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 2 theorems; No failures!


### PR DESCRIPTION
Fixes #246 

* When checking the `match` cases, order the `case` names according to `SrcLoc` as opposed to ascending order. This way `default` behaves as expected.
* Give better error messages when a `case` occurs after `default`.