### PR TITLE
CORE-620: Ensure `Participant` Can Make First Publication

### DIFF
--- a/docs-src/guide-changelog.scrbl
+++ b/docs-src/guide-changelog.scrbl
@@ -18,7 +18,7 @@ This has the impact of frontends not being asked to sign transactions that canno
 @item{2021/09/16: Bare integers used as time arguments will throw a deprecation warning. Use @reachin{relativeTime} instead.}
 @item{2021/09/16: The concept of deployment modes has been removed and the only available behavior is what was previously the @litchar{firstMsg} deployment mode.
 
-If you would like the old behavior, then you'll want to create a new participant class, perhaps called @litchar{Constructor}, that exists simply to run @reachin{Constructor.publish(); commit();}, but we expect that almost no one actually wants the old behavior exactly.
+If you would like the old behavior, then you'll want to create a new participant, perhaps called @litchar{Constructor}, that exists simply to run @reachin{Constructor.publish(); commit();}, but we expect that almost no one actually wants the old behavior exactly.
 Instead, you probably want to select one of your existing participants and assign the first publication to them.
 }
 @item{2021/09/16: The backend interface to the compiled objects was updated, so you'll need to recompile for this release and older, deployed contracts will not work with this version.}

--- a/docs-src/ref-error-codes.scrbl
+++ b/docs-src/ref-error-codes.scrbl
@@ -2065,6 +2065,22 @@ This error can be corrected by either removing the @reachin{Some} case or placin
 This error indicates that you have inspected the details about a publication, such as via @reachin{didPublish()}, before there has been a publication.
 This is impossible, so the expression must be moved after the first publication.
 
+@error{RE0120}
+
+This error indicates that an actor who is not a @reachin{Participant}, e.g. a @reachin{ParticipantClass}, is
+attempting to make the first publication of a Reach program.
+
+You can fix this error by assigning the first publication to one of your @reachin{Participant}s.
+Additionally, you can create a new @reachin{Participant} to specifically perform this action.
+
+@reach{
+  const Constructor = Participant('Constructor', {});
+  // ...
+  deploy();
+  Constructor.publish();
+  commit();
+  // ...
+}
 
 @error{REP0000}
 

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -3853,8 +3853,10 @@ doToConsensus ks (ToConsensusRec {..}) = locAt slptc_at $ do
   ensure_live "to consensus"
   let st_pure = st {st_mode = SLM_ConsensusPure}
   let pdvs = st_pdvs st
-  allClasses <- and <$> traverse is_class (S.toList whos)
-  when (not (st_after_first st) && allClasses) $ do
+  isSoloSend <- case S.toList whos of
+                  [solo] -> not <$> is_class solo
+                  _ -> return False
+  unless (st_after_first st || isSoloSend) $ do
         expect_thrown at Err_UniqueFirstPublish
   let ctepee t e = compileCheckType t =<< ensure_public =<< evalExpr e
   -- We go back to the original env from before the to-consensus step

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -3853,6 +3853,9 @@ doToConsensus ks (ToConsensusRec {..}) = locAt slptc_at $ do
   ensure_live "to consensus"
   let st_pure = st {st_mode = SLM_ConsensusPure}
   let pdvs = st_pdvs st
+  allClasses <- and <$> traverse is_class (S.toList whos)
+  when (not (st_after_first st) && allClasses) $ do
+        expect_thrown at Err_UniqueFirstPublish
   let ctepee t e = compileCheckType t =<< ensure_public =<< evalExpr e
   -- We go back to the original env from before the to-consensus step
   -- Handle sending

--- a/hs/src/Reach/Eval/Error.hs
+++ b/hs/src/Reach/Eval/Error.hs
@@ -148,6 +148,7 @@ data EvalError
   | Err_Return_BothSidesMust
   | Err_Switch_UnreachableCase SrcLoc SLVar SrcLoc
   | Err_NotAfterFirst
+  | Err_UniqueFirstPublish
   deriving (Eq, Generic)
 
 instance HasErrorCode EvalError where
@@ -277,6 +278,7 @@ instance HasErrorCode EvalError where
     Err_Return_BothSidesMust -> 117
     Err_Switch_UnreachableCase {} -> 118
     Err_NotAfterFirst -> 119
+    Err_UniqueFirstPublish -> 120
 
 --- FIXME I think most of these things should be in Pretty
 
@@ -700,5 +702,7 @@ instance Show EvalError where
       "The switch case `" <> cs <> "` defined at " <> show cat <> " is unreachable because `default` was used at " <> show dat
     Err_NotAfterFirst ->
       "Cannot inspect publication details until after first publication"
+    Err_UniqueFirstPublish ->
+      "A unique `Participant` must make the first publication"
     where
       displayPrim = drop (length ("SLPrim_" :: String)) . conNameOf

--- a/hs/t/n/Err_ToConsensus_WhenNoTimeout_noMatterWhat.rsh
+++ b/hs/t/n/Err_ToConsensus_WhenNoTimeout_noMatterWhat.rsh
@@ -1,10 +1,14 @@
 'reach 0.1';
 
 export const main = Reach.App(() => {
+  const C = Participant('Constructor', {});
   const A = ParticipantClass('A', {
     go: Fun([], Bool),
     ok: Fun([], Null) });
   deploy();
+
+  C.publish();
+  commit();
 
   A.publish();
 

--- a/hs/t/n/Err_ToConsensus_WhenNoTimeout_noMatterWhat.txt
+++ b/hs/t/n/Err_ToConsensus_WhenNoTimeout_noMatterWhat.txt
@@ -1,8 +1,8 @@
 reachc: error[RE0080]: Cannot ignore timeout requirement, unless at least one participant always races or one class might race
 
- ./Err_ToConsensus_WhenNoTimeout_noMatterWhat.rsh:11:27:application
+ ./Err_ToConsensus_WhenNoTimeout_noMatterWhat.rsh:15:27:application
 
- 11|   const x = parallelReduce(0)
+ 15|   const x = parallelReduce(0)
 
 For further explanation of this error, see: https://docs.reach.sh/RE0080.html
 

--- a/hs/t/n/Err_UniqueFirstPublish.rsh
+++ b/hs/t/n/Err_UniqueFirstPublish.rsh
@@ -1,0 +1,11 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const Sigma = Participant('Sigma', {});
+  const Betas = ParticipantClass('Betas', {});
+  deploy();
+
+  Betas.publish();
+  commit();
+  exit();
+});

--- a/hs/t/n/Err_UniqueFirstPublish.txt
+++ b/hs/t/n/Err_UniqueFirstPublish.txt
@@ -1,0 +1,8 @@
+reachc: error[RE0120]: A unique `Participant` must make the first publication
+
+ ./Err_UniqueFirstPublish.rsh:8:9:dot
+
+ 8|   Betas.publish();
+
+For further explanation of this error, see: https://docs.reach.sh/RE0120.html
+

--- a/hs/t/n/class_addr.rsh
+++ b/hs/t/n/class_addr.rsh
@@ -3,8 +3,12 @@
 export const main =
   Reach.App(
     {},
-    [ParticipantClass('C', {})],
-    (C) => {
+    [Participant('Constructor', {}),
+     ParticipantClass('C', {})],
+    (Constructor, C) => {
+      Constructor.publish();
+      commit();
+
       C.only(() => {
         const addr1 = this; });
       C.publish(addr1);

--- a/hs/t/n/class_addr.txt
+++ b/hs/t/n/class_addr.txt
@@ -4,23 +4,24 @@ Verifying for generic connector
 Verification failed:
   when ALL participants are honest
   of theorem: require
-  at ./class_addr.rsh:16:14:application
+  at ./class_addr.rsh:20:14:application
 
   // Violation Witness
 
-  const v38 = selfAddress(""C"", true, 15 );
+  const v47 = selfAddress(""C"", true, 20 );
   //    ^ could = <abstract address 0>
-  //      from: ./class_addr.rsh:8:13:application
-  const v45 = selfAddress(""C"", true, 24 );
+  //      from: ./class_addr.rsh:12:13:application
+  const v54 = selfAddress(""C"", true, 29 );
   //    ^ could = <abstract address 1>
-  //      from: ./class_addr.rsh:13:13:application
+  //      from: ./class_addr.rsh:17:13:application
 
   // Theorem Formalization
 
-  const v52 = v38 == v45;
+  const v61 = v47 == v54;
   //    ^ would be false
-  require(v52);
+  require(v61);
 
   Verifying when NO participants are honest
   Verifying when ONLY "C" is honest
-Checked 10 theorems; 1 failures :'(
+  Verifying when ONLY "Constructor" is honest
+Checked 14 theorems; 1 failures :'(

--- a/hs/t/n/race-other-shadow.rsh
+++ b/hs/t/n/race-other-shadow.rsh
@@ -6,8 +6,11 @@ export const main =
     [Participant('Alice', {}),
      Participant('Bob', {}),
      Participant('Claire', {}),
+     Participant('Constructor', {}),
     ],
-    (Alice, Bob, Claire) => {
+    (Alice, Bob, Claire, Constructor) => {
+      Constructor.publish();
+      commit();
       Alice.only(() => {
         const x = 1; });
       Bob.only(() => {

--- a/hs/t/n/race-other-shadow.txt
+++ b/hs/t/n/race-other-shadow.txt
@@ -1,8 +1,8 @@
-reachc: error[RE0056]: Invalid name shadowing. Identifier 'x' is already bound at ./race-other-shadow.rsh:16:15:id. It cannot be bound again at ./race-other-shadow.rsh:17:24:dot
+reachc: error[RE0056]: Invalid name shadowing. Identifier 'x' is already bound at ./race-other-shadow.rsh:19:15:id. It cannot be bound again at ./race-other-shadow.rsh:20:24:dot
 
- ./race-other-shadow.rsh:17:24:dot
+ ./race-other-shadow.rsh:20:24:dot
 
- 17|       race(Alice, Bob).publish(x);
+ 20|       race(Alice, Bob).publish(x);
 
 For further explanation of this error, see: https://docs.reach.sh/RE0056.html
 

--- a/hs/t/y/fork_no_timeout.rsh
+++ b/hs/t/y/fork_no_timeout.rsh
@@ -1,9 +1,12 @@
 'reach 0.1';
 
 export const main = Reach.App(() => {
+  const C = Participant('Constructor', {});
   const A = ParticipantClass('A', { go: Fun([], Bool), ok: Fun([], Null) });
   deploy();
 
+  C.publish();
+  commit();
 
   fork()
     .case(A,

--- a/hs/t/y/fork_no_timeout.txt
+++ b/hs/t/y/fork_no_timeout.txt
@@ -3,4 +3,5 @@ Verifying for generic connector
   Verifying when ALL participants are honest
   Verifying when NO participants are honest
   Verifying when ONLY "A" is honest
-Checked 6 theorems; No failures!
+  Verifying when ONLY "Constructor" is honest
+Checked 10 theorems; No failures!

--- a/hs/t/y/parallelReduce_no_timeout.rsh
+++ b/hs/t/y/parallelReduce_no_timeout.rsh
@@ -1,10 +1,14 @@
 'reach 0.1';
 
 export const main = Reach.App(() => {
+  const C = Participant('Constructor', { });
   const A = ParticipantClass('A', {
     go: Fun([], Bool),
     ok: Fun([], Null) });
   deploy();
+
+  C.publish();
+  commit();
 
   A.publish();
 

--- a/hs/t/y/parallelReduce_no_timeout.txt
+++ b/hs/t/y/parallelReduce_no_timeout.txt
@@ -3,4 +3,5 @@ Verifying for generic connector
   Verifying when ALL participants are honest
   Verifying when NO participants are honest
   Verifying when ONLY "A" is honest
-Checked 15 theorems; No failures!
+  Verifying when ONLY "Constructor" is honest
+Checked 21 theorems; No failures!

--- a/hs/t/y/pr-3e579.rsh
+++ b/hs/t/y/pr-3e579.rsh
@@ -11,7 +11,7 @@ export const main = Reach.App(() => {
   deploy();
   const arr = array(UInt, [0, 1, 2, 3, 4]);
 
-  Anybody.publish();
+  Alice.publish();
 
   const i = 8;
   const temp = i < 5 ? arr[i] : i;

--- a/hs/t/y/pr-3e579.txt
+++ b/hs/t/y/pr-3e579.txt
@@ -4,4 +4,4 @@ Verifying for generic connector
   Verifying when NO participants are honest
   Verifying when ONLY "Alice" is honest
   Verifying when ONLY "Bob" is honest
-Checked 12 theorems; No failures!
+Checked 7 theorems; No failures!


### PR DESCRIPTION
Have the compiler ensure that the first publication of a Reach program is made by a unique `Participant` and update documentation.