### PR TITLE
CORE-757: Disallow Publications From `API`s

### DIFF
--- a/docs/scrbl/ref-error-codes.scrbl
+++ b/docs/scrbl/ref-error-codes.scrbl
@@ -2179,6 +2179,23 @@ You can fix this error by using different names:
   const B = API('Flower', { girl2: Fun([UInt], Null) });
 }
 
+@error{RE0124}
+
+This error indicates that there is an attempt to make a publication in your program, but there are
+no @reachin{Participant}s or @reachin{ParticipantClass}es declared.
+
+This issue can arise when you use @reachin{Anybody.publish()}. To fix this issue, ensure you declare
+a @reachin{Participant} or @reachin{ParticipantClass}.
+
+@error{RE0125}
+
+This error indicates that an @reachin{API} is explicitly attempting to make a publication, e.g. @reachin{api.publish()}.
+An API may only make a publication through a @reachin{fork}, @reachin{parallelReduce}, or @reachin{call}.
+
+Depending on your program, you can fix this error by performing a @reachin{call} or adding an @reachin{.api}
+case to your @reachin{fork} or @reachin{parallelReduce} statement.
+
+
 @error{REP0000}
 
 This error indicates that the body of a @reachin{while} loop does not make a publication before the @reachin{continue}

--- a/examples/api-call/index.txt
+++ b/examples/api-call/index.txt
@@ -6,7 +6,7 @@ Verifying for generic connector
   Verifying when ONLY "Bob_checkEq" is honest
   Verifying when ONLY "Bob_noop" is honest
   Verifying when ONLY "Bob_payMe" is honest
-Checked 55 theorems; No failures!
+Checked 34 theorems; No failures!
 warning[RW0000]: Using a bare value as a time argument is now deprecated. Please use relativeTime, absoluteTime, relativeSecs, or absoluteSecs
 
   ./index.rsh:38:5:application

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -446,6 +446,7 @@ data ToConsensusMode
   | TCM_Timeout
   | TCM_ThrowTimeout
   | TCM_Fork
+  | TCM_Api
   deriving (Eq, Generic, Show)
 
 data ForkMode
@@ -484,6 +485,7 @@ data ToConsensusRec = ToConsensusRec
   , slptc_whene :: Maybe JSExpression
   , slptc_timeout :: Maybe (SrcLoc, JSExpression, Maybe JSBlock)
   , slptc_fork :: Bool
+  , slptc_api :: Bool
   }
   deriving (Eq, Generic)
 

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -1123,7 +1123,7 @@ evalAsEnv obj = case obj of
         , ("interact", makeInteractField)
         ]
     where
-      go m = withAt $ \at -> public $ SLV_Form (SLForm_Part_ToConsensus $ ToConsensusRec at whos vas (Just m) Nothing Nothing Nothing Nothing False)
+      go m = withAt $ \at -> public $ SLV_Form (SLForm_Part_ToConsensus $ ToConsensusRec at whos vas (Just m) Nothing Nothing Nothing Nothing False False)
       whos = S.singleton who
   SLV_Anybody -> do
     at <- withAt id
@@ -1140,7 +1140,7 @@ evalAsEnv obj = case obj of
         [ ("publish", go TCM_Publish)
         , ("pay", go TCM_Pay) ]
     where
-      go m = withAt $ \at -> public $ SLV_Form (SLForm_Part_ToConsensus $ ToConsensusRec at whos Nothing (Just m) Nothing Nothing Nothing Nothing False)
+      go m = withAt $ \at -> public $ SLV_Form (SLForm_Part_ToConsensus $ ToConsensusRec at whos Nothing (Just m) Nothing Nothing Nothing Nothing False False)
   SLV_Form (SLForm_Part_ToConsensus p@(ToConsensusRec {..})) | slptc_mode == Nothing ->
     return $
       M.fromList $
@@ -1150,6 +1150,7 @@ evalAsEnv obj = case obj of
           <> gom "timeout" TCM_Timeout slptc_timeout
           <> gom "throwTimeout" TCM_ThrowTimeout slptc_timeout
           <> gob ".fork" TCM_Fork slptc_fork
+          <> gob ".api" TCM_Api slptc_api
     where
       gob key mode = \case
         False -> go key mode
@@ -1625,6 +1626,9 @@ evalForm f args = do
         Just TCM_Fork -> do
           zero_args
           go $ p { slptc_fork = True }
+        Just TCM_Api -> do
+          zero_args
+          go $ p { slptc_api = True }
         Just TCM_Timeout -> do
           at <- withAt id
           let proc = \case
@@ -4094,6 +4098,9 @@ compilePayAmt tt v = do
 doToConsensus :: [JSStatement] -> ToConsensusRec -> App SLStmtRes
 doToConsensus ks (ToConsensusRec {..}) = locAt slptc_at $ do
   let whos = slptc_whos
+  who_apis <- S.intersection whos <$> (ae_apis <$> aisd)
+  unless (S.null who_apis || slptc_api) $
+    expect_ $ Err_Api_Publish who_apis
   let vas = slptc_mv
   let msg = fromMaybe [] slptc_msg
   let amt_e = fromMaybe (JSDecimal JSNoAnnot "0") slptc_amte
@@ -4364,6 +4371,7 @@ doApiCall lhs (ApiCallRec{..}) = do
         case slac_mtime of
           Nothing -> pub2
           Just (to, e) -> jsCall a (mkDot a [pub2, jid "throwTimeout"]) [to, e]
+  let pub4 = jsCall a (mkDot a [pub3, jid ".api"]) []
   -- Construct `k = interact.out()`
   let returnVal = jidg "rng"
   let returnLVal = jidg "rngl"
@@ -4374,7 +4382,7 @@ doApiCall lhs (ApiCallRec{..}) = do
   --
   let assignRet = jsConst a ret apiReturn
   let setDetails = jsCall a (jid ".setApiDetails") [slac_who, dom]
-  let ss = [callOnly [onlyThunk], es pub3, es setDetails, assignRet]
+  let ss = [callOnly [onlyThunk], es pub4, es setDetails, assignRet]
   return ss
   where
     sepLHS a = \case
@@ -4597,7 +4605,8 @@ doFork ks (ForkRec {..}) = locAt slf_at $ do
         let before_tc_ss = data_ss <> cases_onlys
         return $ (True, before_tc_ss, pay_e, tc_head_e, switch_ss)
   let tc_pub_e = JSCallExpression (JSMemberDot tc_head_e a (jid "publish")) a (JSLOne msg_e) a
-  let tc_when_e = JSCallExpression (JSMemberDot tc_pub_e a (jid "when")) a (JSLOne when_e) a
+  let tc_api_e = JSCallExpression (JSMemberDot tc_pub_e a (jid ".api")) a JSLNil a
+  let tc_when_e = JSCallExpression (JSMemberDot tc_api_e a (jid "when")) a (JSLOne when_e) a
   -- START: Non-network token pay
   pay_expr <-
     case slf_mnntpay of

--- a/hs/src/Reach/Eval/Error.hs
+++ b/hs/src/Reach/Eval/Error.hs
@@ -152,6 +152,7 @@ data EvalError
   | Err_UniqueFirstPublish
   | Err_ApiCallAssign
   | Err_DuplicateName String SrcLoc
+  | Err_No_Participants
   deriving (Eq, Generic)
 
 instance HasErrorCode EvalError where
@@ -285,6 +286,7 @@ instance HasErrorCode EvalError where
     Err_API_NotFun {} -> 121
     Err_ApiCallAssign {} -> 122
     Err_DuplicateName {} -> 123
+    Err_No_Participants {} -> 124
 
 --- FIXME I think most of these things should be in Pretty
 
@@ -717,5 +719,7 @@ instance Show EvalError where
       "The left hand side of an API call must be a pair consisting of the domain and return function."
     Err_DuplicateName s at ->
       "The name `" <> s <> "` has already been used by a Participant, View or API at: " <> show at
+    Err_No_Participants ->
+      "There are no `Participant`s in the program."
     where
       displayPrim = drop (length ("SLPrim_" :: String)) . conNameOf

--- a/hs/t/n/Err_Api_Publish.rsh
+++ b/hs/t/n/Err_Api_Publish.rsh
@@ -1,0 +1,13 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const A = Participant('A', {});
+  const B = API({ b: Fun([], Null) });
+  deploy();
+
+  A.publish();
+  commit();
+
+  B.b.publish()
+  commit();
+});

--- a/hs/t/n/Err_Api_Publish.txt
+++ b/hs/t/n/Err_Api_Publish.txt
@@ -1,0 +1,8 @@
+reachc: error[RE0125]: The b `API`(s) cannot explicitly make a publication.
+
+  ./Err_Api_Publish.rsh:11:7:dot
+
+  11|   B.b.publish()
+
+For further explanation of this error, see: https://docs.reach.sh/RE0125.html
+

--- a/hs/t/n/Err_No_Participants.rsh
+++ b/hs/t/n/Err_No_Participants.rsh
@@ -1,0 +1,9 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const A = API({ b: Fun([], Null) });
+  deploy();
+
+  Anybody.publish();
+  commit();
+});

--- a/hs/t/n/Err_No_Participants.txt
+++ b/hs/t/n/Err_No_Participants.txt
@@ -1,7 +1,8 @@
 reachc: error[RE0124]: There are no `Participant`s in the program.
 
-  ./Err_No_Participants.rsh:11:11:dot
+  ./Err_No_Participants.rsh:7:11:dot
 
-  11|   Anybody.publish();
+  7|   Anybody.publish();
 
 For further explanation of this error, see: https://docs.reach.sh/RE0124.html
+

--- a/hs/t/n/Err_No_Participants.txt
+++ b/hs/t/n/Err_No_Participants.txt
@@ -1,0 +1,7 @@
+reachc: error[RE0124]: There are no `Participant`s in the program.
+
+  ./Err_No_Participants.rsh:11:11:dot
+
+  11|   Anybody.publish();
+
+For further explanation of this error, see: https://docs.reach.sh/RE0124.html

--- a/hs/t/n/foreign_to_reach.txt
+++ b/hs/t/n/foreign_to_reach.txt
@@ -1,4 +1,4 @@
-reachc: error[RE0025]: exposeAs is not a field of <SLV_Form>. Did you mean: [".fork","when","timeout","throwTimeout"]
+reachc: error[RE0025]: exposeAs is not a field of <SLV_Form>. Did you mean: ["when","timeout","throwTimeout"]
 
   ./foreign_to_reach.rsh:12:26:dot
 

--- a/hs/t/n/non-network_token.txt
+++ b/hs/t/n/non-network_token.txt
@@ -1,4 +1,4 @@
-reachc: error[RE0025]: currency is not a field of <SLV_Form>. Did you mean: ["when",".fork","publish","timeout","throwTimeout"]
+reachc: error[RE0025]: currency is not a field of <SLV_Form>. Did you mean: ["when","publish","timeout","throwTimeout"]
 
   ./non-network_token.rsh:12:16:dot
 


### PR DESCRIPTION
Made `fork`s and `call`s emit `.api` as part of the `publish` chain. So, when a `publish` is made that does not stem from these sources it will error. 

Remove `API`s from consideration for `Anybody`