### PR TITLE
docs: change `run` to `compile` b/c `compile` gens text

### DIFF
--- a/docs-md/src/tut.md
+++ b/docs-md/src/tut.md
@@ -582,7 +582,7 @@ ${code("/examples/tut-5-attack/index.rsh", 34, 37)}
 + Line 36 conducts the proof by including an assert statement in the program.
 
 
-Before we had this line in the file, when we ran `./reach run`, it would print out the message:
+Before we had this line in the file, when we ran `./reach compile`, it would print out the message:
 
 ${code("/examples/tut-4/index.txt", 2, 7)}
 

--- a/docs-src/tut.scrbl
+++ b/docs-src/tut.scrbl
@@ -596,7 +596,7 @@ We can instruct Reach to prove this theorem by adding these lines after computin
 
 ]
 
-Before we had this line in the file, when we ran @exec{./reach run}, it would print out the message:
+Before we had this line in the file, when we ran @exec{./reach compile}, it would print out the message:
 
 @reachex[#:mode verbatim
          "tut-4/index.txt"


### PR DESCRIPTION
https://docs.reach.sh/tut-5.html says,

"Before we had this line in the file, when we ran `./reach run`, it would print out the message:"

```
Verifying for generic connector
  Verifying when ALL participants are honest
  Verifying when NO participants are honest
  Verifying when ONLY "Alice" is honest
  Verifying when ONLY "Bob" is honest
Checked 18 theorems; No failures!
```

But, `./reach compile` is actually the command that prints out that message, no?

At least, it is for me:

```
tut % ./reach compile
Verifying knowledge assertions
Verifying for generic connector
  Verifying when ALL participants are honest
  Verifying when NO participants are honest
  Verifying when ONLY "Alice" is honest
  Verifying when ONLY "Bob" is honest
Checked 18 theorems; No failures!
```