### PR TITLE
CORE-753 add `reinstall` command for easier dev

### DIFF
--- a/vsce/package.json
+++ b/vsce/package.json
@@ -305,6 +305,7 @@
 		"compile": "tsc -b",
 		"watch": "tsc -b -w",
 		"postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
+		"reinstall": "rm -rf ./node_modules && rm -rf ./server/node_modules && rm -rf ./client/node_modules && npm install",
 		"test": "sh ./scripts/e2e.sh"
 	},
 	"devDependencies": {


### PR DESCRIPTION
This is a very small change that just adds `"reinstall": "rm -rf ./node_modules && rm -rf ./server/node_modules && rm -rf ./client/node_modules && npm install",` to `vsce/package.json` so that development on Reach's language server and extension is easier.

With this change added, we can use `npm run reinstall` to clean up dependencies, which is especially useful when switching between different branches that involve changed dependencies.