### PR TITLE
CORE-601: Recognize `REACH_DEBUG` Environment Var In Compiler

### DIFF
--- a/docs-src/ref.scrbl
+++ b/docs-src/ref.scrbl
@@ -79,7 +79,11 @@ named @tt{default}.
 
   @item{@DFlag{verify-timeout} @nonterm{TIMEOUT-MS} --- Sets the timeout of individual verification theorems, in milliseconds.
   The default value is 2 minutes.}
-]
+
+  @item{
+    The environment variable @defenv{REACH_DEBUG}, if set to any non-empty value, enables debug messages from the Reach compiler, which will appear in the console.
+    This debug information includes: the estimated cost of the contract on Algorand.
+  }]
 
 @subsection[#:tag "ref-usage-init"]{@tt{reach init}}
 @;TODO document [TEMPLATE] once more templates have been added

--- a/hs/app/reachc/Main.hs
+++ b/hs/app/reachc/Main.hs
@@ -9,23 +9,6 @@ import Reach.Version
 import System.Environment
 import System.Exit
 
-data CompilerToolEnv = CompilerToolEnv
-  { cte_REACHC_ID :: Maybe String
-  , cte_REACHC_HASH :: Maybe String
-  , cte_CI :: Maybe String -- most CI services
-  , cte_GITHUB_ACTIONS :: Maybe String -- Github Actions
-  , cte_TF_BUILD :: Maybe String -- Azure Pipelines
-  }
-
-getCompilerEnv :: IO CompilerToolEnv
-getCompilerEnv = do
-  cte_REACHC_ID <- lookupEnv "REACHC_ID"
-  cte_REACHC_HASH <- lookupEnv "REACHC_HASH"
-  cte_CI <- lookupEnv "CI"
-  cte_GITHUB_ACTIONS <- lookupEnv "GITHUB_ACTIONS"
-  cte_TF_BUILD <- lookupEnv "TF_BUILD"
-  return CompilerToolEnv {..}
-
 shouldReport :: CompilerToolArgs -> CompilerToolEnv -> Bool
 shouldReport CompilerToolArgs {..} CompilerToolEnv {..} =
   not cta_disableReporting
@@ -57,7 +40,7 @@ main = do
       False -> return $ const $ return ()
       True -> startReport (cte_REACHC_ID env)
   (e :: Either SomeException ()) <-
-    try $ compile $ cta_co args
+    try $ compile env $ cta_co args
   report e
   case e of
     Left exn -> throwIO exn

--- a/hs/src/Reach/CommandLine.hs
+++ b/hs/src/Reach/CommandLine.hs
@@ -1,11 +1,15 @@
 module Reach.CommandLine
   ( CompilerToolArgs (..)
   , CompilerOpts (..)
+  , CompilerToolEnv (..)
   , compiler
   , getCompilerArgs
+  , getCompilerEnv
   ) where
 
 import Options.Applicative
+import System.Environment
+import Data.Maybe (isJust)
 
 data CompilerToolArgs = CompilerToolArgs
   { cta_disableReporting :: Bool
@@ -70,3 +74,23 @@ getCompilerArgs versionCliDisp = do
              <> progDesc "verify and compile an Reach program"
              <> header versionCliDisp)
   execParser opts
+
+
+data CompilerToolEnv = CompilerToolEnv
+  { cte_REACHC_ID :: Maybe String
+  , cte_REACHC_HASH :: Maybe String
+  , cte_CI :: Maybe String -- most CI services
+  , cte_GITHUB_ACTIONS :: Maybe String -- Github Actions
+  , cte_TF_BUILD :: Maybe String -- Azure Pipelines
+  , cte_REACH_DEBUG :: Bool
+  }
+
+getCompilerEnv :: IO CompilerToolEnv
+getCompilerEnv = do
+  cte_REACHC_ID <- lookupEnv "REACHC_ID"
+  cte_REACHC_HASH <- lookupEnv "REACHC_HASH"
+  cte_CI <- lookupEnv "CI"
+  cte_GITHUB_ACTIONS <- lookupEnv "GITHUB_ACTIONS"
+  cte_TF_BUILD <- lookupEnv "TF_BUILD"
+  cte_REACH_DEBUG <- fmap isJust $ lookupEnv "REACH_DEBUG"
+  return CompilerToolEnv {..}

--- a/hs/src/Reach/Connector/ALGO.hs
+++ b/hs/src/Reach/Connector/ALGO.hs
@@ -35,6 +35,7 @@ import Reach.Warning
 import Safe (atMay)
 import Text.Read
 import Generics.Deriving ( Generic )
+import Reach.CommandLine
 
 -- import Debug.Trace
 
@@ -96,6 +97,12 @@ typeObjectTypes a =
     _ -> impossible $ "should be obj"
 
 -- Algorand constants
+
+conName' :: T.Text
+conName' = "ALGO"
+
+conCons' :: DLConstant -> DLLiteral
+conCons' DLC_UInt_max = DLL_Int sb $ 2 ^ (64 :: Integer) - 1
 
 algoMinTxnFee :: Integer
 algoMinTxnFee = 1000
@@ -272,8 +279,8 @@ opt_b1 = \case
       let x_bs = LB.toStrict $ toLazyByteString $ word64BE $ fromIntegral x
       return $ base64d x_bs
 
-checkCost :: [TEAL] -> IO ()
-checkCost ts = do
+checkCost :: Bool -> [TEAL] -> IO ()
+checkCost alwaysShow ts = do
   (cgr :: IORef (M.Map String (M.Map String Int))) <- newIORef $ mempty
   let lTop = "TOP"
   let lBot = "BOT"
@@ -338,13 +345,18 @@ checkCost ts = do
         case x of
           True -> [ e ]
           False -> []
+  let showCost = "This program could take " <> show c <> " units of cost"
+  let exceedsCost = fromIntegral c > algoMaxAppProgramCost
   let cs = []
         <> (whenl hasFor $
               "This program contains a loop, which cannot be tracked accurately for cost.")
-        <> (whenl (fromIntegral c > algoMaxAppProgramCost) $
-              "This program could take " <> show c <> " units of cost, but the limit is " <> show algoMaxAppProgramCost <> ": " <> show p)
+        <> (whenl exceedsCost $
+              showCost <> ", but the limit is " <> show algoMaxAppProgramCost <> ": " <> show p)
   unless (null cs) $
     emitWarning $ W_ALGOConservative cs
+  -- If we always want to see the cost and not already shown the cost in a warning
+  when (alwaysShow && not exceedsCost) $
+    putStrLn $ "Conservative analysis found: " <> showCost <> " on Algorand."
 
 data Shared = Shared
   { sFailuresR :: IORef (S.Set LT.Text)
@@ -598,7 +610,7 @@ ctzero = \case
     cfrombs t
 
 tint :: SrcLoc -> Integer -> LT.Text
-tint at i = texty $ checkIntLiteralC at connect_algo i
+tint at i = texty $ checkIntLiteralC at conName' conCons' i
 
 base64d :: B.ByteString -> LT.Text
 base64d bs = "base64(" <> encodeBase64 bs <> ")"
@@ -648,7 +660,7 @@ cv = lookup_let
 ca :: DLArg -> App ()
 ca = \case
   DLA_Var v -> cv v
-  DLA_Constant c -> cl $ conCons connect_algo c
+  DLA_Constant c -> cl $ conCons' c
   DLA_Literal c -> cl c
   DLA_Interact {} -> impossible "consensus interact"
 
@@ -1750,8 +1762,8 @@ cStateSlice at size iw = do
   let k = algoMaxAppBytesValueLen_usable
   csubstring at (k * i) (min size $ k * (i + 1))
 
-compile_algo :: Disp -> PLProg -> IO ConnectorInfo
-compile_algo disp pl = do
+compile_algo :: CompilerToolEnv -> Disp -> PLProg -> IO ConnectorInfo
+compile_algo env disp pl = do
   let PLProg _at plo dli _ _ cpp = pl
   let CPProg at _ (CHandlers hm) = cpp
   let sMaps = dli_maps dli
@@ -1793,17 +1805,17 @@ compile_algo disp pl = do
         flip runReaderT (Env {..}) m
         readIORef eOutputR
   let bad' = bad_io sFailuresR
-  let addProg lab m = do
+  let addProg lab showCost m = do
         ts <- run m
         let tsl = DL.toList ts
         let tsl' = optimize tsl
-        checkCost tsl'
+        checkCost showCost tsl'
         let lts = tealVersionPragma : (map LT.unwords tsl')
         let lt = LT.unlines lts
         let t = LT.toStrict lt
         modifyIORef resr $ M.insert (T.pack lab) $ Aeson.String t
         disp lab t
-  addProg "appApproval" $ do
+  addProg "appApproval" (cte_REACH_DEBUG env) $ do
     checkRekeyTo
     checkLease
     cint 0
@@ -1881,10 +1893,10 @@ compile_algo disp pl = do
       gvStore gv
     code "b" [ "updateState" ]
   -- Clear state is never allowed
-  addProg "appClear" $ do
+  addProg "appClear" False $ do
     cl $ DLL_Bool False
   -- The escrow account defers to the application
-  addProg "escrow" $ do
+  addProg "escrow" False $ do
     code "global" ["GroupSize"]
     cint 1
     op "-"
@@ -1913,10 +1925,10 @@ compile_algo disp pl = do
   res <- readIORef resr
   return $ Aeson.Object $ HM.fromList $ M.toList res
 
-connect_algo :: Connector
-connect_algo = Connector {..}
+connect_algo :: CompilerToolEnv -> Connector
+connect_algo env = Connector {..}
   where
-    conName = "ALGO"
-    conCons DLC_UInt_max = DLL_Int sb $ 2 ^ (64 :: Integer) - 1
-    conGen moutn = compile_algo (disp . T.pack)
+    conName = conName'
+    conCons = conCons'
+    conGen moutn = compile_algo env (disp . T.pack)
       where disp which = conWrite moutn (which <> ".teal")


### PR DESCRIPTION
When `REACH_DEBUG` env var is set to a non-empty value: display the cost of an ALGO program and produce intermediate files.

I made it so `connect_algo` now receives the command line env info to know whether to enable debugging information. This caused some unsatisfactory changes because `connect_algo` is also used when compiling constants or checking that numbers are less than UInt.max. So, I changed some code from taking the connector as a whole to just the individual fields needed.