### PR TITLE
CORE-761 make compilation use `--stop-after-eval`

### DIFF
--- a/vsce/server/src/server.ts
+++ b/vsce/server/src/server.ts
@@ -310,7 +310,7 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
 		"Starting compilation at",
 		new Date().toLocaleTimeString()
 	);
-	await exec("cd " + tempFolder + " && " + reachPath + " compile " + REACH_TEMP_FILE_NAME + " --error-format-json", (error: { message: any; }, stdout: any, stderr: any) => {
+	await exec("cd " + tempFolder + " && " + reachPath + " compile " + REACH_TEMP_FILE_NAME + " --error-format-json --stop-after-eval", (error: { message: any; }, stdout: any, stderr: any) => {
 		// This callback function should execute exactly
 		// when this compilation command has finished.
 		// "child_process.exec(): spawns a shell...


### PR DESCRIPTION
This only affects Reach's automatic, background compilation. It does not affect the `./reach compile` that occurs when developers click the button in the UI or type `./reach compile` manually, or even if they use the command palette to run `./reach compile`.

This change just makes the automatic background compilation more lightweight, and thus, faster, by checking fewer things.