### PR TITLE
fix line number in 2.6 Timeouts and Participation

### DIFF
--- a/docs/scrbl/tut.scrbl
+++ b/docs/scrbl/tut.scrbl
@@ -988,7 +988,7 @@ if she doesn't start the game, then no one is any worse off.
 @itemlist[
 
 @item{Line 50 has Alice declassify the @reachin{deadline} @tech{time delta}.}
-@item{Line 51 now has Alice publish the @reachin{deadline}.}
+@item{Line 52 now has Alice publish the @reachin{deadline}.}
 
 ]
 


### PR DESCRIPTION
[2.6 Timeouts and Participation](https://docs.reach.sh/tut-6.html) says `Line 51 now has Alice publish the deadline.`, but it is actually line 52 that has `Alice.publish(wager, commitAlice, deadline)`.

![image](https://user-images.githubusercontent.com/43425812/142491474-07cfee71-41d7-4a19-89ca-2ce56b6c7afa.png)