### PR TITLE
CORE-484: Disallow Mismatched Type `==` Comparisons

### DIFF
--- a/docs-src/guide-changelog.scrbl
+++ b/docs-src/guide-changelog.scrbl
@@ -11,6 +11,7 @@ Versions and changes-within-versions are listed in reverse-chronological order: 
 Version 0.1.5 is the current Reach release candidate version.
 
 @itemlist[
+@item{2021/10/4: Added @reachin{unstrict}.}
 @item{2021/09/25: Reach clients will detect that they are attempting to publish in a race that they cannot win and switch to listening for the publication of another.
 This has the impact of frontends not being asked to sign transactions that cannot possibly succeed.}
 @item{2021/09/25: Added @reachin{didPublish()}.}

--- a/docs-src/ref-programs-compute.scrbl
+++ b/docs-src/ref-programs-compute.scrbl
@@ -340,6 +340,7 @@ The correct way to write a program like this in @tech{strict mode} is to use @re
 
 @subsection{@tt{unstrict}}
 
+@(mint-define! '("unstrict"))
 @reach{
   assert(unstrict(() => {
     'use strict';

--- a/docs-src/ref-programs-compute.scrbl
+++ b/docs-src/ref-programs-compute.scrbl
@@ -338,6 +338,20 @@ The correct way to write a program like this in @tech{strict mode} is to use @re
   void foo(MObj.Some({ b : true }));
   void foo(MObj.None()); }
 
+@subsection{@tt{unstrict}}
+
+@reach{
+  assert(unstrict(() => {
+    'use strict';
+    // the following fails in strict mode due to a type mismatch
+    return 1 != true;
+  }));
+}
+
+@index{unstrict} @reachin{unstrict} applies a thunk, ignoring any usage of @tech{strict mode}. This
+can be useful when dealing with libraries that are written in @tech{strict mode}.
+
+
 @subsection{Identifier reference}
 
 @reach{

--- a/hs/rsh/stdlib.rsh
+++ b/hs/rsh/stdlib.rsh
@@ -6,9 +6,6 @@ export function not (x) {
   return (x ? false : true); }
 export const boolEq = (x, y) => (x ? y : !y);
 
-export function polyNeq (x, y) {
-  return not(x == y); }
-
 // Operator aliases
 export const add = (x, y) => x + y;
 export const sub = (x, y) => x - y;

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -677,7 +677,7 @@ data SLPrimitive
   | SLPrim_Token_destroyed
   | SLPrim_muldiv
   | SLPrim_didPublish
-  | SLPrim_Unstrict
+  | SLPrim_unstrict
   | SLPrim_polyNeq
   deriving (Eq, Generic)
 

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -677,6 +677,8 @@ data SLPrimitive
   | SLPrim_Token_destroyed
   | SLPrim_muldiv
   | SLPrim_didPublish
+  | SLPrim_Unstrict
+  | SLPrim_polyNeq
   deriving (Eq, Generic)
 
 instance Equiv SLPrimitive where

--- a/hs/src/Reach/Eval.hs
+++ b/hs/src/Reach/Eval.hs
@@ -41,6 +41,7 @@ compileDApp shared_lifts exports (SLV_Prim (SLPrim_App_Delay at top_s (top_env, 
           , sco_penvs = mempty
           , sco_cenv = top_env
           , sco_use_strict = top_use_strict
+          , sco_use_unstrict = False
           }
   init_dlo <- readDlo id
   envr <- liftIO $ newIORef $ AppEnv mempty init_dlo mempty
@@ -110,6 +111,7 @@ makeEnv cns = do
             sco_penvs = mempty
           , sco_cenv = mempty
           , sco_use_strict = False
+          , sco_use_unstrict = False
           }
   let e_depth = recursionDepthLimit
   let e_while_invariant = False

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -2985,9 +2985,8 @@ evalPrim p sargs =
       zero_args
       evalPrim (SLPrim_fluid_read FV_didSend) []
     SLPrim_unstrict -> do
-      one_arg >>= \case
-        clo@SLV_Clo {} -> locUseUnstrict True $ evalApply clo []
-        ow -> expect_t ow Err_Eval_NotApplicable
+      x <- one_arg
+      locUseUnstrict True $ evalApply x []
     SLPrim_polyNeq -> do
       (x, y) <- two_args
       notFn <- unaryToPrim (JSUnaryOpNot JSNoAnnot)

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -565,7 +565,7 @@ base_env =
     , ("setOptions", SLV_Prim SLPrim_setOptions)
     , (".adaptReachAppTupleArgs", SLV_Prim SLPrim_adaptReachAppTupleArgs)
     , ("muldiv", SLV_Prim $ SLPrim_op MUL_DIV)
-    , ("unstrict", SLV_Prim $ SLPrim_Unstrict)
+    , ("unstrict", SLV_Prim $ SLPrim_unstrict)
     , ( "Reach"
       , (SLV_Object srcloc_builtin (Just $ "Reach") $
            m_fromList_public_builtin
@@ -2984,14 +2984,9 @@ evalPrim p sargs =
       ensure_after_first
       zero_args
       evalPrim (SLPrim_fluid_read FV_didSend) []
-    SLPrim_Unstrict -> do
+    SLPrim_unstrict -> do
       one_arg >>= \case
-        SLV_Clo clo_at Nothing clo@(SLClo _ clo_args _ _) -> do
-          at <- withAt id
-          unless (null clo_args) $
-            expect_thrown clo_at $
-              Err_Apply_ArgCount at 0 (length clo_args)
-          locUseUnstrict True $ evalApply (SLV_Clo clo_at Nothing clo) []
+        clo@SLV_Clo {} -> locUseUnstrict True $ evalApply clo []
         ow -> expect_t ow Err_Eval_NotApplicable
     SLPrim_polyNeq -> do
       (x, y) <- two_args

--- a/hs/src/Reach/Eval/Module.hs
+++ b/hs/src/Reach/Eval/Module.hs
@@ -114,6 +114,7 @@ evalTopBody libm env exenv = \case
                  , sco_penvs = mempty
                  , sco_cenv = env
                  , sco_use_strict = use_strict
+                 , sco_use_unstrict = False
                  })
         smr <- locSco sco $ evalStmt [sm]
         case smr of

--- a/hs/t/n/Err_Eval_IllegalWait.txt
+++ b/hs/t/n/Err_Eval_IllegalWait.txt
@@ -1,11 +1,11 @@
 reachc: error[RE0027]: Cannot inspect consensus time until after first publication
 
-  reach standard library:589:31:application
+  reach standard library:586:31:application
 
   
 
 Trace:
-  in "relativeTime" from (reach standard library:585:52:function exp) at (./Err_Eval_IllegalWait.rsh:7:22:application)
+  in "relativeTime" from (reach standard library:582:52:function exp) at (./Err_Eval_IllegalWait.rsh:7:22:application)
 
 For further explanation of this error, see: https://docs.reach.sh/RE0027.html
 

--- a/hs/t/n/Err_Eval_IncompatibleStates.txt
+++ b/hs/t/n/Err_Eval_IncompatibleStates.txt
@@ -1,12 +1,12 @@
 WARNING: Using a bare value as a time argument is now deprecated. Please use relativeTime, absoluteTime, relativeSecs, or absoluteSecs at ./Err_Eval_IncompatibleStates.rsh:6:15:application
 reachc: error[RE0027]: Cannot inspect consensus time until after first publication
 
-  reach standard library:589:31:application
+  reach standard library:586:31:application
 
   
 
 Trace:
-  in "relativeTime" from (reach standard library:585:52:function exp) at (./Err_Eval_IncompatibleStates.rsh:6:15:application)
+  in "relativeTime" from (reach standard library:582:52:function exp) at (./Err_Eval_IncompatibleStates.rsh:6:15:application)
 
 For further explanation of this error, see: https://docs.reach.sh/RE0027.html
 

--- a/hs/t/n/Err_Invalid_Statement.txt
+++ b/hs/t/n/Err_Invalid_Statement.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0093]: Effects cannot be bound, got: <SLV_Form>
 
-  ./Err_Invalid_Statement.rsh:207:30:id
+  ./Err_Invalid_Statement.rsh:204:30:id
 
   
 

--- a/hs/t/n/Err_Prim_InvalidArg_Dynamic.txt
+++ b/hs/t/n/Err_Prim_InvalidArg_Dynamic.txt
@@ -1,11 +1,11 @@
 reachc: error[RE0054]: Invalid arg for Array_iota. The argument must be computable at compile time
 
-  reach standard library:218:13:application
+  reach standard library:215:13:application
 
   
 
 Trace:
-  in "sqrt" from (reach standard library:217:28:function exp) at (./Err_Prim_InvalidArg_Dynamic.rsh:9:20:application)
+  in "sqrt" from (reach standard library:214:28:function exp) at (./Err_Prim_InvalidArg_Dynamic.rsh:9:20:application)
   in [unknown function] from (./Err_Prim_InvalidArg_Dynamic.rsh:8:17:function exp) at (./Err_Prim_InvalidArg_Dynamic.rsh:8:13:application)
 
 For further explanation of this error, see: https://docs.reach.sh/RE0054.html

--- a/hs/t/n/Err_ToConsensus_NoTimeoutBlock.txt
+++ b/hs/t/n/Err_ToConsensus_NoTimeoutBlock.txt
@@ -1,12 +1,12 @@
 WARNING: Using a bare value as a time argument is now deprecated. Please use relativeTime, absoluteTime, relativeSecs, or absoluteSecs at ./Err_ToConsensus_NoTimeoutBlock.rsh:8:23:application
 reachc: error[RE0027]: Cannot inspect consensus time until after first publication
 
-  reach standard library:589:31:application
+  reach standard library:586:31:application
 
   
 
 Trace:
-  in "relativeTime" from (reach standard library:585:52:function exp) at (./Err_ToConsensus_NoTimeoutBlock.rsh:8:23:application)
+  in "relativeTime" from (reach standard library:582:52:function exp) at (./Err_ToConsensus_NoTimeoutBlock.rsh:8:23:application)
 
 For further explanation of this error, see: https://docs.reach.sh/RE0027.html
 

--- a/hs/t/n/fxsqrt.txt
+++ b/hs/t/n/fxsqrt.txt
@@ -5,8 +5,8 @@ Verification failed:
   when ALL participants are honest
   of theorem: assert
   msg: "fxsqrt: Cannot find the square root of a negative number."
-  at reach standard library:336:9:application
-  at ./fxsqrt.rsh:10:30:application call to "fxsqrt" (defined at: reach standard library:335:30:function exp)
+  at reach standard library:333:9:application
+  at ./fxsqrt.rsh:10:30:application call to "fxsqrt" (defined at: reach standard library:332:30:function exp)
   at ./fxsqrt.rsh:9:13:application call to [unknown function] (defined at: ./fxsqrt.rsh:9:17:function exp)
 
   assert(false);

--- a/hs/t/n/pr-671006p.txt
+++ b/hs/t/n/pr-671006p.txt
@@ -16,7 +16,7 @@ Verification failed:
   //      from: ./pr-671006p.rsh:31:37:while
   const v218 = <map reduction>;
   //    ^ could = 1
-  //      from: reach standard library:146:18:application
+  //      from: reach standard library:143:18:application
 
   // Theorem Formalization
 


### PR DESCRIPTION
Do not allow comparing values for equality if they are not of the same type. If the values do not have runtime type representations, then the Haskell AST will be tested for equality.

Added a new primitive `unstrict : () -> a` that runs a thunk ignoring any usage of strict mode. 

Turned `polyNeq` into a primitive so it'll use the users program state to determine whether or not to evaluate in strict mode.

# 

`polyNeq` was defined in the stdlib in strict mode. So, a program not in strict mode would still receive this restriction on equality comparison. Inversely, if `polyNeq` used `unstrict` then programs in strict mode would not have the restriction on eq cmp.  Now, `==` and `!=` will behave similarly in a user's program.
