### PR TITLE
cfx portal testnet

### DIFF
--- a/js/stdlib/ts/CFX_compiled.ts
+++ b/js/stdlib/ts/CFX_compiled.ts
@@ -3,7 +3,7 @@ import { EthLikeCompiled } from './ETH_like_interfaces';
 import * as cfxCompiledImpl from './CFX_compiled_impl';
 
 const cfxCompiled: EthLikeCompiled = makeEthLikeCompiled(cfxCompiledImpl);
-export const { setNetworkId } = cfxCompiledImpl;
+export const { getNetworkId, setNetworkId } = cfxCompiledImpl;
 // The following should be identical to ETH_compiled.ts
 export const {
   stdlib,

--- a/js/stdlib/ts/CFX_compiled_impl.ts
+++ b/js/stdlib/ts/CFX_compiled_impl.ts
@@ -14,6 +14,10 @@ export function setNetworkId(networkId: number) {
   T_Address.defaultValue = recomputeDefaultAddr();
 }
 
+export function getNetworkId() {
+  return netId;
+}
+
 // XXX this should not be computed at compile time, because it can change based on the netId
 // Note: 0x1 = user, 0x8 = contract
 // https://github.com/resodo/conflux-address-js/blob/0cbbe3d17fbd6cbc2c2fbafc3470ff6087f38087/lib/index.js#L86

--- a/js/stdlib/ts/CFX_impl.ts
+++ b/js/stdlib/ts/CFX_impl.ts
@@ -37,6 +37,11 @@ export function isWindowProvider(): boolean {
   return 'CFX_NET' in env && env.CFX_NET === 'window' && !!window.conflux;
 }
 
+export function canGetDefaultAccount(): boolean {
+  // XXX be pickier
+  return true;
+}
+
 // /**
 //  * Strategies for deciding what getDefaultAccount returns.
 //  */

--- a/js/stdlib/ts/ETH_impl.ts
+++ b/js/stdlib/ts/ETH_impl.ts
@@ -192,6 +192,10 @@ export function isWindowProvider(): boolean {
   return 'ETH_NET' in env && env.ETH_NET === 'window' && !!window.ethereum;
 }
 
+export function canGetDefaultAccount(): boolean {
+  return isWindowProvider() || isIsolatedNetwork();
+}
+
 function windowLooksIsolated() {
   if (!window.ethereum) return false;
   // XXX this is a hacky way of checking if we're on a devnet

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -151,6 +151,7 @@ const {
   _getDefaultNetworkAccount,
   _getDefaultFaucetNetworkAccount,
   _warnTxNoBlockNumber = true,
+  _specialFundFromFaucet = async () => null,
   standardUnit,
   atomicUnit,
   validQueryWindow,
@@ -970,8 +971,13 @@ const createAccount = async () => {
 }
 
 const fundFromFaucet = async (account: AccountTransferable, value: any) => {
-  const faucet = await getFaucet();
-  await transfer(faucet, account, value);
+  const f = await _specialFundFromFaucet();
+  if (f) {
+    return await f(account, value);
+  } else {
+    const faucet = await getFaucet();
+    await transfer(faucet, account, value);
+  }
 };
 
 const newTestAccount = async (startingBalance: any): Promise<Account> => {

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -146,7 +146,8 @@ const {
   standardDigits = 18,
   providerLib,
   isIsolatedNetwork,
-  isWindowProvider,
+  canGetDefaultAccount,
+  // isWindowProvider,
   _getDefaultNetworkAccount,
   _getDefaultFaucetNetworkAccount,
   _warnTxNoBlockNumber = true,
@@ -951,7 +952,7 @@ const newAccountFromMnemonic = async (phrase: string): Promise<Account> => {
 
 const getDefaultAccount = async (): Promise<Account> => {
   debug(`getDefaultAccount`);
-  if (!(isWindowProvider() || isIsolatedNetwork())) throw Error(`Default account not available`);
+  if (!canGetDefaultAccount()) throw Error(`Default account not available`);
   return connectAccount(await _getDefaultNetworkAccount());
 };
 

--- a/js/stdlib/ts/ETH_like_interfaces.ts
+++ b/js/stdlib/ts/ETH_like_interfaces.ts
@@ -105,6 +105,7 @@ export interface EthLikeArgs {
   canGetDefaultAccount(): boolean
   _getDefaultNetworkAccount(): any
   _getDefaultFaucetNetworkAccount(): any
+  _specialFundFromFaucet?: () => Promise<null | ((acc: any, val: any) => Promise<any>)>
   _warnTxNoBlockNumber?: boolean
   standardUnit: string
   atomicUnit: string

--- a/js/stdlib/ts/ETH_like_interfaces.ts
+++ b/js/stdlib/ts/ETH_like_interfaces.ts
@@ -102,6 +102,7 @@ export interface EthLikeArgs {
   providerLib: ProviderLib
   isIsolatedNetwork(): boolean
   isWindowProvider(): boolean
+  canGetDefaultAccount(): boolean
   _getDefaultNetworkAccount(): any
   _getDefaultFaucetNetworkAccount(): any
   _warnTxNoBlockNumber?: boolean

--- a/js/stdlib/ts/shim.ts
+++ b/js/stdlib/ts/shim.ts
@@ -53,6 +53,7 @@ type Window = {
   ethereum?: ethers.providers.ExternalProvider,
   prompt?: (s: string) => string | null,
   reach?: any, // TODO
+  fetch?: (...args: any) => any,
 };
 
 const windowShim: Window = (() => {


### PR DESCRIPTION
Tweaks to allow

* working with conflux portal on testnet (currently only with `'BlockNumber'` provider name)
* `fundFromFaucet` automated on conflux testnet (currently only works in browser)