### PR TITLE
continue consensus mode

### DIFF
--- a/docs-src/ref-programs-consensus.scrbl
+++ b/docs-src/ref-programs-consensus.scrbl
@@ -115,7 +115,7 @@ A @tech{continue statement} may be written without the preceding identifier upda
  [] = [];
  continue; }
 
-A @tech{continue statement} must be @tech{dominated} by a @tech{consensus transfer}, which means that the body of a @tech{while statement} must always @reachin{commit();} before calling @reachin{continue;}.
+A @tech{continue statement} must be @tech{dominated} by a @tech{consensus transfer}, which means that the body of a @tech{while statement} must always @reachin{commit();} before calling @reachin{continue;}. A continue statement may occur in a step, provided the @reachin{RHS} modifies the state into a consensus step.
 This restriction may be lifted in future versions of Reach, which will perform termination checking.
 
 @subsection{@tt{parallelReduce}}
@@ -438,4 +438,3 @@ set, @reachin{s}, or @reachin{s.remove(ADDRESS)} to remove the @reachin{ADDRESS}
 Such modifications may only occur in a @tech{consensus step}.
 
 @reachin{s.member(ADDRESS)} will return a @reachin{Bool} representing whether the address is in the set.
-

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -4676,15 +4676,15 @@ evalStmt = \case
     case (op, ks) of
       ((JSAssign var_a), ((JSContinue cont_a _bl cont_sp) : cont_ks)) -> do
         let lab = "continue"
-        ensure_mode SLM_ConsensusStep lab
         let var_at = srcloc_jsa lab var_a
         rhs_sv <- locAtf var_at $ evalExpr rhs
+        ensure_mode SLM_ConsensusStep lab
         sco <- e_sco <$> ask
         locAtf var_at $ do
           whilem <-
             case sco_while_vars sco of
               Nothing -> locAtf (srcloc_jsa lab cont_a) $ expect_ $ Err_Eval_ContinueNotInWhile
-              Just x -> return $ x
+              Just x -> return x
           doWhileLikeContinueEval lhs whilem rhs_sv
         -- NOTE We could/should look at sco_must_ret and see if it is
         -- RS_MayBeEmpty which means that the outside scope has an empty

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -4684,7 +4684,7 @@ evalStmt = \case
           whilem <-
             case sco_while_vars sco of
               Nothing -> locAtf (srcloc_jsa lab cont_a) $ expect_ $ Err_Eval_ContinueNotInWhile
-              Just x -> return x
+              Just x -> return $ x
           doWhileLikeContinueEval lhs whilem rhs_sv
         -- NOTE We could/should look at sco_must_ret and see if it is
         -- RS_MayBeEmpty which means that the outside scope has an empty

--- a/hs/t/y/continue-mode.rsh
+++ b/hs/t/y/continue-mode.rsh
@@ -1,0 +1,23 @@
+'reach 0.1';
+
+const f = ((p) => {
+  p.only(() => {
+    const choice = declassify(interact.choice)
+  });
+  p.publish(choice);
+});
+
+export const main = Reach.App(() => {
+  const Alice = Participant('Alice', {
+    choice: UInt,
+  });
+  deploy();
+  f(Alice);
+  var keepGoing = true;
+  invariant(keepGoing);
+  while (keepGoing) {
+    commit();
+    f(Alice)
+    continue;
+  };
+});

--- a/hs/t/y/continue-mode.rsh
+++ b/hs/t/y/continue-mode.rsh
@@ -3,7 +3,6 @@
 
 export const main = Reach.App(() => {
   const Alice = Participant('Alice', {
-    choice: UInt,
   });
   deploy();
 
@@ -14,7 +13,7 @@ export const main = Reach.App(() => {
 
   Alice.publish();
   var keepGoing = true;
-  invariant(keepGoing);
+  invariant(balance() == 0);
   while (keepGoing) {
     commit();
     keepGoing = f();

--- a/hs/t/y/continue-mode.rsh
+++ b/hs/t/y/continue-mode.rsh
@@ -20,4 +20,5 @@ export const main = Reach.App(() => {
     f(Alice)
     continue;
   };
+  commit();
 });

--- a/hs/t/y/continue-mode.rsh
+++ b/hs/t/y/continue-mode.rsh
@@ -1,23 +1,23 @@
 'reach 0.1';
 
-const f = ((p) => {
-  p.only(() => {
-    const choice = declassify(interact.choice)
-  });
-  p.publish(choice);
-});
 
 export const main = Reach.App(() => {
   const Alice = Participant('Alice', {
     choice: UInt,
   });
   deploy();
-  f(Alice);
+
+  const f = (() => {
+    Alice.publish();
+    return false;
+  });
+
+  Alice.publish();
   var keepGoing = true;
   invariant(keepGoing);
   while (keepGoing) {
     commit();
-    f(Alice)
+    keepGoing = f();
     continue;
   };
   commit();

--- a/hs/t/y/continue-mode.txt
+++ b/hs/t/y/continue-mode.txt
@@ -1,0 +1,6 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+  Verifying when ONLY "Alice" is honest
+Checked 15 theorems; No failures!


### PR DESCRIPTION
> Eval continue RHS before checking mode to allow more programs, such as a function call on the RHS, which does communication and comes back to the consensus state
