### PR TITLE
Fix rps-7-rpc/client-js concurrency for Bob participant

### DIFF
--- a/examples/rps-7-rpc/client-js/index.mjs
+++ b/examples/rps-7-rpc/client-js/index.mjs
@@ -46,13 +46,13 @@ import { mkRPC } from '@reach-sh/rpc-client';
 
     rpc(`/ctc/getInfo`, ctcAlice).then(async (info) => {
       const ctcBob = await rpc(`/acc/attach`, accBob, info);
-      rpcCallbacks(`/backend/Bob`, ctcBob, {
+      await rpcCallbacks(`/backend/Bob`, ctcBob, {
         ...Player('Bob'),
         acceptWager: async (amt) => {
           console.log(`Bob accepts the wager of ${await fmt(amt)}.`);
         },
       });
-    return await rpc(`/forget/ctc`, ctcBob);
+      return await rpc(`/forget/ctc`, ctcBob);
     }),
   ]);
 


### PR DESCRIPTION
Note how, before, `ctcBob` is being sent to `/forget/ctc` before his backend has necessarily completed:

https://85282-205868997-gh.circle-artifacts.com/0/tmp/artifacts/ETH.rps-7-rpc.gz