### PR TITLE
make diffs more identical when using build script

### DIFF
--- a/vsce/build.package.json.js
+++ b/vsce/build.package.json.js
@@ -125,7 +125,8 @@ NEW_PACKAGE_JSON.contributes.menus["editor/context"]
 NEW_PACKAGE_JSON.activationEvents
 	= ACTIVATION_EVENTS_ARRAY;
 
+// Add a newline character for more identical diffs
 fs.writeFileSync(
 	'./package.json',
-	JSON.stringify(NEW_PACKAGE_JSON, null, 4)
+	JSON.stringify(NEW_PACKAGE_JSON, null, 4) + "\n"
 );


### PR DESCRIPTION
Installing a dependency will cause `npm` to automatically add a new line to `package.json`.

The build script I wrote in https://github.com/reach-sh/reach-lang/pull/374 doesn't automatically append a newline character to the generated `package.json`, so there will always be an additional, unnecessary change to view when generating `package.json` using `build.package.json.js`, namely, that blank line.

This change fixes that by adding a newline character to the
`package.json` generated by `build.package.json.js`.