### PR TITLE
CORE 759 add compiler err JSON type for safer dev

### DIFF
--- a/vsce/server/src/server.ts
+++ b/vsce/server/src/server.ts
@@ -350,7 +350,7 @@ export interface ErrorLocation {
 
 // Based on
 // https://github.com/reach-sh/reach-lang/blob/master/hs/src/Reach/AST/Base.hs#L84
-type ReachCompilerErrorJSON {
+type ReachCompilerErrorJSON = {
 	ce_position: number[];
 	ce_suggestions: string[];
 	ce_errorMessage: string;

--- a/vsce/server/src/server.ts
+++ b/vsce/server/src/server.ts
@@ -388,7 +388,7 @@ CallStack (from HasCallStack):
 		const suggestions = errorJson.ce_suggestions;
 		const actualMessage = errorJson.ce_errorMessage;
 		const offendingToken = errorJson.ce_offendingToken;
-		const REACH_ERROR_CODE = errorJson.ce_errorCode;
+		const reachCompilerErrorCode = errorJson.ce_errorCode;
 
 		const start ={ line: linePos, character: charPos };
 		const end = offendingToken ?
@@ -399,7 +399,7 @@ CallStack (from HasCallStack):
 		// In other words, the highlighting for error "RE0013" is weird;
 		// it highlights a colon instead of a word, so we have special
 		// logic for this error code that we don't have for others.
-		if (REACH_ERROR_CODE === "RE0013") {
+		if (reachCompilerErrorCode === "RE0013") {
 			// If we have this error code, an offendingToken will exist,
 			// which is why we can assert to TypeScript that
 			// offendingToken is non-null with the "!" operator.
@@ -409,7 +409,7 @@ CallStack (from HasCallStack):
 		}
 
 		let location: ErrorLocation = {
-			code: REACH_ERROR_CODE,
+			code: reachCompilerErrorCode,
 			range: { start: start, end: end },
 			errorMessage: actualMessage,
 			suggestions: suggestions

--- a/vsce/server/src/server.ts
+++ b/vsce/server/src/server.ts
@@ -354,7 +354,7 @@ type ReachCompilerErrorJSON {
 	ce_position: number[];
 	ce_suggestions: string[];
 	ce_errorMessage: string;
-	ce_offendingToken?: string;
+	ce_offendingToken: string | null;
 	ce_errorCode: string;
 }
 

--- a/vsce/server/src/server.ts
+++ b/vsce/server/src/server.ts
@@ -402,7 +402,7 @@ CallStack (from HasCallStack):
 		if (REACH_ERROR_CODE === "RE0013") {
 			// If we have this error code, an offendingToken will exist,
 			// which is why we can assert to TypeScript that
-			// offendingToken is non-undefined with the "!" operator.
+			// offendingToken is non-null with the "!" operator.
 			// https://stackoverflow.com/questions/38874928/operator-in-typescript-after-object-method
 			start.character -= offendingToken!.length;
 			end.character   -= offendingToken!.length;

--- a/vsce/server/src/server.ts
+++ b/vsce/server/src/server.ts
@@ -342,9 +342,20 @@ connection.onDidChangeWatchedFiles(_change => {
 });
 
 export interface ErrorLocation {
+	code: string;
 	range: Range;
 	errorMessage: string; // e.g. id ref: Invalid unbound identifier: declassify.
 	suggestions: string[]; // e.g. literally this whole thing: "declassify","array","assert","assume","closeTo"
+}
+
+// Based on
+// https://github.com/reach-sh/reach-lang/blob/master/hs/src/Reach/AST/Base.hs#L84
+type ReachCompilerErrorJSON {
+	ce_position: number[];
+	ce_suggestions: string[];
+	ce_errorMessage: string;
+	ce_offendingToken?: string;
+	ce_errorCode: string;
 }
 
 function findErrorLocations(compileErrors: string): ErrorLocation[] {
@@ -369,7 +380,7 @@ CallStack (from HasCallStack):
 		connection.console.log(`Found pattern: ${m}`);
 
 		// ERROR MESSAGE m: error: <json>
-		const errorJson = JSON.parse(m[0].substring(7));
+		const errorJson: ReachCompilerErrorJSON = JSON.parse(m[0].substring(7));
 
 		//connection.console.log(`Tokens: ` + tokens);
 		const linePos = errorJson.ce_position[0] - 1;
@@ -377,6 +388,7 @@ CallStack (from HasCallStack):
 		const suggestions = errorJson.ce_suggestions;
 		const actualMessage = errorJson.ce_errorMessage;
 		const offendingToken = errorJson.ce_offendingToken;
+		const REACH_ERROR_CODE = errorJson.ce_errorCode;
 
 		const start ={ line: linePos, character: charPos };
 		const end = offendingToken ?
@@ -384,12 +396,20 @@ CallStack (from HasCallStack):
 			:	{ line: linePos + 1, character: 0 };
 
 		// App options currently have error position at the `:` of a json field: `<k> : <v>`.
-		if (actualMessage.includes('not a valid app option')) {
-			start.character -= offendingToken.length;
-			end.character   -= offendingToken.length;
+		// In other words, the highlighting for error "RE0013" is weird;
+		// it highlights a colon instead of a word, so we have special
+		// logic for this error code that we don't have for others.
+		if (REACH_ERROR_CODE === "RE0013") {
+			// If we have this error code, an offendingToken will exist,
+			// which is why we can assert to TypeScript that
+			// offendingToken is non-undefined with the "!" operator.
+			// https://stackoverflow.com/questions/38874928/operator-in-typescript-after-object-method
+			start.character -= offendingToken!.length;
+			end.character   -= offendingToken!.length;
 		}
 
 		let location: ErrorLocation = {
+			code: REACH_ERROR_CODE,
 			range: { start: start, end: end },
 			errorMessage: actualMessage,
 			suggestions: suggestions


### PR DESCRIPTION
Since we know the ["shape" of the compiler error message JSON](https://github.com/reach-sh/reach-lang/blob/master/hs/src/Reach/AST/Base.hs#L84), we can add that as a type to `vsce/server/src/server.ts`, to make development in `vsce/server/src/server.ts` less likely to break things.

Warning: This change accesses an error code from the compiler that's only available on release 09c295c6 and later. This shouldn't be a problem, since we want all users to be on version 09c295c6 or later, anyway.

Since we're assuming access to error codes from the Reach compiler is available, we can rewrite the conditional that checks for the error that has odd highlighting behavior by checking for its error code, `"RE0013"`, instead of by looking at its error message.