### PR TITLE
change "20" to "21" to fix incorrect line number

### DIFF
--- a/docs-src/tut.scrbl
+++ b/docs-src/tut.scrbl
@@ -137,7 +137,7 @@ This will only work on the Reach-provided developer testing network.}
 
 @item{Line 13 waits for the backends to complete.}
 
-@item{Line 20 calls this asynchronous function that we've defined.}
+@item{Line 21 calls this asynchronous function that we've defined.}
 
 ]
 

--- a/docs-vue/src/tut.md
+++ b/docs-vue/src/tut.md
@@ -159,7 +159,7 @@ The program defined in [tut-2/index.rsh](@github/examples/tut-2/index.rsh) will 
 + Lines 14 through 16 initialize a backend for Alice.
 + Lines 17 through 19 initialize a backend for Bob.
 + Line 13 waits for the backends to complete.
-+ Line 20 calls this asynchronous function that we've defined.
++ Line 21 calls this asynchronous function that we've defined.
 
 
 This is now enough for Reach to compile and run our program. Let's try by running


### PR DESCRIPTION
[The docs](https://docs.reach.sh/tut-2.html) currently say we call the asynchronous function on line 20, but we actually call it on line 21.

![Screen Shot 2021-08-27 at 11 31 07 AM](https://user-images.githubusercontent.com/43425812/131173093-bafd8f17-b91e-4b53-be4b-523d945d4ce5.png)
