### PR TITLE
Fix Lifted API Call

### DIFF
--- a/examples/ctc-address/index.txt
+++ b/examples/ctc-address/index.txt
@@ -4,4 +4,4 @@ Verifying for generic connector
   Verifying when NO participants are honest
   Verifying when ONLY "Alice" is honest
   Verifying when ONLY "Bob" is honest
-Checked 15 theorems; No failures!
+Checked 12 theorems; No failures!

--- a/hs/src/Reach/Connector/ETH_Solidity.hs
+++ b/hs/src/Reach/Connector/ETH_Solidity.hs
@@ -1190,7 +1190,7 @@ apiDef who ApiInfo{..} = do
         let indexedTypes = zip ts [0..]
         unzip <$> mapM (\ (ty, i :: Int) -> do
           let name = pretty $ "_a" <> show i
-          sol_ty <- solType_ ty
+          sol_ty <- solType ty
           let decl = solDecl name (sol_ty <> withArgLoc ty)
           return (name, decl)
           ) indexedTypes

--- a/hs/src/Reach/Connector/ETH_Solidity.hs
+++ b/hs/src/Reach/Connector/ETH_Solidity.hs
@@ -1201,10 +1201,15 @@ apiDef who ApiInfo{..} = do
           [] -> return "false"
           _ -> do
             tc_args <-
-              case ai_msg_vs of
-                [DLVar _ _ (T_Tuple []) _] ->
+              case (ai_msg_vs, ai_msg_tys) of
+                ([DLVar _ _ (T_Tuple []) _], _) ->
                   return $ [ "false" ]
-                [v] -> do
+                -- If the argument to the exported function
+                -- is the same type that the consensus msg's
+                -- type constructor takes, apply it directly
+                ([v], [T_Tuple [t]]) | varType v == t -> do
+                  return $ args
+                ([v], _) -> do
                   tc' <- solType_ $ varType v
                   return $ [ solApply tc' args ]
                 _ -> return args

--- a/hs/t/y/api_address.rsh
+++ b/hs/t/y/api_address.rsh
@@ -1,0 +1,31 @@
+'reach 0.1';
+'use strict';
+
+export const main = Reach.App(() => {
+  const A = Participant('A', {
+    x: Fun([], UInt),
+  });
+  const B = API({ pay: Fun([Address], Null) });
+  deploy();
+
+  A.only(() => {
+    const x = declassify(interact.x());
+  })
+  A.publish(x);
+
+  const [ paid ] =
+    parallelReduce([ false ])
+      .invariant(balance() == 0)
+      .while(!paid)
+      .api(B.pay,
+        _ => 2,
+        (a, k) => {
+          transfer(2).to(a);
+          k(null);
+          return [ true ];
+        })
+      .timeout(false);
+
+  commit();
+
+});

--- a/hs/t/y/api_address.txt
+++ b/hs/t/y/api_address.txt
@@ -1,0 +1,7 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+  Verifying when ONLY "A" is honest
+  Verifying when ONLY "guess" is honest
+Checked 22 theorems; No failures!

--- a/hs/t/y/api_call_arg.rsh
+++ b/hs/t/y/api_call_arg.rsh
@@ -1,0 +1,37 @@
+'reach 0.1';
+
+const Addr = Bytes(64);
+
+export const main = Reach.App(() => {
+  const Constructor = Participant('Constructor', {
+    printInfo: Fun([], Null),
+  });
+  const Manager = API('Manager', {
+    getPoolInfo: Fun([Addr], Null),
+  });
+  const Listener = ParticipantClass('Listener', {
+    hear: Fun([Addr], Null),
+  });
+
+  deploy();
+
+  Constructor.publish();
+  Constructor.interact.printInfo();
+
+  var [] = [];
+  invariant(balance() == 0);
+  while (true) {
+    commit();
+
+    const [ [poolInfo], k ] = call(Manager.getPoolInfo).throwTimeout(false);
+    k(null);
+
+    Listener.interact.hear(poolInfo);
+
+    continue;
+  }
+
+  commit();
+  exit();
+
+});

--- a/hs/t/y/api_call_arg.txt
+++ b/hs/t/y/api_call_arg.txt
@@ -1,0 +1,8 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+  Verifying when ONLY "Constructor" is honest
+  Verifying when ONLY "Listener" is honest
+  Verifying when ONLY "Manager_getPoolInfo" is honest
+Checked 21 theorems; No failures!


### PR DESCRIPTION
If a consensus function expects `arg : T5` and `T5 : { msg : T4 }` and the lifted API function takes an argument `a : T4` do:
`T5(a)` instead of `T5(T4(a))`.

Also, make `Address` arguments `payable` for API functions