### PR TITLE
make diagnostic `code` use err code added in #335

### DIFF
--- a/vsce/server/src/server.ts
+++ b/vsce/server/src/server.ts
@@ -64,8 +64,6 @@ let hasDiagnosticRelatedInformationCapability: boolean = false;
 
 const NAME: string = 'Reach IDE';
 
-const DIAGNOSTIC_TYPE_COMPILE_ERROR: string = 'Compile Error';
-
 const DID_YOU_MEAN_PREFIX = 'Did you mean: ';
 
 let reachTempIndexFile: string;
@@ -337,7 +335,7 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
 						`${err.errorMessage}`,
 						'Reach compilation encountered an error.',
 						DiagnosticSeverity.Error,
-						DIAGNOSTIC_TYPE_COMPILE_ERROR,
+						err.code,
 						err.suggestions
 					);
 				}


### PR DESCRIPTION
On [line 89 of `hs/src/Reach/AST/Base.hs`, which Chris added in #335](https://github.com/reach-sh/reach-lang/pull/335/files#diff-27c5e2605d727a1d825bfc17e9fc740d8f4b6149ae0efa9835b327b57811c6eaR89) (thank you, Chris!), we gave what is basically Reach's language server access to an error code from Reach's compiler.

This change lets us utilize that error code, so that diagnostics can use that code from Reach's compiler instead of a generic "Compile Error" code, which is what we have currently.

Without this change:

![image](https://user-images.githubusercontent.com/43425812/143129905-ef7551ab-8a7d-486a-b501-61dde26a9523.png)

With this change:

![image](https://user-images.githubusercontent.com/43425812/143129875-26efa069-3652-4ff8-8e78-2df3a8d6dabb.png)

Also, since this change just uses the code from Reach's compiler, now, we can remove a constant that had the sole purpose of holding the `string` `'Compile Error'`.