### PR TITLE
make source of compiler diagnostics more precise

### DIFF
--- a/vsce/server/src/server.ts
+++ b/vsce/server/src/server.ts
@@ -69,7 +69,7 @@ let hasConfigurationCapability: boolean = false;
 let hasWorkspaceFolderCapability: boolean = false;
 let hasDiagnosticRelatedInformationCapability: boolean = false;
 
-const COMPILER_DIAGNOSTIC_SRC: string = 'Reach Compiler';
+const DIAGNOSTIC_SOURCE: string = 'Reach';
 
 const DID_YOU_MEAN_PREFIX = 'Did you mean: ';
 
@@ -344,7 +344,7 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
 						DiagnosticSeverity.Error,
 						err.code,
 						err.suggestions,
-						COMPILER_DIAGNOSTIC_SRC
+						DIAGNOSTIC_SOURCE
 					);
 				}
 			});

--- a/vsce/server/src/server.ts
+++ b/vsce/server/src/server.ts
@@ -69,7 +69,7 @@ let hasConfigurationCapability: boolean = false;
 let hasWorkspaceFolderCapability: boolean = false;
 let hasDiagnosticRelatedInformationCapability: boolean = false;
 
-const NAME: string = 'Reach IDE';
+const COMPILER_DIAGNOSTIC_SRC: string = 'Reach Compiler';
 
 const DID_YOU_MEAN_PREFIX = 'Did you mean: ';
 
@@ -343,7 +343,8 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
 						'Reach compilation encountered an error.',
 						DiagnosticSeverity.Error,
 						err.code,
-						err.suggestions
+						err.suggestions,
+						COMPILER_DIAGNOSTIC_SRC
 					);
 				}
 			});
@@ -362,13 +363,13 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
 	// Send the computed diagnostics to VSCode (before the above promise finishes, just to clear stuff).
 	connection.sendDiagnostics({ uri: textDocument.uri, diagnostics });
 
-	function addDiagnostic(element: ErrorLocation, message: string, details: string, severity: DiagnosticSeverity, code: string | undefined, suggestions: string[]) {
+	function addDiagnostic(element: ErrorLocation, message: string, details: string, severity: DiagnosticSeverity, code: string | undefined, suggestions: string[], source: string) {
 		const href = `https://docs.reach.sh/${code}.html`;
 		let diagnostic: Diagnostic = {
 			severity: severity,
 			range: element.range,
 			message: message,
-			source: NAME,
+			source,
 			code: code,
 			codeDescription: {
 				href


### PR DESCRIPTION
When we publish compiler errors, we don't have to say "Reach IDE". We can be more precise, since we know Reach's compiler is reporting the error messages, and say "Reach Compiler".

Without this change:

![image](https://user-images.githubusercontent.com/43425812/143721966-92a0eb44-c265-4357-951f-0e59601a502c.png)

With this change:

![image](https://user-images.githubusercontent.com/43425812/143721979-1d7f6bcc-dcbd-476c-a09c-2d66507e86c2.png)