### PR TITLE
CORE-887 add new info to suggestions dropdown list

### DIFF
--- a/vsce/server/src/mapKeywordsWithAPeriodToAKeywordList.ts
+++ b/vsce/server/src/mapKeywordsWithAPeriodToAKeywordList.ts
@@ -1,6 +1,6 @@
 // Declare the type here, this way, to avoid an error
 // from TypeScript about an invalid index signature.
-const KEYWORD_TO_ITEM_KIND_IMPORT: {
+export const KEYWORD_TO_ITEM_KIND_IMPORT: {
 	[keyword: string] : 'Text' | 'Method' |
 		'Function' | 'Constructor' | 'Field' |
 		'Variable' | 'Class' | 'Interface' |

--- a/vsce/server/src/server.ts
+++ b/vsce/server/src/server.ts
@@ -60,7 +60,8 @@ const KEYWORD_TO_DOCUMENTATION: { [ keyword: string ] : string } = require(
 // for "smart auto-complete" for things like
 // Reach.App, Participant.Set, Array.zip, etc.
 import {
-	KEYWORD_WITH_PERIOD_TO_KEYWORDS_LIST
+	KEYWORD_WITH_PERIOD_TO_KEYWORDS_LIST,
+	KEYWORD_TO_ITEM_KIND_IMPORT
 } from "./mapKeywordsWithAPeriodToAKeywordList";
 
 // Create a connection for the server. The connection uses Node's IPC as a transport.
@@ -597,7 +598,9 @@ connection.onCompletion((
 			keyword
 		] || CompletionItemKind.Text,
 		data: undefined,
-		detail: keyword,
+		detail: `(${
+			KEYWORD_TO_ITEM_KIND_IMPORT[keyword]
+		})`,
 		documentation: {
 			kind: 'markdown',
 			value: getReachKeywordMarkdown(keyword)


### PR DESCRIPTION
This change has the effect of changing the righthand side of the suggestions dropdown list when developers select a Reach keyword.

For example, the righthand side of `checkCommitment` now says `(Function)`, instead of `checkCommitment`. So, the suggestions dropdown list now adds new information, instead of just repeating existing information, for Reach keywords.

Without this change:

![Screen Shot 2021-12-09 at 3 55 50 PM](https://user-images.githubusercontent.com/43425812/145494065-e137c0da-673c-48c8-b793-e5d81ed54d0b.png)

With this change:

![Screen Shot 2021-12-09 at 3 53 41 PM](https://user-images.githubusercontent.com/43425812/145493857-ad310c0b-a6f5-49d7-8738-f45e0363ba40.png)