### PR TITLE
Add `muldiv` primitive

### DIFF
--- a/docs-src/guide-changelog.scrbl
+++ b/docs-src/guide-changelog.scrbl
@@ -10,6 +10,7 @@ Versions and changes-within-versions are listed in reverse-chronological order: 
 
 Version 0.1.4 is the current Reach release candidate version.
 @itemlist[
+@item{2021/09/15: @reachin{muldiv} added.}
 @item{2021/09/08: Add @DFlag{stop-after-eval} and @DFlag{verify-timeout} options to @exec{reach compile}.}
 @item{2021/08/31: Removed @jsin{getSignStrategy} and @jsin{setSignStrategy} in favor of @jsin{setWalletFallBack} and @jsin{walletFallback}.}
 @item{2021/08/31: Algorand devnet updated to versions 2.9.1 and 2.6.1}

--- a/docs-src/ref-programs-compute.scrbl
+++ b/docs-src/ref-programs-compute.scrbl
@@ -1495,6 +1495,17 @@ This pattern is so common that it can be abbreviated as @reachin{.timeRemaining}
 @index{compose} Creates a new function that applies its argument to @tt{g}, then pipes the result to the function @tt{f}.
 The argument type of @tt{f} must be the return type of @tt{g}.
 
+@subsection{@tt{muldiv}}
+
+@margin-note{Currently, wide arithmetic operations are only suported on Algorand.}
+
+@(mint-define! '("muldiv"))
+@reach{
+  muldiv(a, b, c) }
+
+@index{muldiv(a, b, c)} Multiplies @reachin{a} by @reachin{b}, then immediately divides the product by @reachin{c}.
+The intermediate value may be larger than @reachin{UInt.max} if the connector supports wide arithmetic operations.
+The resulting quotient must be less than @reachin{UInt.max}.
 
 @subsection{@tt{sqrt}}
 

--- a/examples/muldiv/index.mjs
+++ b/examples/muldiv/index.mjs
@@ -1,0 +1,27 @@
+import {loadStdlib} from '@reach-sh/stdlib';
+import * as backend from './build/index.main.mjs';
+const stdlib = loadStdlib(process.env);
+
+(async () => {
+  const startingBalance = stdlib.parseCurrency(100);
+
+  const [ accAlice ] =
+    await stdlib.newTestAccounts(1, startingBalance);
+  console.log('Hello, Alice!');
+
+  console.log('Launching...');
+  const ctcAlice = accAlice.deploy(backend);
+
+  console.log('Starting backends...');
+  await Promise.all([
+    backend.Alice(ctcAlice, {
+      ...stdlib.hasRandom,
+      log: (msg, x) => console.log(msg, x.toString()),
+      // This will be multiplied by 4 then divided by 5.
+      // x * 4 would normally overflow on Algorand
+      x: 9223372036854775807,
+    }),
+  ]);
+
+  console.log('Goodbye, Alice!');
+})();

--- a/examples/muldiv/index.mjs
+++ b/examples/muldiv/index.mjs
@@ -7,21 +7,27 @@ const stdlib = loadStdlib(process.env);
 
   const [ accAlice ] =
     await stdlib.newTestAccounts(1, startingBalance);
-  console.log('Hello, Alice!');
 
-  console.log('Launching...');
+  console.log(`Deploying...`);
   const ctcAlice = accAlice.deploy(backend);
 
-  console.log('Starting backends...');
+  const x = stdlib.bigNumberify(9223372036854775807);
+  const y = stdlib.bigNumberify(4);
+  const z = stdlib.bigNumberify(5);
+
   await Promise.all([
     backend.Alice(ctcAlice, {
       ...stdlib.hasRandom,
-      log: (msg, x) => console.log(msg, x.toString()),
-      // This will be multiplied by 4 then divided by 5.
-      // x * 4 would normally overflow on Algorand
-      x: 9223372036854775807,
+      check: (actual) => {
+        const expected = x.mul(y).div(z);
+        console.log(`Check: `, actual.toString(), `=`, expected.toString());
+        console.assert(actual.eq(expected));
+      },
+      // x will be multiplied by y then divided by z.
+      // x * y would normally overflow on Algorand
+      x, y, z,
     }),
   ]);
 
-  console.log('Goodbye, Alice!');
+  console.log('Done!');
 })();

--- a/examples/muldiv/index.rsh
+++ b/examples/muldiv/index.rsh
@@ -2,24 +2,28 @@
 
 export const main = Reach.App(() => {
   const A = Participant('Alice', {
-    ...hasConsoleLogger,
+    check: Fun(true, Null),
     x: UInt,
+    y: UInt,
+    z: UInt,
   });
   deploy();
 
   A.only(() => {
     const x = declassify(interact.x);
-    const z = muldiv(x, 4, 5);
+    const y = declassify(interact.y);
+    const z = declassify(interact.z);
+    const r1 = muldiv(x, y, z);
   });
-  A.publish(x, z);
+  A.publish(x, y, z, r1);
 
-  const y = muldiv(x, 4, 5);
+  const r2 = muldiv(x, y, z);
 
-  require(y == z);
+  require(r1 == r2);
 
   commit();
 
-  const a = muldiv(x, 4, 5);
-  A.interact.log("a", a);
+  const a = muldiv(x, y, z);
+  A.interact.check(a);
 
 });

--- a/examples/muldiv/index.rsh
+++ b/examples/muldiv/index.rsh
@@ -1,0 +1,25 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const A = Participant('Alice', {
+    ...hasConsoleLogger,
+    x: UInt,
+  });
+  deploy();
+
+  A.only(() => {
+    const x = declassify(interact.x);
+    const z = muldiv(x, 4, 5);
+  });
+  A.publish(x, z);
+
+  const y = muldiv(x, 4, 5);
+
+  require(y == z);
+
+  commit();
+
+  const a = muldiv(x, 4, 5);
+  A.interact.log("a", a);
+
+});

--- a/examples/muldiv/index.txt
+++ b/examples/muldiv/index.txt
@@ -1,0 +1,6 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+  Verifying when ONLY "Alice" is honest
+Checked 7 theorems; No failures!

--- a/hs/src/Reach/AST/Base.hs
+++ b/hs/src/Reach/AST/Base.hs
@@ -247,6 +247,7 @@ data PrimOp
   | BIOR
   | BXOR
   | BYTES_CONCAT
+  | MUL_DIV
   deriving (Eq, Generic, NFData, Ord, Show)
 
 instance Pretty PrimOp where
@@ -272,6 +273,7 @@ instance Pretty PrimOp where
     BIOR -> "|"
     BXOR -> "^"
     BYTES_CONCAT -> "concat"
+    MUL_DIV -> "muldiv"
 
 data SLCtxtFrame
   = SLC_CloApp SrcLoc SrcLoc (Maybe SLVar)

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -595,6 +595,7 @@ primOpType RSH = ([T_UInt, T_UInt], T_UInt)
 primOpType BAND = ([T_UInt, T_UInt], T_UInt)
 primOpType BIOR = ([T_UInt, T_UInt], T_UInt)
 primOpType BXOR = ([T_UInt, T_UInt], T_UInt)
+primOpType MUL_DIV = ([T_UInt, T_UInt, T_UInt], T_UInt)
 
 data RemoteFunMode
   = RFM_Pay
@@ -673,6 +674,7 @@ data SLPrimitive
   | SLPrim_Token_burn
   | SLPrim_Token_destroy
   | SLPrim_Token_destroyed
+  | SLPrim_muldiv
   deriving (Eq, Generic)
 
 instance Equiv SLPrimitive where

--- a/hs/src/Reach/Backend/JS.hs
+++ b/hs/src/Reach/Backend/JS.hs
@@ -268,6 +268,7 @@ jsPrimApply = \case
   SUB -> jsApply "stdlib.sub"
   MUL -> jsApply "stdlib.mul"
   DIV -> jsApply "stdlib.div"
+  MUL_DIV -> jsApply "stdlib.muldiv"
   MOD -> jsApply "stdlib.mod"
   PLT -> jsApply "stdlib.lt"
   PLE -> jsApply "stdlib.le"

--- a/hs/src/Reach/Connector/ALGO.hs
+++ b/hs/src/Reach/Connector/ALGO.hs
@@ -628,6 +628,19 @@ cprim = \case
   SUB -> call "-"
   MUL -> call "*"
   DIV -> call "/"
+  MUL_DIV -> \case
+    [x, y, z] -> do
+      ca x
+      ca y
+      op "mulw"
+      ca $ DLA_Literal $ DLL_Int srcloc_builtin 0
+      ca z
+      op "divmodw"
+      op "pop"
+      op "pop"
+      op "swap"
+      op "pop"
+    _ -> impossible "cprim: MUL_DIV args"
   MOD -> call "%"
   PLT -> call "<"
   PLE -> call "<="

--- a/hs/src/Reach/Connector/ALGO.hs
+++ b/hs/src/Reach/Connector/ALGO.hs
@@ -633,13 +633,14 @@ cprim = \case
       ca x
       ca y
       op "mulw"
-      ca $ DLA_Literal $ DLL_Int srcloc_builtin 0
+      cl $ DLL_Int sb 0
       ca z
       op "divmodw"
       op "pop"
       op "pop"
       op "swap"
-      op "pop"
+      cl $ DLL_Int sb 0
+      asserteq
     _ -> impossible "cprim: MUL_DIV args"
   MOD -> call "%"
   PLT -> call "<"

--- a/hs/src/Reach/Connector/ETH_Solidity.hs
+++ b/hs/src/Reach/Connector/ETH_Solidity.hs
@@ -486,6 +486,11 @@ solPrimApply = \case
   SUB -> safeOp "unsafeSub" "-"
   MUL -> safeOp "unsafeMul" "*"
   DIV -> binOp "/"
+  MUL_DIV -> \case
+    [x, y, den] -> do
+      mul <- safeOp "unsafeMul" "*" [x, y]
+      binOp "/" [mul, den]
+    _ -> impossible "solPrimApply: MUL_DIV args"
   MOD -> binOp "%"
   PLT -> binOp "<"
   PLE -> binOp "<="

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -1848,6 +1848,9 @@ evalPrimOp p sargs = do
       let chkDiv denom = do
             ca <- doCmp PGT [denom, DLA_Literal $ DLL_Int srcloc_builtin 0]
             dopClaim ca "div by zero"
+      let chkMul = do
+            ca <- doCmp PLE [da, lim_maxUInt_a]
+            dopClaim ca "mul overflow"
       whenVerifyArithmetic $
         case p of
           ADD -> do
@@ -1864,13 +1867,12 @@ evalPrimOp p sargs = do
             chkDiv $ case dargs of
                   [_, b] -> b
                   _ -> impossible "div args"
-          MUL -> do
-            ca <- doCmp PLE [da, lim_maxUInt_a]
-            dopClaim ca "mul overflow"
+          MUL -> chkMul
           MUL_DIV -> do
             chkDiv $ case dargs of
                   [_, _, b] -> b
                   _ -> impossible "muldiv args"
+            chkMul
           _ -> return $ mempty
       return $ (lvl, SLV_DLVar dv)
 

--- a/hs/src/Reach/Optimize.hs
+++ b/hs/src/Reach/Optimize.hs
@@ -263,6 +263,19 @@ instance Optimize DLExpr where
           return $ DLE_Arg at zero
         (DIV, [lhs, (DLA_Literal (DLL_Int _ 1))]) ->
           return $ DLE_Arg at lhs
+        (MUL_DIV, [l, r, d])
+          | l == d -> return $ DLE_Arg at r
+          | r == d -> return $ DLE_Arg at l
+        (MUL_DIV, [l, r, DLA_Literal (DLL_Int _ 1)]) ->
+            opt $ DLE_PrimOp at MUL [l, r]
+        (MUL_DIV, [DLA_Literal (DLL_Int _ 1), r, d]) ->
+            opt $ DLE_PrimOp at DIV [r, d]
+        (MUL_DIV, [l, DLA_Literal (DLL_Int _ 1), d]) ->
+            opt $ DLE_PrimOp at DIV [l, d]
+        (MUL_DIV, [DLA_Literal (DLL_Int _ 0), _, _]) ->
+          return $ DLE_Arg at zero
+        (MUL_DIV, [_, DLA_Literal (DLL_Int _ 0), _, _]) ->
+          return $ DLE_Arg at zero
         (IF_THEN_ELSE, [c, (DLA_Literal (DLL_Bool True)), (DLA_Literal (DLL_Bool False))]) ->
           return $ DLE_Arg at $ c
         (IF_THEN_ELSE, [(DLA_Literal (DLL_Bool c)), t, f]) ->

--- a/hs/src/Reach/Verify/SMT.hs
+++ b/hs/src/Reach/Verify/SMT.hs
@@ -299,6 +299,10 @@ smtPrimOp at p dargs =
     ADDRESS_EQ -> app "="
     TOKEN_EQ -> app "="
     BYTES_CONCAT -> app "bytesAppend"
+    MUL_DIV ->
+      \case
+        [x, y, den] -> return $ smtApply "div" [ smtApply "*" [ x, y ], den ]
+        _ -> impossible "smtPrimOp: MUL_DIV args"
     SELF_ADDRESS ->
       case dargs of
         [ DLA_Literal (DLL_Bytes pn)

--- a/js/stdlib/ts/shared_impl.ts
+++ b/js/stdlib/ts/shared_impl.ts
@@ -368,7 +368,11 @@ export const makeArith = (m:BigNumber) => {
   const mod = (a: num, b: num): BigNumber => check(bigNumberify(a).mod(bigNumberify(b)));
   const mul = (a: num, b: num): BigNumber => check(bigNumberify(a).mul(bigNumberify(b)));
   const div = (a: num, b: num): BigNumber => check(bigNumberify(a).div(bigNumberify(b)));
-  return { add, sub, mod, mul, div };
+  const muldiv = (a: num, b: num, c: num): BigNumber => {
+    const prod = bigNumberify(a).mul(bigNumberify(b));
+    return check( prod.div(bigNumberify(c)) );
+  };
+  return { add, sub, mod, mul, div, muldiv };
 };
 
 export const argsSlice = <T>(args: Array<T>, cnt: number): Array<T> =>


### PR DESCRIPTION
Add `muldiv: UInt -> UInt -> UInt` which will multiply the first two arguments and divide the result by the third argument. If a connector supports wide arithmetic operations, it will use them. The resulting quotient must be less than or equal to `UInt.max`.