### PR TITLE
Duoswap on ALGO

### DIFF
--- a/examples/duoswap/Makefile
+++ b/examples/duoswap/Makefile
@@ -8,7 +8,7 @@ build/%.main.mjs: %.rsh
 	$(REACH) compile $^
 
 .PHONY: build
-build: build/announcer.main.mjs build/index.main.mjs
+build: build/announcer.main.mjs build/index.main.mjs build/n2nn.main.mjs
 	docker build -f Dockerfile --tag=reachsh/reach-app-duoswap:latest .
 
 .PHONY: run

--- a/examples/duoswap/announcer.mjs
+++ b/examples/duoswap/announcer.mjs
@@ -2,16 +2,14 @@ import { loadStdlib } from '@reach-sh/stdlib';
 import * as backend from './build/announcer.main.mjs';
 import * as poolBackend from './build/index.main.mjs';
 import * as ask from '@reach-sh/stdlib/ask.mjs';
+import { getTestNetAccount } from './util.mjs';
 
 export const runManager = async (useTestnet) => {
   const stdlib = await loadStdlib();
   let manager;
   if (useTestnet) {
     stdlib.setProviderByName('TestNet');
-    const secret = await ask.ask(`What is your secret key (ETH) / mnemonic (ALGO) ?`);
-    manager = await (stdlib.connector == 'ALGO'
-      ? stdlib.newAccountFromMnemonic(secret)
-      : stdlib.newAccountFromSecret(secret));
+    manager = await getTestNetAccount(stdlib);
   } else {
     const startingBalance = stdlib.parseCurrency(100);
     manager = await stdlib.newTestAccount(startingBalance);
@@ -50,10 +48,7 @@ export const runListener = async (useTestnet) => {
   let accListener;
   if (useTestnet) {
     stdlib.setProviderByName('TestNet');
-    const secret = await ask.ask(`What is your secret key (ETH) / mnemonic (ALGO) ?`);
-    accListener = await (stdlib.connector == 'ALGO'
-      ? stdlib.newAccountFromMnemonic(secret)
-      : stdlib.newAccountFromSecret(secret));
+    accListener = await getTestNetAccount(stdlib);
   } else {
     const startingBalance = stdlib.parseCurrency(100);
     accListener = await stdlib.newTestAccount(startingBalance);

--- a/examples/duoswap/announcer.mjs
+++ b/examples/duoswap/announcer.mjs
@@ -81,12 +81,14 @@ export const runListener_ = (stdlib, accListener, listenerInfo) => async () => {
       const tokB = await views.Tokens.bTok();
       let aBal = await views.Tokens.aBal();
       let bBal = await views.Tokens.bBal();
-      if (tokA[0] == 'None' || tokB[0] == 'None') {
+      if (tokB[0] == 'None') {
         console.log(`XXX: Pool ${ctcInfo} does not have token info`);
         return;
       }
 
-      const resA = await accListener.tokenMetadata(tokA[1]);
+      const resA = await (tokA[1] == 0)
+        ? { id: 0, name: stdlib.connector, symbol: stdlib.connector }
+        : accListener.tokenMetadata(tokA[1]);
       const tokASym = resA.symbol;
       const tokABal = (aBal[0] == 'None') ? 0 : aBal[1];
       console.log(`\x1b[2m`, `  *`, tokABal.toString(), tokASym, '\x1b[0m');

--- a/examples/duoswap/announcer.rsh
+++ b/examples/duoswap/announcer.rsh
@@ -1,14 +1,16 @@
 'reach 0.1';
 
+const Addr = Bytes(64);
+
 export const Common = {
-  hear: Fun([Address], Null),
+  hear: Fun([Addr], Null),
 };
 
 export const main = Reach.App(() => {
   const Manager = Participant('Manager', {
     ...Common,
     printInfo: Fun([], Null),
-    getPoolInfo: Fun([], Address),
+    getPoolInfo: Fun([], Addr),
   });
   const Listener = ParticipantClass('Listener', {
     ...Common,

--- a/examples/duoswap/announcer.rsh
+++ b/examples/duoswap/announcer.rsh
@@ -3,14 +3,14 @@
 const Addr = Bytes(64);
 
 export const Common = {
-  hear: Fun([Addr], Null),
+  hear: Fun([Addr, Bool], Null),
 };
 
 export const main = Reach.App(() => {
   const Manager = Participant('Manager', {
     ...Common,
     printInfo: Fun([], Null),
-    getPoolInfo: Fun([], Addr),
+    getPoolInfo: Fun([], Tuple(Addr, Bool)),
   });
   const Listener = ParticipantClass('Listener', {
     ...Common,
@@ -27,15 +27,15 @@ export const main = Reach.App(() => {
     commit();
 
     Manager.only(() => {
-      const poolInfo = declassify(interact.getPoolInfo());
+      const [poolInfo, usesNetwork] = declassify(interact.getPoolInfo());
     });
 
     Manager
-      .publish(poolInfo)
+      .publish(poolInfo, usesNetwork)
       .timeout(false);
 
-    Manager.interact.hear(poolInfo);
-    Listener.interact.hear(poolInfo);
+    Manager.interact.hear(poolInfo, usesNetwork);
+    Listener.interact.hear(poolInfo, usesNetwork);
 
     commit();
 

--- a/examples/duoswap/index.mjs
+++ b/examples/duoswap/index.mjs
@@ -162,24 +162,24 @@ export const runAutomated = async () => {
             ? ({
               amtA: amt,
               amtB: 0,
-              amtInTok: zmd.id,
+              amtInTok: ['Some', zmd.id],
             })
           : ({
               amtA: 0,
               amtB: amt,
-              amtInTok: gil.id,
+              amtInTok: ['Some', gil.id],
             });
 
         const didNotTrade = traded[who] == false;
         if (didNotTrade) {
-          console.log("\x1b[32m", `${who} tries to trade ${amt} ${toks[trade.amtInTok]}`,'\x1b[0m')
+          console.log("\x1b[32m", `${who} tries to trade ${amt} ${toks[trade.amtInTok[1]]}`,'\x1b[0m')
         }
         return { when: didNotTrade, msg: trade };
       },
       tradeDone: (isMe, [amtIn, amtInTok, amtOut, amtOutTok]) => {
         if (isMe) {
           traded[who] = true;
-          console.log("\x1b[32m", `${who} traded ${amtIn} ${toks[amtInTok]} for ${amtOut} ${toks[amtOutTok]}`,'\x1b[0m');
+          console.log("\x1b[32m", `${who} traded ${amtIn} ${toks[amtInTok[1]]} for ${amtOut} ${toks[amtOutTok[1]]}`,'\x1b[0m');
         }
       }
     });

--- a/examples/duoswap/interactive.mjs
+++ b/examples/duoswap/interactive.mjs
@@ -185,7 +185,7 @@ const compareTokens = (stdlib, token, tokenId) => {
   if (token[0] == 'None') {
     return true;
   }
-  return (stdlib.connector == 'ALGO') ? token[1].eq(tokenId) : (token[1] == tokenId)
+  return (stdlib.connector == 'ALGO') ? token[1].eq(tokenId || 0) : (token[1] == tokenId)
 }
 
 const maybeTok = (tokA) =>

--- a/examples/duoswap/interactive.mjs
+++ b/examples/duoswap/interactive.mjs
@@ -167,6 +167,10 @@ const runDuoSwapLP = async (useTestnet) => {
   await Promise.all([ backendProvider ]);
 }
 
+const compareTokens = (stdlib, token, tokenId) => {
+  return (stdlib.connector == 'ALGO') ? token.eq(tokenId) : (token == tokenId)
+}
+
 const runDuoSwapTrader = async (useTestnet) => {
 
   const stdlib = await loadStdlib();
@@ -216,11 +220,11 @@ const runDuoSwapTrader = async (useTestnet) => {
       await accTrader.tokenAccept(tokId);
     },
     tradeDone: (isMe, [amtIn, amtInTok, amtOut, amtOutTok]) => {
-      const tokIn  = amtInTok == tokA.id ? tokA : tokB;
-      const tokOut = amtOutTok == tokA.id ? tokA : tokB;
+      const tokIn  = compareTokens(stdlib, amtInTok, tokA.id) ? tokA : tokB;
+      const tokOut = compareTokens(stdlib, amtOutTok, tokA.id) ? tokA : tokB;
       if (isMe) {
         traded[accTrader] = true;
-        console.log("\x1b[32m", `I traded ${amtIn} ${tokIn.symbol} for ${amtOut} ${tokOut.symbol}`,'\x1b[0m');
+        console.log("\x1b[32m", `I traded ${amtIn} ${tokIn.symbol} for ${amtOut} ${tokOut.symbol}`, '\x1b[0m');
       }
     },
     tradeMaybe: async ([ alive, market ]) => {

--- a/examples/duoswap/interactive.mjs
+++ b/examples/duoswap/interactive.mjs
@@ -3,6 +3,7 @@ import * as backend from './build/index.main.mjs';
 import * as ask from '@reach-sh/stdlib/ask.mjs';
 import { runManager, runListener, runListener_ } from './announcer.mjs';
 import { runTokens } from './tokens.mjs';
+import { getTestNetAccount } from './util.mjs';
 
 // Track who withdrew/deposited
 const withdrew  = {};
@@ -27,7 +28,8 @@ const getBalance = async (stdlib, tokenX, who) => {
     tokId = stdlib.bigNumberify(tokId.hex).toNumber();
   }
   const amt = await stdlib.balanceOf(who, tokId);
-  return `${fmt(stdlib, amt)} ${tokenX.symbol}`; };
+  return `${fmt(stdlib, amt)} ${tokenX.symbol}`;
+};
 
 const getBalances = async (stdlib, who, tokA, tokB) =>
   `${await getBalance(stdlib, tokA, who)} & ${await getBalance(stdlib, tokB, who)}`;
@@ -41,10 +43,7 @@ const runDuoSwapAdmin = async (useTestnet) => {
   let accAdmin;
   if (useTestnet) {
     stdlib.setProviderByName('TestNet');
-    const secret = await ask.ask(`What is your secret key (ETH) / mnemonic (ALGO) ?`);
-    accAdmin = await (stdlib.connector == 'ALGO'
-      ? stdlib.newAccountFromMnemonic(secret)
-      : stdlib.newAccountFromSecret(secret));
+    accAdmin = await getTestNetAccount(stdlib);
   } else {
     // Create & Fund Admin
     const startingBalance = stdlib.parseCurrency(9999);
@@ -85,10 +84,7 @@ const runDuoSwapLP = async (useTestnet) => {
   let accProvider;
   if (useTestnet) {
     stdlib.setProviderByName('TestNet');
-    const secret = await ask.ask(`What is your secret key (ETH) / mnemonic (ALGO) ?`);
-    accProvider = await (stdlib.connector == 'ALGO'
-      ? stdlib.newAccountFromMnemonic(secret)
-      : stdlib.newAccountFromSecret(secret));
+    accProvider = await getTestNetAccount(stdlib);
   } else {
     // Create & Fund Provider
     const startingBalance = stdlib.parseCurrency(9999);
@@ -177,10 +173,7 @@ const runDuoSwapTrader = async (useTestnet) => {
   let accTrader;
   if (useTestnet) {
     stdlib.setProviderByName('TestNet');
-    const secret = await ask.ask(`What is your secret key (ETH) / mnemonic (ALGO) ?`);
-    accTrader = await (stdlib.connector == 'ALGO'
-      ? stdlib.newAccountFromMnemonic(secret)
-      : stdlib.newAccountFromSecret(secret));
+    accTrader = await getTestNetAccount(stdlib);
   } else {
     // Create & Fund Trader
     const startingBalance = stdlib.parseCurrency(9999);

--- a/examples/duoswap/tokens.mjs
+++ b/examples/duoswap/tokens.mjs
@@ -9,6 +9,17 @@ const getTokenInfo = async () => {
   return [ tokSym, tokName ];
 }
 
+const tryMint = async (stdlib, tok, addr) => {
+  const acc = (stdlib.connector == 'ALGO')
+    ? { networkAccount: { addr } }
+    : { networkAccount: { address: addr } };
+  try {
+    await tok.mint(acc, stdlib.parseCurrency(1000))
+  } catch (e) {
+    console.log(`Could not mint for ${addr}. This is expected if you're funding an Admin who created a network to non-network pool.`);
+  };
+}
+
 export const runTokens = async (useTestnet) => {
   const stdlib = await loadStdlib();
 
@@ -41,10 +52,7 @@ export const runTokens = async (useTestnet) => {
   while (true) {
     console.log(`Ready To Mint 1000 ${symA} & 1000 ${symB}`);
     const addr = await ask.ask(`Address: `);
-    const acc = (stdlib.connector == 'ALGO')
-      ? { networkAccount: { addr } }
-      : { networkAccount: { address: addr } };
-    await tokA.mint(acc, stdlib.parseCurrency(1000));
-    await tokB.mint(acc, stdlib.parseCurrency(1000));
+    await tryMint(stdlib, tokA, addr);
+    await tryMint(stdlib, tokB, addr);
   }
 }

--- a/examples/duoswap/tokens.mjs
+++ b/examples/duoswap/tokens.mjs
@@ -27,8 +27,8 @@ export const runTokens = async (useTestnet) => {
   console.log(`Creating second token...`);
   const [symB, nameB] = await getTokenInfo();
 
-  const tokA = await launchToken(nameA, symA, stdlib, accCreator);
-  const tokB = await launchToken(nameB, symB, stdlib, accCreator);
+  const tokA = await launchToken(stdlib, accCreator, nameA, symA);
+  const tokB = await launchToken(stdlib, accCreator, nameB, symB);
   console.log(`Token Info:`, JSON.stringify({
     tokA: tokA.id,
     tokB: tokB.id,
@@ -37,7 +37,9 @@ export const runTokens = async (useTestnet) => {
   while (true) {
     console.log(`Ready To Mint 1000 ${symA} & 1000 ${symB}`);
     const addr = await ask.ask(`Address: `);
-    const acc = { networkAccount: { address: addr } };
+    const acc = (stdlib.connector == 'ALGO')
+      ? { networkAccount: { addr } }
+      : { networkAccount: { address: addr } };
     tokA.mint(acc, stdlib.parseCurrency(1000));
     tokB.mint(acc, stdlib.parseCurrency(1000));
   }

--- a/examples/duoswap/tokens.mjs
+++ b/examples/duoswap/tokens.mjs
@@ -14,8 +14,10 @@ export const runTokens = async (useTestnet) => {
   let accCreator;
   if (useTestnet) {
     stdlib.setProviderByName(`TestNet`);
-    const secret = await ask.ask(`What is your secret key?`);
-    accCreator = await stdlib.newAccountFromSecret(secret);
+    const secret = await ask.ask(`What is your secret key (ETH) / mnemonic (ALGO) ?`);
+    accCreator = await (stdlib.connector == 'ALGO'
+      ? stdlib.newAccountFromMnemonic(secret)
+      : stdlib.newAccountFromSecret(secret));
   } else {
     const startingBalance = stdlib.parseCurrency(100);
     accCreator = await stdlib.newTestAccount(startingBalance);

--- a/examples/duoswap/tokens.mjs
+++ b/examples/duoswap/tokens.mjs
@@ -23,6 +23,10 @@ export const runTokens = async (useTestnet) => {
     accCreator = await stdlib.newTestAccount(startingBalance);
   }
 
+  if (stdlib.connector == 'ETH') {
+    accCreator.setGasLimit(5000000);
+  }
+
   console.log(`Creating first token...`);
   const [symA, nameA] = await getTokenInfo();
 
@@ -42,7 +46,7 @@ export const runTokens = async (useTestnet) => {
     const acc = (stdlib.connector == 'ALGO')
       ? { networkAccount: { addr } }
       : { networkAccount: { address: addr } };
-    tokA.mint(acc, stdlib.parseCurrency(1000));
-    tokB.mint(acc, stdlib.parseCurrency(1000));
+    await tokA.mint(acc, stdlib.parseCurrency(1000));
+    await tokB.mint(acc, stdlib.parseCurrency(1000));
   }
 }

--- a/examples/duoswap/tokens.mjs
+++ b/examples/duoswap/tokens.mjs
@@ -1,6 +1,7 @@
 import { loadStdlib } from '@reach-sh/stdlib';
 import launchToken from '@reach-sh/stdlib/launchToken.mjs';
 import * as ask from '@reach-sh/stdlib/ask.mjs';
+import { getTestNetAccount } from './util.mjs';
 
 const getTokenInfo = async () => {
   const tokSym = await ask.ask(`Token symbol:`);
@@ -14,10 +15,7 @@ export const runTokens = async (useTestnet) => {
   let accCreator;
   if (useTestnet) {
     stdlib.setProviderByName(`TestNet`);
-    const secret = await ask.ask(`What is your secret key (ETH) / mnemonic (ALGO) ?`);
-    accCreator = await (stdlib.connector == 'ALGO'
-      ? stdlib.newAccountFromMnemonic(secret)
-      : stdlib.newAccountFromSecret(secret));
+    accCreator = await getTestNetAccount(stdlib);
   } else {
     const startingBalance = stdlib.parseCurrency(100);
     accCreator = await stdlib.newTestAccount(startingBalance);

--- a/examples/duoswap/util.mjs
+++ b/examples/duoswap/util.mjs
@@ -1,0 +1,10 @@
+import * as ask from '@reach-sh/stdlib/ask.mjs';
+
+export const getTestNetAccount = async (stdlib) => {
+  const isAlgo = stdlib.connector == 'ALGO';
+  const prompt = isAlgo ? 'mnemonic' : 'key';
+  const secret = await ask.ask(`What is your secret ${prompt}?`);
+  return (await isAlgo
+    ? stdlib.newAccountFromMnemonic(secret)
+    : stdlib.newAccountFromSecret(secret));
+}

--- a/examples/duoswap/util.rsh
+++ b/examples/duoswap/util.rsh
@@ -1,0 +1,91 @@
+'reach 0.1';
+
+export const NUM_OF_TOKENS = 2;
+
+export const avg = (a, b) => (a + b) / 2;
+
+export const getAmtOut = (amtIn, reserveIn, reserveOut) => {
+  const amtInWithFee = amtIn * 997;
+  const num = amtInWithFee * reserveOut;
+  const den = (reserveIn * 1000) + amtInWithFee;
+  return num / den;
+}
+
+// Calculates how many LP tokens to mint
+export const mint = (amtIn, bal, poolMinted) => {
+  const t = amtIn * poolMinted;
+  assume(t >= bal, "t >= bal");
+  return t / ((bal == 0) ? 1 : bal);
+};
+
+// Types
+export const MkArray = (ty) => Array(ty, NUM_OF_TOKENS);
+
+export const MToken = Maybe(Token);
+
+export const Market = Object({
+  k: UInt
+});
+
+export const State = Tuple(Bool, Market);
+
+export const Withdraw = Object({
+  liquidity: UInt
+});
+
+export const Deposit = Object({
+  amtA: UInt,
+  amtB: UInt
+});
+
+export const Trade = Object({
+  amtA: UInt,
+  amtB: UInt,
+  amtInTok: Maybe(Token),
+});
+
+// Participants
+export const ProviderInterface = {
+  ...hasConsoleLogger,
+  withdrawMaybe: Fun([State], Object({
+    when: Bool,
+    msg : Withdraw,
+  })),
+  withdrawDone: Fun([Bool, MkArray(UInt)], Null),
+  depositMaybe: Fun([State], Object({
+    when: Bool,
+    msg: Deposit,
+  })),
+  depositDone: Fun([Bool, UInt, UInt, UInt], Null),
+  acceptToken: Fun([Token], Null),
+};
+
+export const mkAdminInterface = (hasTokA) => {
+  const base = {
+    tokB: Token,
+    conUnit: UInt,
+    shouldClosePool: Fun([State], Object({
+      when: Bool,
+      msg : Null,
+    }))
+  };
+  return hasTokA ? { ...base, tokA: Token} : base;
+};
+
+export const TraderInterface = {
+  ...hasConsoleLogger,
+  logMarket: Fun(true, Null),
+  tradeMaybe: Fun([State], Object({
+    when: Bool,
+    msg : Trade,
+  })),
+  tradeDone: Fun([Bool, Tuple(UInt, MToken, UInt, MToken)], Null),
+  acceptToken: Fun([Token], Null),
+};
+
+export const TokensView = {
+  aTok : Token,
+  bTok : Token,
+  aBal : UInt,
+  bBal : UInt,
+};

--- a/hs/src/Reach/Connector/ALGO.hs
+++ b/hs/src/Reach/Connector/ALGO.hs
@@ -210,7 +210,7 @@ opt_b1 = \case
   a@["substring", s0, _] : b@["int", x] : c@["getbyte"] : l ->
     case mse of
       Just (s0x, s0xp1) ->
-        opt_b1 $ ["substring", s0x, s0xp1] : l
+        opt_b1 $ ["substring", s0x, s0xp1] : ["btoi"] : l
       Nothing ->
         a : b : c : l
     where

--- a/js/stdlib/ts/shared_impl.ts
+++ b/js/stdlib/ts/shared_impl.ts
@@ -186,7 +186,7 @@ export const deferContract =
     // @ts-ignore
     selfAddress: mnow('selfAddress'),
     // @ts-ignore
-    getViews: not_yet('getViews'),
+    getViews: mnow('getViews'),
     stdlib: (() => {
       if ( implNow.stdlib === undefined ) {
         throw Error(`stdlib not defined`); }


### PR DESCRIPTION
* Have accounts accept non-network tokens in frontend.
* Adjust ALGO runtime shim, so calling `getViews` will call `delay` instead of `not_yet`.
* Fix overflow on ALGO when performing math in pool ctc
  * The initial mint calculation will divide its inputs by the connector unit (10^6 ALGO / 10^18 ETH) and then scale it back. This adds the constraint that initial deposit values may not be fractional. Any idea if this can be avoided?
* Have Announcer announce `Bytes` instead of `Address` to work with ALGO.
* Add conditionals in the frontend for dealing with differences between ALGO and ETH.