### PR TITLE
update more dependencies after adding link to err

### DIFF
--- a/vsce/client/package-lock.json
+++ b/vsce/client/package-lock.json
@@ -12,17 +12,17 @@
 				"vscode-languageclient": "^7.0.0"
 			},
 			"devDependencies": {
-				"@types/vscode": "1.43.0",
+				"@types/vscode": "^1.52.0",
 				"vscode-test": "^1.3.0"
 			},
 			"engines": {
-				"vscode": "^1.43.0"
+				"vscode": "^1.52.0"
 			}
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.43.0.tgz",
-			"integrity": "sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==",
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
+			"integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
 			"dev": true
 		},
 		"node_modules/agent-base": {
@@ -256,9 +256,9 @@
 	},
 	"dependencies": {
 		"@types/vscode": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.43.0.tgz",
-			"integrity": "sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==",
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
+			"integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
 			"dev": true
 		},
 		"agent-base": {

--- a/vsce/client/package.json
+++ b/vsce/client/package.json
@@ -10,13 +10,13 @@
 		"url": "https://github.com/reach-sh/reach-lang"
 	},
 	"engines": {
-		"vscode": "^1.43.0"
+		"vscode": "^1.52.0"
 	},
 	"dependencies": {
 		"vscode-languageclient": "^7.0.0"
 	},
 	"devDependencies": {
-		"@types/vscode": "1.43.0",
+		"@types/vscode": "^1.52.0",
 		"vscode-test": "^1.3.0"
 	}
 }

--- a/vsce/client/src/extension.ts
+++ b/vsce/client/src/extension.ts
@@ -20,7 +20,7 @@ import {
 	LanguageClientOptions,
 	ServerOptions,
 	TransportKind,
-} from 'vscode-languageclient';
+} from 'vscode-languageclient/node';
 import { CommandsTreeDataProvider, DocumentationTreeDataProvider, HelpTreeDataProvider } from './CommandsTreeDataProvider';
 
 const COMMANDS = require('../../data/commands.json');


### PR DESCRIPTION
While [CORE-823 update dependencies, add link to err code](https://github.com/reach-sh/reach-lang/pull/410) added a link to an error code on hover, and everything seemed to work fine, it appears that updating

```
"engines": {
		"vscode": "^1.52.0"
	},
```

in `client/package.json` is necessary for TypeScript to build successfully.