### PR TITLE
UPDTE: RAPI0002 docs with example snippet

### DIFF
--- a/docs/scrbl/ref-error-codes.scrbl
+++ b/docs/scrbl/ref-error-codes.scrbl
@@ -2466,7 +2466,7 @@ The error means that you use an @tech{API} in two places in your program, which 
 
 This might look like the following in the API_CONSENSUS_EXPR
 @reach{
-  (algoAmount, apiReturn) => {
+  .api(User.mintTok, (algoAmount, apiReturn) => {
     require(algoAmount > 0);
     require(oraclePrice > 0);
     const mint = algoAmount * oraclePrice;
@@ -2475,7 +2475,7 @@ This might look like the following in the API_CONSENSUS_EXPR
       apiReturn(true);
     }
     apiReturn(false);
-  }
+  })
 }
 
 You cannot call @tt{apiReturn} twice.

--- a/docs/scrbl/ref-error-codes.scrbl
+++ b/docs/scrbl/ref-error-codes.scrbl
@@ -2464,6 +2464,22 @@ This is generally not possible unless you directly use the internal representati
 
 The error means that you use an @tech{API} in two places in your program, which is not allowed.
 
+This might look like the following in the API_CONSENSUS_EXPR
+@reach{
+  (algoAmount, apiReturn) => {
+    require(algoAmount > 0);
+    require(oraclePrice > 0);
+    const mint = algoAmount * oraclePrice;
+    if(balance(tok) > mint) {
+      transfer(mint, tok).to(this);
+      apiReturn(true);
+    }
+    apiReturn(false);
+  }
+}
+
+You cannot call @tt{apiReturn} twice.
+
 @error{RAPI0003}
 
 This error means that you did not return a result from an @tech{API} call.


### PR DESCRIPTION
<!--
Hey! Thanks so much!
-->

## Summary

<!-- Explain what you're trying to do in this pull request -->
Had a confusing error today. In an `API_CONSENSUS_EXPR` block there was the following snippet:
```javascript
.api(User.mintTok, (algoAmount, apiReturn) => {
    require(algoAmount > 0);
    require(oraclePrice > 0);
    const mint = algoAmount * oraclePrice;
    if(balance(tok) > mint) {
      transfer(mint, tok).to(this);
      apiReturn(true);
    }
    apiReturn(false);
  }
})
```

Calling `apiReturn` twice was the problem, however the error in this section of the docs was slightly misleading to begin with, and we were asking the question "How can User.mintTok be called twice?". This update to the docs clarifies what `RAPI0002` might mean.
