### PR TITLE
Remove deprecation warning from deploy & attach by using contract

### DIFF
--- a/examples/rps-1-setup/index.mjs
+++ b/examples/rps-1-setup/index.mjs
@@ -7,8 +7,8 @@ const stdlib = loadStdlib(process.env);
   const accAlice = await stdlib.newTestAccount(startingBalance);
   const accBob = await stdlib.newTestAccount(startingBalance);
 
-  const ctcAlice = accAlice.deploy(backend);
-  const ctcBob = accBob.attach(backend, ctcAlice.getInfo());
+  const ctcAlice = accAlice.contract(backend);
+  const ctcBob = accBob.contract(backend, ctcAlice.getInfo());
 
   await Promise.all([
     backend.Alice(ctcAlice, {

--- a/examples/rps-2-rps/index.mjs
+++ b/examples/rps-2-rps/index.mjs
@@ -7,8 +7,8 @@ const stdlib = loadStdlib(process.env);
   const accAlice = await stdlib.newTestAccount(startingBalance);
   const accBob = await stdlib.newTestAccount(startingBalance);
 
-  const ctcAlice = accAlice.deploy(backend);
-  const ctcBob = accBob.attach(backend, ctcAlice.getInfo());
+  const ctcAlice = accAlice.contract(backend);
+  const ctcBob = accBob.contract(backend, ctcAlice.getInfo());
 
   const HAND = ['Rock', 'Paper', 'Scissors'];
   const OUTCOME = ['Bob wins', 'Draw', 'Alice wins'];

--- a/examples/rps-3-bets/index.mjs
+++ b/examples/rps-3-bets/index.mjs
@@ -12,8 +12,8 @@ const stdlib = loadStdlib(process.env);
   const beforeAlice = await getBalance(accAlice);
   const beforeBob = await getBalance(accBob);
 
-  const ctcAlice = accAlice.deploy(backend);
-  const ctcBob = accBob.attach(backend, ctcAlice.getInfo());
+  const ctcAlice = accAlice.contract(backend);
+  const ctcBob = accBob.contract(backend, ctcAlice.getInfo());
 
   const HAND = ['Rock', 'Paper', 'Scissors'];
   const OUTCOME = ['Bob wins', 'Draw', 'Alice wins'];

--- a/examples/rps-4-attack/index.mjs
+++ b/examples/rps-4-attack/index.mjs
@@ -12,8 +12,8 @@ import * as backend from './build/index.main.mjs';
   const beforeAlice = await getBalance(accAlice);
   const beforeBob = await getBalance(accBob);
 
-  const ctcAlice = accAlice.deploy(backend);
-  const ctcBob = accBob.attach(backend, ctcAlice.getInfo());
+  const ctcAlice = accAlice.contract(backend);
+  const ctcBob = accBob.contract(backend, ctcAlice.getInfo());
 
   const HAND = ['Rock', 'Paper', 'Scissors'];
   const OUTCOME = ['Bob wins', 'Draw', 'Alice wins'];

--- a/examples/rps-5-trust/index.mjs
+++ b/examples/rps-5-trust/index.mjs
@@ -12,8 +12,8 @@ const stdlib = loadStdlib(process.env);
   const beforeAlice = await getBalance(accAlice);
   const beforeBob = await getBalance(accBob);
 
-  const ctcAlice = accAlice.deploy(backend);
-  const ctcBob = accBob.attach(backend, ctcAlice.getInfo());
+  const ctcAlice = accAlice.contract(backend);
+  const ctcBob = accBob.contract(backend, ctcAlice.getInfo());
 
   const HAND = ['Rock', 'Paper', 'Scissors'];
   const OUTCOME = ['Bob wins', 'Draw', 'Alice wins'];

--- a/examples/rps-6-timeouts/index.mjs
+++ b/examples/rps-6-timeouts/index.mjs
@@ -12,8 +12,8 @@ const stdlib = loadStdlib(process.env);
   const beforeAlice = await getBalance(accAlice);
   const beforeBob = await getBalance(accBob);
 
-  const ctcAlice = accAlice.deploy(backend);
-  const ctcBob = accBob.attach(backend, ctcAlice.getInfo());
+  const ctcAlice = accAlice.contract(backend);
+  const ctcBob = accBob.contract(backend, ctcAlice.getInfo());
 
   const HAND = ['Rock', 'Paper', 'Scissors'];
   const OUTCOME = ['Bob wins', 'Draw', 'Alice wins'];

--- a/examples/rps-7-array/index.mjs
+++ b/examples/rps-7-array/index.mjs
@@ -12,8 +12,8 @@ import * as backend from './build/index.main.mjs';
   const beforeAlice = await getBalance(accAlice);
   const beforeBob = await getBalance(accBob);
 
-  const ctcAlice = accAlice.deploy(backend);
-  const ctcBob = accBob.attach(backend, ctcAlice.getInfo());
+  const ctcAlice = accAlice.contract(backend);
+  const ctcBob = accBob.contract(backend, ctcAlice.getInfo());
 
   const HAND = ['Rock', 'Paper', 'Scissors'];
   const OUTCOME = ['Bob wins', 'Draw', 'Alice wins'];

--- a/examples/rps-7-loops/index.mjs
+++ b/examples/rps-7-loops/index.mjs
@@ -12,8 +12,8 @@ const stdlib = loadStdlib(process.env);
   const beforeAlice = await getBalance(accAlice);
   const beforeBob = await getBalance(accBob);
 
-  const ctcAlice = accAlice.deploy(backend);
-  const ctcBob = accBob.attach(backend, ctcAlice.getInfo());
+  const ctcAlice = accAlice.contract(backend);
+  const ctcBob = accBob.contract(backend, ctcAlice.getInfo());
 
   const HAND = ['Rock', 'Paper', 'Scissors'];
   const OUTCOME = ['Bob wins', 'Draw', 'Alice wins'];

--- a/examples/rps-8-interact/index.mjs
+++ b/examples/rps-8-interact/index.mjs
@@ -33,7 +33,7 @@ const stdlib = loadStdlib(process.env);
     yesno
   );
   if (deployCtc) {
-    ctc = acc.deploy(backend);
+    ctc = acc.contract(backend);
     ctc.getInfo().then((info) => {
       console.log(`The contract is deployed as = ${JSON.stringify(info)}`); });
   } else {
@@ -41,7 +41,7 @@ const stdlib = loadStdlib(process.env);
       `Please paste the contract information:`,
       JSON.parse
     );
-    ctc = acc.attach(backend, info);
+    ctc = acc.contract(backend, info);
   }
 
   const fmt = (x) => stdlib.formatCurrency(x, 4);


### PR DESCRIPTION
<!--
Hey! Thanks so much!
-->

## Summary
As mentioned in issue #405, this removes the deprecation warning for `deploy` and `attach`.

<!-- Explain what you're trying to do in this pull request -->

<!-- DESIGN: Does this code have some deeper design concept that motivates it that is hard to understand just by reading the code? -->

<!-- TESTING: How did you test this? Is there a new example? Do you have some test scenario you're using? -->
I've manually tested the code in tutorial 3 sample code.

<!-- DOCS: Should there be a documentation or changelog update with this code? -->

Fixes issue #405.