### PR TITLE
Removed deprecated calls to deploy and attach.

### DIFF
--- a/examples/tut-2/index.mjs
+++ b/examples/tut-2/index.mjs
@@ -7,8 +7,8 @@ const stdlib = loadStdlib(process.env);
   const accAlice = await stdlib.newTestAccount(startingBalance);
   const accBob = await stdlib.newTestAccount(startingBalance);
 
-  const ctcAlice = accAlice.deploy(backend);
-  const ctcBob = accBob.attach(backend, ctcAlice.getInfo());
+  const ctcAlice = accAlice.contract(backend);
+  const ctcBob = accBob.contract(backend, ctcAlice.getInfo());
 
   await Promise.all([
     backend.Alice(ctcAlice, {


### PR DESCRIPTION
When compiling with Reach `0.1.6` the cli produces deprecation warnings when using `deploy` and `attach`. The suggested replacement is `contract`.

<!--
Hey! Thanks so much!
-->

## Summary

I'm removing deprecated code so that people following this tutorial are not confused by the compiler spitting out warnings.

DESIGN: no changes.

TESTING: I compiled with the Reach compiler `0.1.6` without warnings or errors.

DOCS: The tutorial should change its language about `deploy` and `attach`.
