### PR TITLE
overwrite `base.package.json` first when building

### DIFF
--- a/vsce/Makefile
+++ b/vsce/Makefile
@@ -14,6 +14,10 @@ SHELL=/bin/bash
 VSCE_VER := $$(($$(($$(($(MAJOR)+1))*1000)) + $(MINOR))).$(PATCH).$(DRAFT)
 
 package.json: base.package.json
+# Replace base.package.json with package.json, first, in
+# case we updated package.json since we last made
+# base.package.json.
+	cp package.json base.package.json
 	node build.package.json.js
 
 publish:

--- a/vsce/build.package.json.js
+++ b/vsce/build.package.json.js
@@ -12,10 +12,12 @@ const MENUS_EDITORTITLE_ARRAY = [];
 const MENUS_TOUCHBAR_ARRAY = [];
 const MENUS_EDITORCONTEXT_ARRAY = [];
 
-// This actually has some pre-existing elements that
-// we need! See original.package.json.
-const ACTIVATION_EVENTS_ARRAY
-	= NEW_PACKAGE_JSON.activationEvents;
+// Build the activationEvents array from scratch
+// each time to avoid duplicate strings.
+const ACTIVATION_EVENTS_ARRAY = [
+	"workspaceContains:**/*.rsh",
+	"workspaceContains:reach"
+];
 
 // **Every** command seems to be present in
 // MAIN_JSON.contributes.menus["explorer/context"].


### PR DESCRIPTION
With the current configuration, if I install a new dependency, say, to add telemetry, `npm` changes `package.json`. That's normal.

However, what isn't normal is that [the build script that I wrote in #374, `build.package.json.js`](https://github.com/reach-sh/reach-lang/pull/374/files#diff-e962954cc645c240eae12773c998486bd4bf8bffd49d8fcdd10a15ba79683b9c), uses `base.package.json` to build the new `package.json`, meaning that running `make package.json` overwrites `package.json` using `base.package.json`, resulting in `package.json` losing the necessary changes that installation of a new dependency added.

This change fixes that by overwriting `base.package.json` with `package.json`, first, before building a new `package.json` with `make package.json`, so that `package.json` retains the necessary changes added by installing a new dependency.