### PR TITLE
docs: update IDE install instructions

### DIFF
--- a/docs/dev/src/en/books/essentials/getting-started/set-up-an-ide/index.md
+++ b/docs/dev/src/en/books/essentials/getting-started/set-up-an-ide/index.md
@@ -42,13 +42,7 @@ Many instructions on this site assume that you have added `~/reach` to `PATH`.
 
 1. Install [Visual Studio Code](https://code.visualstudio.com/).
 
-1. Add the following file association to vscode preferences:
-
-    ``` nonum
-    "files.associations": {
-      "*.rsh": "javascript"
-    }
-    ```
+1. Install the [Reach IDE](https://marketplace.visualstudio.com/items?itemName=reachsh.reach-ide).
     
 1. Open `~/reach`:
 


### PR DESCRIPTION
Replaced manual settings.json instructions with REACH IDE installation