### PR TITLE
CORE-20: Add `Contract` Type

### DIFF
--- a/docs-src/guide-changelog.scrbl
+++ b/docs-src/guide-changelog.scrbl
@@ -11,6 +11,7 @@ Versions and changes-within-versions are listed in reverse-chronological order: 
 Version 0.1.5 is the current Reach release candidate version.
 
 @itemlist[
+@item{2021/10/5: Added @reachin{Contract}. Updated @jsin{ctc.getInfo} to return a @reachin{Contract}.}
 @item{2021/10/4: Added @reachin{unstrict}.}
 @item{2021/09/25: Reach clients will detect that they are attempting to publish in a race that they cannot win and switch to listening for the publication of another.
 This has the impact of frontends not being asked to sign transactions that cannot possibly succeed.}

--- a/docs-src/ref-frontends-js.scrbl
+++ b/docs-src/ref-frontends-js.scrbl
@@ -333,7 +333,7 @@ To wait for deployment, see @reachin{ctc.getInfo}.
 @js{
  ctc.getInfo() => Promise<ctcInfo> }
 
-@index{ctc.getInfo} Returns a Promise for an object that may be given to @jsin{attach} to construct a Reach @tech{contract} abstraction representing this contract.
+@index{ctc.getInfo} Returns a Promise for a @reachin{Contract} that may be given to @jsin{attach} to construct a Reach @tech{contract} abstraction representing this contract.
 This object may be stringified with @jsin{JSON.stringify} for printing and parsed again with @jsin{JSON.parse} without any loss of information.
 The Promise will only be resolved after the contract is actually deployed on the network.
 You cannot block on this Promise with @jsin{await} until after the first @reachin{publish} has occurred.

--- a/docs-src/ref-frontends-js.scrbl
+++ b/docs-src/ref-frontends-js.scrbl
@@ -25,6 +25,7 @@ These libraries provide a standard interface that support developing @tech{front
 @section[#:tag "ref-frontends-js-types"]{Types}
 
 The table below shows the JavaScript representation of each of the Reach types:
+@(mint-define! '("Contract"))
 @js{
  // Reach  => JavaScript
  Null      => null
@@ -33,6 +34,7 @@ The table below shows the JavaScript representation of each of the Reach types:
  Bytes     => 'string'
  Digest    => 'BigNumber'
  Address   => NetworkAccount
+ Contract  => Address on ETH; UInt on ALGO
  Token     => Address on ETH; UInt on ALGO
  Array     => array
  Tuple     => array
@@ -46,7 +48,7 @@ For example, the Reach type @reachin{MInt = Data({None: Null, Some: UInt})} inha
 @(hrule)
 @(mint-define! '("Connector"))
 @js{
-  type Connector = 'ETH' | 'ALGO'
+  type Connector = 'ETH' | 'ALGO' | 'CFX'
 }
 
 A @reachin{Connector} is the abbreviated name of the network
@@ -333,7 +335,7 @@ To wait for deployment, see @reachin{ctc.getInfo}.
 @js{
  ctc.getInfo() => Promise<ctcInfo> }
 
-@index{ctc.getInfo} Returns a Promise for a @reachin{Contract} that may be given to @jsin{attach} to construct a Reach @tech{contract} abstraction representing this contract.
+@index{ctc.getInfo} Returns a Promise for a @jsin{Contract} that may be given to @jsin{attach} to construct a Reach @tech{contract} abstraction representing this contract.
 This object may be stringified with @jsin{JSON.stringify} for printing and parsed again with @jsin{JSON.parse} without any loss of information.
 The Promise will only be resolved after the contract is actually deployed on the network.
 You cannot block on this Promise with @jsin{await} until after the first @reachin{publish} has occurred.

--- a/docs-src/ref-programs-compute.scrbl
+++ b/docs-src/ref-programs-compute.scrbl
@@ -397,7 +397,7 @@ Reach's @deftech{type}s are represented in programs by the following identifiers
   @item{
     @margin-note{Reach has different representations of @tech{contract}s across @tech{connector}s.
       For example, on Algorand a @reachin{Contract} is an Application ID, but on Ethereum it is an Address.}
-    @(mint-define! '("Contract")) @reachin{Contract}, which denotes the connection information for a @tech{contract}.}
+    @(mint-define! '("Contract")) @reachin{Contract}, which denotes the identifying information of a @tech{contract}.}
   @item{@(mint-define! '("Token")) @reachin{Token}, which denotes a @tech{non-network token}. @secref["ref-networks"]{} discusses how @reachin{Token}s are represented on specific networks.}
   @item{@(mint-define! '("Fun")) @reachin{Fun([Domain_0, ..., Domain_N], Range)}, which denotes a @deftech{function type}, when @reachin{Domain_i} and @reachin{Range} are types.
   The domain of a function is @tech{negative position}.

--- a/docs-src/ref-programs-compute.scrbl
+++ b/docs-src/ref-programs-compute.scrbl
@@ -394,6 +394,10 @@ Reach's @deftech{type}s are represented in programs by the following identifiers
   Bytes of different lengths are not compatible; however the shorter bytes may be @tech{padded}.}
   @item{@(mint-define! '("Digest")) @reachin{Digest}, which denotes a @tech{digest}.}
   @item{@(mint-define! '("Address")) @reachin{Address}, which denotes an @tech{account} @tech{address}.}
+  @item{
+    @margin-note{Reach has different representations of @tech{contract}s across @tech{connector}s.
+      For example, on Algorand a @reachin{Contract} is an Application ID, but on Ethereum it is an Address.}
+    @(mint-define! '("Contract")) @reachin{Contract}, which denotes the connection information for a @tech{contract}.}
   @item{@(mint-define! '("Token")) @reachin{Token}, which denotes a @tech{non-network token}. @secref["ref-networks"]{} discusses how @reachin{Token}s are represented on specific networks.}
   @item{@(mint-define! '("Fun")) @reachin{Fun([Domain_0, ..., Domain_N], Range)}, which denotes a @deftech{function type}, when @reachin{Domain_i} and @reachin{Range} are types.
   The domain of a function is @tech{negative position}.

--- a/docs-src/ref-programs-consensus.scrbl
+++ b/docs-src/ref-programs-consensus.scrbl
@@ -369,7 +369,7 @@ has been called on @reachin{tok} yet.
 @(mint-define! '("remote"))
 @reach{
   const randomOracle =
-    remote( randomOracleAddr, {
+    remote( randomOracleCtcInfo, {
       getRandom: Fun([], UInt),
     });
   const randomVal = randomOracle.getRandom.pay(randomFee)();
@@ -382,16 +382,16 @@ has been called on @reachin{tok} yet.
 A @deftech{remote object} represents a foreign @tech{contract} in a Reach application.
 During a @tech{consensus step}, a Reach computation may consensually communicate with such an object via a prescribed interface.
 
-A @tech{remote object} is constructed by calling the @reachin{remote} function with an @tech{address} and an interface---an object where each key is bound to a @tech{function type}. For example:
+A @tech{remote object} is constructed by calling the @reachin{remote} function with a @reachin{Contract} and an interface---an object where each key is bound to a @tech{function type}. For example:
 @reach{
   const randomOracle =
-    remote( randomOracleAddr, {
+    remote( randomOracleCtcInfo, {
       getRandom: Fun([], UInt),
     });
   const token =
-    remote( tokenAddr, {
+    remote( tokenCtcInfo, {
       balanceOf: Fun([Address], UInt),
-      transferTo: Fun([UInt, Addres], Null),
+      transferTo: Fun([UInt, Address], Null),
     });
 }
 

--- a/examples/remote/index.mjs
+++ b/examples/remote/index.mjs
@@ -50,8 +50,8 @@ import launchToken from '@reach-sh/stdlib/launchToken.mjs';
 
   await Promise.all([
     backend.Alice(ctcAlice, {
-      getAddr: (() => remoteAddr),
-      getCT: (() => [ amt, remoteAddr ]),
+      getCTX: (() => remoteAddr),
+      getCTY: (() => [ amt, remoteAddr ]),
       getGIL: (() => gil.id),
       getZMD: (() => zorkmid.id),
     }),

--- a/examples/remote/index.rsh
+++ b/examples/remote/index.rsh
@@ -17,8 +17,8 @@ const CoolThing = {
 export const main = Reach.App(
   {},
   [ Participant('Alice', {
-      getAddr: Fun([], Address),
-      getCT: Fun([], Tuple(UInt, Address)),
+      getCTX: Fun([], Contract),
+      getCTY: Fun([], Tuple(UInt, Contract)),
       getGIL: Fun([], Token),
       getZMD: Fun([], Token),
     }),
@@ -30,8 +30,8 @@ export const main = Reach.App(
   ],
   (A, B) => {
     A.only(() => {
-      const ctxa = declassify(interact.getAddr());
-      const [amt, ctya] = declassify(interact.getCT()); });
+      const ctxa = declassify(interact.getCTX());
+      const [amt, ctya] = declassify(interact.getCTY()); });
     A.publish(ctxa, amt, ctya).pay(amt);
     const ctx = remote(ctxa, CoolThing);
     const cty = remote(ctya, CoolThing);

--- a/hs/smt2/runtime.smt2
+++ b/hs/smt2/runtime.smt2
@@ -69,3 +69,6 @@
 ;;  (forall ((x Token) (y Token))
 ;;          (=> (not (= x y))
 ;;              (not (= (Token_toBytes x) (Token_toBytes y))))))
+
+(declare-sort Contract 0)
+(declare-fun Contract_toBytes (Contract) Bytes)

--- a/hs/src/Reach/AST/DLBase.hs
+++ b/hs/src/Reach/AST/DLBase.hs
@@ -45,6 +45,7 @@ data DLType
   | T_Bytes Integer
   | T_Digest
   | T_Address
+  | T_Contract
   | T_Token
   | T_Array DLType Integer
   | T_Tuple [DLType]
@@ -92,18 +93,20 @@ showTyList = List.intercalate ", " . map showPair
     showPair (name, ty) = "['" <> show name <> "', " <> show ty <> "]"
 
 instance Show DLType where
-  show T_Null = "Null"
-  show T_Bool = "Bool"
-  show T_UInt = "UInt"
-  show (T_Bytes sz) = "Bytes(" <> show sz <> ")"
-  show T_Digest = "Digest"
-  show T_Address = "Address"
-  show T_Token = "Token"
-  show (T_Array ty i) = "Array(" <> show ty <> ", " <> show i <> ")"
-  show (T_Tuple tys) = "Tuple(" <> showTys tys <> ")"
-  show (T_Object tyMap) = "Object({" <> showTyMap tyMap <> "})"
-  show (T_Data tyMap) = "Data({" <> showTyMap tyMap <> "})"
-  show (T_Struct tys) = "Struct([" <> showTyList tys <> "])"
+  show = \case
+    T_Null -> "Null"
+    T_Bool -> "Bool"
+    T_UInt -> "UInt"
+    (T_Bytes sz) -> "Bytes(" <> show sz <> ")"
+    T_Digest -> "Digest"
+    T_Address -> "Address"
+    T_Contract -> "Contract"
+    T_Token -> "Token"
+    (T_Array ty i) -> "Array(" <> show ty <> ", " <> show i <> ")"
+    (T_Tuple tys) -> "Tuple(" <> showTys tys <> ")"
+    (T_Object tyMap) -> "Object({" <> showTyMap tyMap <> "})"
+    (T_Data tyMap) -> "Data({" <> showTyMap tyMap <> "})"
+    (T_Struct tys) -> "Struct([" <> showTyList tys <> "])"
 
 instance Pretty DLType where
   pretty = viaShow

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -28,6 +28,7 @@ data SLType
   | ST_Bytes Integer
   | ST_Digest
   | ST_Address
+  | ST_Contract
   | ST_Token
   | ST_Array SLType Integer
   | ST_Tuple [SLType]
@@ -58,6 +59,7 @@ instance Show SLType where
     ST_Bytes sz -> "Bytes(" <> show sz <> ")"
     ST_Digest -> "Digest"
     ST_Address -> "Address"
+    ST_Contract -> "Contract"
     ST_Token -> "Token"
     ST_Array ty i -> "Array(" <> show ty <> ", " <> show i <> ")"
     ST_Tuple tys -> "Tuple(" <> showTys tys <> ")"
@@ -84,6 +86,7 @@ st2dt = \case
   ST_Bytes i -> pure $ T_Bytes i
   ST_Digest -> pure T_Digest
   ST_Address -> pure T_Address
+  ST_Contract -> pure T_Contract
   ST_Token -> pure T_Token
   ST_Array ty i -> T_Array <$> st2dt ty <*> pure i
   ST_Tuple tys -> T_Tuple <$> traverse st2dt tys
@@ -103,6 +106,7 @@ dt2st = \case
   T_Bytes i -> ST_Bytes i
   T_Digest -> ST_Digest
   T_Address -> ST_Address
+  T_Contract -> ST_Contract
   T_Token -> ST_Token
   T_Array ty i -> ST_Array (dt2st ty) i
   T_Tuple tys -> ST_Tuple $ map dt2st tys
@@ -302,6 +306,7 @@ instance Equiv SLType where
     (ST_UInt, ST_UInt) -> True
     (ST_Digest, ST_Digest) -> True
     (ST_Address, ST_Address) -> True
+    (ST_Contract, ST_Contract) -> True
     (ST_Token, ST_Token) -> True
     ((ST_Bytes i), (ST_Bytes i2)) -> equiv i i2
     ((ST_Array s1 _len1), (ST_Array s2 _len2)) -> equiv s1 s2

--- a/hs/src/Reach/Backend/JS.hs
+++ b/hs/src/Reach/Backend/JS.hs
@@ -141,6 +141,7 @@ jsContract_ = \case
     return $ jsApply "stdlib.T_Bytes" [sz']
   T_Digest -> return $ "stdlib.T_Digest"
   T_Address -> return $ "stdlib.T_Address"
+  T_Contract -> return $ "stdlib.T_Contract"
   T_Token -> return $ "stdlib.T_Token"
   T_Array t sz -> do
     t' <- jsContract t

--- a/hs/src/Reach/CollectTypes.hs
+++ b/hs/src/Reach/CollectTypes.hs
@@ -53,6 +53,7 @@ instance CollectsTypes DLType where
         T_Bytes _ -> mempty
         T_Digest -> mempty
         T_Address -> mempty
+        T_Contract -> mempty
         T_Token -> mempty
         T_Array e _ -> cts e
         T_Tuple elems -> cts elems

--- a/hs/src/Reach/Connector/ALGO.hs
+++ b/hs/src/Reach/Connector/ALGO.hs
@@ -153,6 +153,7 @@ typeSizeOf = \case
   T_Bytes sz -> sz
   T_Digest -> 32
   T_Address -> 32
+  T_Contract -> typeSizeOf $ T_UInt
   T_Token -> typeSizeOf $ T_UInt
   T_Array t sz -> sz * typeSizeOf t
   T_Tuple ts -> sum $ map typeSizeOf ts
@@ -565,6 +566,7 @@ ctobs = \case
   T_Bytes _ -> nop
   T_Digest -> nop
   T_Address -> nop
+  T_Contract -> ctobs T_UInt
   T_Token -> ctobs T_UInt
   T_Array {} -> nop
   T_Tuple {} -> nop
@@ -580,6 +582,7 @@ cfrombs = \case
   T_Bytes _ -> nop
   T_Digest -> nop
   T_Address -> nop
+  T_Contract -> cfrombs T_UInt
   T_Token -> cfrombs T_UInt
   T_Array {} -> nop
   T_Tuple {} -> nop

--- a/hs/src/Reach/Connector/ETH_Solidity.hs
+++ b/hs/src/Reach/Connector/ETH_Solidity.hs
@@ -436,6 +436,7 @@ mustBeMem = \case
   T_Bytes _ -> True
   T_Digest -> False
   T_Address -> False
+  T_Contract -> False
   T_Token -> False
   T_Array {} -> True
   T_Tuple {} -> True
@@ -1102,6 +1103,7 @@ solDefineType t = case t of
     addMap $ "uint8[" <> pretty sz <> "]"
   T_Digest -> base
   T_Address -> base
+  T_Contract -> base
   T_Token -> base
   T_Array _ 0 -> do
     addMap "bool"
@@ -1205,6 +1207,7 @@ solPLProg (PLProg _ plo dli _ _ (CPProg at (vs, vi) hs)) = do
           , (T_UInt, "uint256")
           , (T_Digest, "uint256")
           , (T_Address, "address")
+          , (T_Contract, "address")
           , (T_Token, "address")
           ]
   ctxt_typem <- newIORef base_typem

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -527,6 +527,7 @@ base_env =
     , ("Bool", SLV_Type ST_Bool)
     , ("UInt", SLV_Type ST_UInt)
     , ("Bytes", SLV_Prim SLPrim_Bytes)
+    , ("Contract", SLV_Type ST_Contract)
     , ("Address", SLV_Type ST_Address)
     , ("Token", SLV_Type ST_Token)
     , ("forall", SLV_Prim SLPrim_forall)
@@ -2832,7 +2833,7 @@ evalPrim p sargs =
     SLPrim_remote -> do
       ensure_modes [SLM_ConsensusStep, SLM_ConsensusPure] "remote"
       (av, ri) <- two_args
-      aa <- compileCheckType T_Address av
+      aa <- compileCheckType T_Contract av
       rm_ <- mustBeObject ri
       rm <- mapWithKeyM (\ k v -> do
         locAt (sss_at v) $
@@ -4079,6 +4080,7 @@ typeToExpr = \case
   T_Bytes i -> call "Bytes" [ie i]
   T_Digest -> var "Digest"
   T_Address -> var "Address"
+  T_Contract -> var "Contract"
   T_Token -> var "Token"
   T_Array t i -> call "Array" [r t, ie i]
   T_Tuple ts -> call "Tuple" $ map r ts

--- a/hs/src/Reach/Verify/SMT.hs
+++ b/hs/src/Reach/Verify/SMT.hs
@@ -425,7 +425,11 @@ parseVal env t v = do
         T_Token -> do
           case v of
             Atom i -> return $ SMV_Token i
-            _ -> impossible $ "parseVal: Digest: " <> show v
+            _ -> impossible $ "parseVal: Token: " <> show v
+        T_Contract -> do
+          case v of
+            Atom i -> return $ SMV_Contract i
+            _ -> impossible $ "parseVal: Contract: " <> show v
         T_Address -> do
           let err = impossible $ "parseVal: Address: " <> show v
           case v of
@@ -1364,6 +1368,7 @@ _smtDefineTypes smt ts = do
          , (T_UInt, ("UInt", uint256_inv))
          , (T_Digest, ("Digest", none))
          , (T_Address, ("Address", none))
+         , (T_Contract, ("Contract", none))
          , (T_Token, ("Token", none))
          ])
   let base = impossible "default"
@@ -1376,6 +1381,7 @@ _smtDefineTypes smt ts = do
           T_Bytes {} -> base
           T_Digest -> base
           T_Address -> base
+          T_Contract -> base
           T_Token -> base
           T_Array et sz -> do
             tni <- type_name et

--- a/hs/src/Reach/Verify/SMTAst.hs
+++ b/hs/src/Reach/Verify/SMTAst.hs
@@ -253,6 +253,7 @@ data SMTVal
   | SMV_Object (M.Map String SMTVal)
   | SMV_Data String [SMTVal]
   | SMV_Token String
+  | SMV_Contract String
   | SMV_Map
   deriving (Eq, Show)
 
@@ -261,6 +262,7 @@ instance Pretty SMTVal where
     SMV_Bool b -> pretty $ DLL_Bool b
     SMV_Int i -> pretty i
     SMV_Address p -> "<abstract address" <+> pretty p <> ">"
+    SMV_Contract p -> pretty p
     SMV_Digest p -> pretty p
     SMV_Token p -> pretty p
     SMV_Null -> "null"

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -41,7 +41,7 @@ import {
   bigNumberToNumber,
 } from './shared_user';
 import {
-  CBR_Address, CBR_Contract, CBR_Val,
+  CBR_Address, CBR_Val,
 } from './CBR';
 import waitPort from './waitPort';
 import {
@@ -116,13 +116,13 @@ type BackendViewsInfo = IBackendViewsInfo<AnyALGO_Ty>;
 type BackendViewInfo = IBackendViewInfo<AnyALGO_Ty>;
 
 type CompiledBackend = {
-  ApplicationID: CBR_Contract,
+  ApplicationID: number,
   appApproval: CompileResultBytes,
   appClear: CompileResultBytes,
   escrow: CompileResultBytes,
 };
 
-type ContractInfo = CBR_Contract;
+type ContractInfo = number;
 type SendRecvArgs = ISendRecvArgs<Address, Token, AnyALGO_Ty>;
 type RecvArgs = IRecvArgs<AnyALGO_Ty>;
 type Recv = IRecv<Address>
@@ -880,7 +880,7 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
   const attachP = async (bin: Backend, ctcInfoP: Promise<ContractInfo>, eventCache = new EventCache(), vr?: VerifyResult|undefined): Promise<Contract> => {
     const ctcInfo = await ctcInfoP;
     const ctorRan = new Signal();
-    const getInfo = async (): Promise<CBR_Contract> => {
+    const getInfo = async (): Promise<ContractInfo> => {
       await ctorRan.wait();
       return ctcInfo;
     };
@@ -1409,7 +1409,7 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
     debug(label, 'deploy');
     const algob = bin._Connectors.ALGO;
     const { stateKeys, mapDataKeys } = algob;
-    const { appApproval, appClear } = await compileFor(bin, T_Contract.canonicalize(0));
+    const { appApproval, appClear } = await compileFor(bin, 0);
     const extraPages =
       Math.ceil((appClear.result.length + appApproval.result.length) / MaxAppProgramLen) - 1;
 
@@ -1435,7 +1435,7 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
       throw Error(`No application-index in ${JSON.stringify(createRes)}`);
     }
     debug(`created`, {ApplicationID});
-    const ctcInfo = T_Contract.canonicalize(ApplicationID);
+    const ctcInfo = ApplicationID;
     const eventCache = new EventCache();
 
     const compiled = await compileFor(bin, ctcInfo);

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -337,8 +337,8 @@ const MaxAppTxnAccounts = 4;
 const MaxExtraAppProgramPages = 3;
 
 async function compileFor(bin: Backend, info: ContractInfo): Promise<CompiledBackend> {
-  debug(`compileFor`, info, typeof(info), Number.isInteger(Number(info)));
-  if ( ! Number.isInteger(Number(info)) ) {
+  debug(`compileFor`, info, typeof(info), Number.isInteger(info));
+  if ( ! Number.isInteger(info) ) {
     throw Error(`This Reach standard library cannot communicate with this contract, because it was deployed with an earlier version of Reach.`); }
   const ApplicationID = info;
   must_be_supported(bin);
@@ -1691,8 +1691,7 @@ export const verifyContract = async (info: ContractInfo, bin: Backend): Promise<
 
 const verifyContract_ = async (label:string, info: ContractInfo, bin: Backend, eventCache: EventCache): Promise<VerifyResult> => {
   const compiled = await compileFor(bin, info);
-  const { appApproval, appClear } = compiled;
-  const ApplicationID = Number(compiled.ApplicationID);
+  const { ApplicationID, appApproval, appClear } = compiled;
   const { mapDataKeys, stateKeys } = bin._Connectors.ALGO;
 
   let dhead = `${label}: verifyContract`;

--- a/js/stdlib/ts/ALGO_compiled.ts
+++ b/js/stdlib/ts/ALGO_compiled.ts
@@ -20,7 +20,6 @@ import {
   CBR_UInt,
   CBR_Bytes,
   CBR_Address,
-  CBR_Contract,
   CBR_Digest,
   CBR_Object,
   CBR_Data,
@@ -145,19 +144,9 @@ export const T_Address: ALGO_Ty<CBR_Address> = {
   }
 };
 
-export const T_Contract: ALGO_Ty<CBR_Contract> = {
-  ...CBR.BT_Contract,
-  netSize: 8,
-  toNet: (bv: CBR_Contract): NV => {
-    try {
-      return ethers.utils.zeroPad(ethers.utils.arrayify(bv), 8)
-    } catch (e) {
-      throw new Error(`toNet: ${bv} is out of range [0, ${UInt_max}]`);
-    }
-  },
-  fromNet: (nv: NV): CBR_Contract => {
-    return ethers.BigNumber.from(nv).toString();
-  },
+export const T_Contract: ALGO_Ty<Contract> = {
+  ...T_UInt,
+  name: 'Contract',
 };
 
 export const T_Array = (
@@ -301,7 +290,11 @@ export const T_Data = (
 export const addressEq = mkAddressEq(T_Address);
 
 const T_Token = T_UInt;
+
 export type Token = CBR_UInt;
+
+export type Contract = CBR_UInt;
+
 export const tokenEq = (x: unknown, y: unknown): boolean =>
   T_Token.canonicalize(x).eq(T_Token.canonicalize(y));
 export type PayAmt = MkPayAmt<Token>;

--- a/js/stdlib/ts/ALGO_compiled.ts
+++ b/js/stdlib/ts/ALGO_compiled.ts
@@ -20,6 +20,7 @@ import {
   CBR_UInt,
   CBR_Bytes,
   CBR_Address,
+  CBR_Contract,
   CBR_Digest,
   CBR_Object,
   CBR_Data,
@@ -142,6 +143,21 @@ export const T_Address: ALGO_Ty<CBR_Address> = {
     // We are filling up with zeros if the address is less than 32 bytes
     return hs.padEnd(32*2+2, '0');
   }
+};
+
+export const T_Contract: ALGO_Ty<CBR_Contract> = {
+  ...CBR.BT_Contract,
+  netSize: 8,
+  toNet: (bv: CBR_Contract): NV => {
+    try {
+      return ethers.utils.zeroPad(ethers.utils.arrayify(bv), 8)
+    } catch (e) {
+      throw new Error(`toNet: ${bv} is out of range [0, ${UInt_max}]`);
+    }
+  },
+  fromNet: (nv: NV): CBR_Contract => {
+    return ethers.BigNumber.from(nv).toString();
+  },
 };
 
 export const T_Array = (
@@ -296,13 +312,14 @@ export const typeDefs = {
   T_UInt,
   T_Bytes,
   T_Address,
+  T_Contract,
   T_Digest,
   T_Token,
   T_Object,
   T_Data,
   T_Array,
   T_Tuple,
-  T_Struct
+  T_Struct,
 };
 
 const arith = makeArith(UInt_max);

--- a/js/stdlib/ts/CBR.ts
+++ b/js/stdlib/ts/CBR.ts
@@ -17,6 +17,7 @@ export type CBR_Bool = boolean;
 export type CBR_UInt = BigNumber;
 export type CBR_Bytes = string;
 export type CBR_Address = string;
+export type CBR_Contract = string;
 export type CBR_Digest = string;
 export type CBR_Object = {[key: string]: CBR_Val};
 export type CBR_Data = [string, CBR_Val];
@@ -30,6 +31,7 @@ export type CBR_Val =
   CBR_UInt |
   CBR_Bytes |
   CBR_Address |
+  CBR_Contract |
   CBR_Digest |
   CBR_Object |
   CBR_Data |
@@ -140,6 +142,27 @@ export const BT_Address: BackendTy<CBR_Address> = ({
 // XXX: don't use this. Use net-specific ones
 export const BV_Address = (val: string): CBR_Address => {
   return BT_Address.canonicalize(val);
+}
+
+export const BT_Contract: BackendTy<CBR_Contract> = ({
+  name: 'Contract',
+  canonicalize: (val: unknown): CBR_Contract => {
+    if (typeof val === 'string') {
+      if (val.slice(0, 2) !== '0x') {
+        throw Error(`Contract must start with 0x, but got: ${JSON.stringify(val)}`);
+      } else if (!ethers.utils.isHexString(val)) {
+        throw Error(`Contract must be a valid hex string, but got: ${JSON.stringify(val)}`);
+      }
+      return val;
+    }
+    if (typeof val === 'number' || typeof val == 'bigint' || val instanceof BigNumber) {
+      return val.toString();
+    }
+    throw Error(`Contract must be a 'string', 'number', 'bigint', or BigNumber, but got: ${typeof val}`);
+  },
+});
+export const BV_Contract = (val: string): CBR_Contract => {
+  return BT_Contract.canonicalize(val);
 }
 
 export const BT_Array = (ctc: BackendTy<CBR_Val> , size: number): BackendTy<CBR_Array> => {

--- a/js/stdlib/ts/CBR.ts
+++ b/js/stdlib/ts/CBR.ts
@@ -17,7 +17,6 @@ export type CBR_Bool = boolean;
 export type CBR_UInt = BigNumber;
 export type CBR_Bytes = string;
 export type CBR_Address = string;
-export type CBR_Contract = string;
 export type CBR_Digest = string;
 export type CBR_Object = {[key: string]: CBR_Val};
 export type CBR_Data = [string, CBR_Val];
@@ -31,7 +30,6 @@ export type CBR_Val =
   CBR_UInt |
   CBR_Bytes |
   CBR_Address |
-  CBR_Contract |
   CBR_Digest |
   CBR_Object |
   CBR_Data |
@@ -144,26 +142,6 @@ export const BV_Address = (val: string): CBR_Address => {
   return BT_Address.canonicalize(val);
 }
 
-export const BT_Contract: BackendTy<CBR_Contract> = ({
-  name: 'Contract',
-  canonicalize: (val: unknown): CBR_Contract => {
-    if (typeof val === 'string') {
-      if (val.slice(0, 2) !== '0x') {
-        throw Error(`Contract must start with 0x, but got: ${JSON.stringify(val)}`);
-      } else if (!ethers.utils.isHexString(val)) {
-        throw Error(`Contract must be a valid hex string, but got: ${JSON.stringify(val)}`);
-      }
-      return val;
-    }
-    if (typeof val === 'number' || typeof val == 'bigint' || val instanceof BigNumber) {
-      return val.toString();
-    }
-    throw Error(`Contract must be a 'string', 'number', 'bigint', or BigNumber, but got: ${typeof val}`);
-  },
-});
-export const BV_Contract = (val: string): CBR_Contract => {
-  return BT_Contract.canonicalize(val);
-}
 
 export const BT_Array = (ctc: BackendTy<CBR_Val> , size: number): BackendTy<CBR_Array> => {
   // TODO: check ctc, sz for sanity

--- a/js/stdlib/ts/CBR.ts
+++ b/js/stdlib/ts/CBR.ts
@@ -142,7 +142,6 @@ export const BV_Address = (val: string): CBR_Address => {
   return BT_Address.canonicalize(val);
 }
 
-
 export const BT_Array = (ctc: BackendTy<CBR_Val> , size: number): BackendTy<CBR_Array> => {
   // TODO: check ctc, sz for sanity
   return {

--- a/js/stdlib/ts/CFX_compiled.ts
+++ b/js/stdlib/ts/CFX_compiled.ts
@@ -24,6 +24,7 @@ export const {
   T_UInt,
   T_Bytes,
   T_Address,
+  T_Contract,
   T_Digest,
   T_Token,
   T_Object,

--- a/js/stdlib/ts/ETH_compiled.ts
+++ b/js/stdlib/ts/ETH_compiled.ts
@@ -29,6 +29,7 @@ export const {
   T_UInt,
   T_Bytes,
   T_Address,
+  T_Contract,
   T_Digest,
   T_Token,
   T_Object,

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -53,7 +53,6 @@ import type { // =>
 import type { // =>
   Stdlib_Backend
 } from './interfaces';
-import { CBR_Contract } from './CBR';
 
 // ****************************************************************************
 // Type Definitions
@@ -88,7 +87,7 @@ type NetworkAccount = {
   getBalance?: (...xs: any) => any, // TODO: better type
 } | EthersLikeWallet | EthersLikeSigner; // required to deploy/attach
 
-type ContractInfo = CBR_Contract;
+type ContractInfo = Address;
 type SendRecvArgs = ISendRecvArgs<Address, Token, AnyETH_Ty>;
 type RecvArgs = IRecvArgs<AnyETH_Ty>;
 type Recv = IRecv<Address>
@@ -685,7 +684,7 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
       return res.evt;
     }
 
-    const getInfo = async (): Promise<CBR_Contract> => await infoP;
+    const getInfo = async (): Promise<ContractInfo> => await infoP;
 
     const canIWin = async (lct:BigNumber): Promise<boolean> => {
       const ethersC = await getC();

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -53,6 +53,7 @@ import type { // =>
 import type { // =>
   Stdlib_Backend
 } from './interfaces';
+import { CBR_Contract } from './CBR';
 
 // ****************************************************************************
 // Type Definitions
@@ -87,7 +88,7 @@ type NetworkAccount = {
   getBalance?: (...xs: any) => any, // TODO: better type
 } | EthersLikeWallet | EthersLikeSigner; // required to deploy/attach
 
-type ContractInfo = Address;
+type ContractInfo = CBR_Contract;
 type SendRecvArgs = ISendRecvArgs<Address, Token, AnyETH_Ty>;
 type RecvArgs = IRecvArgs<AnyETH_Ty>;
 type Recv = IRecv<Address>
@@ -684,7 +685,7 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
       return res.evt;
     }
 
-    const getInfo = async () => await infoP;
+    const getInfo = async (): Promise<CBR_Contract> => await infoP;
 
     const canIWin = async (lct:BigNumber): Promise<boolean> => {
       const ethersC = await getC();

--- a/js/stdlib/ts/ETH_like_compiled.ts
+++ b/js/stdlib/ts/ETH_like_compiled.ts
@@ -346,6 +346,11 @@ const V_Data = <T>(
   return T_Data(co).canonicalize(val);
 };
 
+const T_Contract = {
+  ...T_Address,
+  name: 'Contract'
+};
+
 const addressEq = mkAddressEq(T_Address);
 
 const T_Token = T_Address;
@@ -357,6 +362,7 @@ const typeDefs: TypeDefs = {
   T_UInt,
   T_Bytes,
   T_Address,
+  T_Contract,
   T_Digest,
   T_Token,
   T_Object,

--- a/js/stdlib/ts/interfaces.ts
+++ b/js/stdlib/ts/interfaces.ts
@@ -10,6 +10,7 @@ export interface TypeDefs {
   T_UInt: Ty
   T_Bytes: Ty
   T_Address: Ty
+  T_Contract: Ty
   T_Digest: Ty
   T_Token: Ty
   T_Object: (tyMap: {[key: string]: Ty}) => Ty

--- a/pygments/pygments_reach/__init__.py
+++ b/pygments/pygments_reach/__init__.py
@@ -95,7 +95,7 @@ class ReachLexer(RegexLexer):
              r'decodeURIComponent|encodeURI|encodeURIComponent|'
              r'Error|eval|isFinite|isNaN|isSafeInteger|parseFloat|parseInt|'
              # The reach ones
-             r'UInt|Int|FixedPoint|Interval|IntervalType|Reach|App|Fun|Null|Bool|Bytes|Address|Token|Tuple|Struct|Participant|ParticipantClass|View|Data|Digest|Map|Set|Refine|Anybody|deployMode|verifyArithmetic|verifyPerConnector|connectors|ETH|ALGO|'
+             r'UInt|Int|FixedPoint|Interval|IntervalType|Reach|App|Fun|Null|Bool|Bytes|Address|Contract|Token|Tuple|Struct|Participant|ParticipantClass|View|Data|Digest|Map|Set|Refine|Anybody|deployMode|verifyArithmetic|verifyPerConnector|connectors|ETH|ALGO|'
              r'deploy|balance|digest|implies|ensure|hasRandom|makeCommitment|checkCommitment|closeTo|lastConsensusTime|remote|'
              r'and|or|add|sub|mul|div|mod|lt|le|gt|ge|lsh|rsh|band|bior|bxor|eq|neq|'
              r'polyEq|polyNeq|typeEq|intEq|ite|typeOf|isType|is|'


### PR DESCRIPTION
Add `Contract` type, use it in `remote` and `ctc.getInfo`. The CBR form is a string and can either be constructed from a number for ALGO or an string address