### PR TITLE
CORE-758 wait for comp to finish before comp again

### DIFF
--- a/vsce/server/src/server.ts
+++ b/vsce/server/src/server.ts
@@ -229,7 +229,8 @@ documents.onDidChangeContent(change => {
 	validateTextDocument(change.document);
 });
 
-let theCompilerIsCompiling = false;
+let	theCompilerIsCompiling 	= false,
+	weNeedToCompileAgain 	= false;
 
 async function validateTextDocument(textDocument: TextDocument): Promise<void> {
 
@@ -290,8 +291,9 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
 		: exeLoc;
 
 	if (theCompilerIsCompiling) {
+		weNeedToCompileAgain = true;
 		console.debug(
-			"Compilation is already in process! Returning...",
+			"Compilation already in process; will recompile",
 			new Date().toLocaleTimeString()
 		);
 		return;
@@ -315,6 +317,11 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
 			new Date().toLocaleTimeString()
 		);
 		theCompilerIsCompiling = false;
+		if (weNeedToCompileAgain) {
+			weNeedToCompileAgain = false;
+			validateTextDocument(textDocument);
+			return;
+		}
 
 		if (error) {
 			connection.console.log(`Found compile error: ${error.message}`);


### PR DESCRIPTION
This change seeks to fix a bug users experience where Reach's language server automatically compiles a Reach program on every keystroke.

This fix attempts to solve that problem by using a flag that we reset once compilation has finished. While that flag is set, i.e., while a compilation is already in process, future compilations will not occur.

We can be sure that compilation has finished when the callback for `exec` exectutes, because the documentation for `child_process.exec()` says that it [spawns a shell and runs a command within that shell, passing the stdout and stderr to a callback function **when complete**.](https://nodejs.org/api/child_process.html#child-process)

This approach might be preferable to setting a timeout that waits for the user to finish typing, since different users have different devices, and those with faster devices may not need to wait as long as those with slower ones for compilation completion.