### PR TITLE
CORE-885 track VS ext usage with environment var

### DIFF
--- a/hs/app/reach/Main.hs
+++ b/hs/app/reach/Main.hs
@@ -172,6 +172,7 @@ data Var = Var
   { reachEx :: Text
   , connectorMode :: Maybe ConnectorMode
   , debug :: Bool
+  , ide :: Bool
   , rpcKey :: Text
   , rpcPort :: Text
   , rpcServer'' :: Text
@@ -281,11 +282,6 @@ warnScaffoldDefRPCTLSPair (Project {..}) = do
       defC <- readFile (embd "tls-default.key")
       when (keyC == defC) warnDev
 
-truthyEnv :: Maybe String -> Bool
-truthyEnv = \case
-  Nothing -> False
-  Just s -> not $ elem (map toLower s) [ "", "0", "false", "f", "#f", "no", "off", "n" ]
-
 mkVar :: IO Var
 mkVar = do
   let packed = pure . pack
@@ -299,6 +295,7 @@ mkVar = do
   rpcTLSCrt <- q "REACH_RPC_TLS_CRT" (pure "reach-server.crt")
   version'' <- mkReachVersion
   debug <- truthyEnv <$> lookupEnv "REACH_DEBUG"
+  ide <- truthyEnv <$> lookupEnv "REACH_IDE"
   rpcTLSRejectUnverified <- lookupEnv "REACH_RPC_TLS_REJECT_UNVERIFIED"
     >>= maybe (pure True) (pure . (/= "0"))
   reachEx <- lookupEnv "REACH_EX"
@@ -317,6 +314,7 @@ mkScript :: Text -> App -> App
 mkScript connectorMode' wrapped = do
   Var {..} <- asks e_var
   let debug' = if debug then "REACH_DEBUG=1\n" else ""
+  let ide' = if ide then "REACH_IDE=1\n" else ""
   let rpcTLSRejectUnverified' = case rpcTLSRejectUnverified of
         True -> ""
         False -> "REACH_RPC_TLS_REJECT_UNVERIFIED=0\n"
@@ -335,6 +333,7 @@ mkScript connectorMode' wrapped = do
        |]
     <> "\n\n"
     <> debug'
+    <> ide'
     <> rpcTLSRejectUnverified'
     -- Don't leak production `REACH_RPC_KEY` or `REACH_RPC_TLS_PASSPHRASE`
     <> defOrBlank "REACH_RPC_KEY" defRPCKey rpcKey
@@ -349,6 +348,7 @@ mkScript connectorMode' wrapped = do
 
           export REACH_CONNECTOR_MODE
           export REACH_DEBUG
+          export REACH_IDE
           export REACH_RPC_KEY
           export REACH_RPC_PORT
           export REACH_RPC_SERVER
@@ -895,6 +895,7 @@ compile = command "compile" $ info f d where
             --volume "$$PWD:/app" \
             -u "$(id -ru):$(id -rg)" \
             -e REACH_CONNECTOR_MODE \
+            -e REACH_IDE \
             -e "REACHC_ID=$${ID}" \
             -e "CI=$ci'" \
             $ports \

--- a/hs/src/Reach/CommandLine.hs
+++ b/hs/src/Reach/CommandLine.hs
@@ -5,10 +5,12 @@ module Reach.CommandLine
   , compiler
   , getCompilerArgs
   , getCompilerEnv
+  , truthyEnv
   ) where
 
 import Options.Applicative
 import System.Environment
+import Data.Char
 import Data.Maybe (isJust)
 
 data CompilerToolArgs = CompilerToolArgs
@@ -97,3 +99,8 @@ getCompilerEnv = do
   cte_TF_BUILD <- lookupEnv "TF_BUILD"
   cte_REACH_DEBUG <- fmap isJust $ lookupEnv "REACH_DEBUG"
   return CompilerToolEnv {..}
+
+truthyEnv :: Maybe String -> Bool
+truthyEnv = \case
+  Nothing -> False
+  Just s -> not $ elem (map toLower s) [ "", "0", "false", "f", "#f", "no", "off", "n" ]

--- a/hs/src/Reach/Report.hs
+++ b/hs/src/Reach/Report.hs
@@ -20,6 +20,8 @@ startReport :: Maybe String -> String -> IO (Report -> IO ())
 startReport mwho i = do
   startTime <- getCurrentTime
   cm <- lookupEnv "REACH_CONNECTOR_MODE" >>= maybe (pure "") pure
+  --- check env variable to track extension usage
+  vse <- lookupEnv "REACH_IDE" >>= maybe (pure "") pure
   req <- parseRequest $ "https://log.reach.sh/submit"
   manager <- newManager tlsManagerSettings
   let send log_req = async $ runReaderT (httpNoBody log_req) manager
@@ -37,6 +39,7 @@ startReport mwho i = do
             , "elapsed" .= diffUTCTime endTime startTime
             , "result" .= show what
             , "connectorMode" .= cm
+            , "usingVisualStudioExtension" .= vse
             , "initiator" .= i
             ]
     m <- send (setRequestBodyJSON rep $ setRequestMethod "POST" req)

--- a/hs/src/Reach/Report.hs
+++ b/hs/src/Reach/Report.hs
@@ -11,6 +11,7 @@ import Network.HTTP.Client.TLS
 import Network.HTTP.Conduit
 import Network.HTTP.Simple (setRequestBodyJSON, setRequestMethod)
 import System.Environment
+import Reach.CommandLine
 import Reach.Version
 
 --- TODO maybe have each part collect some information and report it back through a (Map String String)
@@ -20,8 +21,7 @@ startReport :: Maybe String -> String -> IO (Report -> IO ())
 startReport mwho i = do
   startTime <- getCurrentTime
   cm <- lookupEnv "REACH_CONNECTOR_MODE" >>= maybe (pure "") pure
-  --- check env variable to track extension usage
-  vse <- lookupEnv "REACH_IDE" >>= maybe (pure "") pure
+  vse <- truthyEnv <$> lookupEnv "REACH_IDE"
   req <- parseRequest $ "https://log.reach.sh/submit"
   manager <- newManager tlsManagerSettings
   let send log_req = async $ runReaderT (httpNoBody log_req) manager

--- a/reach
+++ b/reach
@@ -29,6 +29,7 @@ run_d () {
       -e "REACH_EX=$0" \
       -e "REACH_CONNECTOR_MODE" \
       -e "REACH_DEBUG" \
+      -e "REACH_IDE" \
       -e "REACH_RPC_KEY" \
       -e "REACH_RPC_PORT"  \
       -e "REACH_RPC_SERVER" \

--- a/vsce/client/src/extension.ts
+++ b/vsce/client/src/extension.ts
@@ -22,6 +22,7 @@ import {
 	TransportKind,
 } from 'vscode-languageclient/node';
 import { CommandsTreeDataProvider, DocumentationTreeDataProvider, HelpTreeDataProvider } from './CommandsTreeDataProvider';
+import { terminalOptions } from "./terminalOptions";
 
 const COMMANDS = require('../../data/commands.json');
 
@@ -54,7 +55,7 @@ export function activate(context: ExtensionContext) {
 		}
 	};
 
-	terminal = window.createTerminal({ name: 'Reach IDE' });
+	terminal = window.createTerminal(terminalOptions);
 	const reachExecutablePath = workspace.getConfiguration().get('reachide.executableLocation') as string;
 	const wf = workspace.workspaceFolders[0].uri.path || '.';
 	const reachPath = (reachExecutablePath === './reach')

--- a/vsce/client/src/terminalOptions.ts
+++ b/vsce/client/src/terminalOptions.ts
@@ -1,0 +1,18 @@
+import { TerminalOptions } from 'vscode';
+
+const env: { [key: string]: string } = {
+	REACH_IDE: "1"
+};
+
+const name = 'Reach IDE';
+
+/**
+ * Use these options when creating a terminal so we
+ * can do things like add custom environment
+ * variables.
+ */
+export const terminalOptions: TerminalOptions = {
+	env,
+	name
+};
+

--- a/vsce/server/src/server.ts
+++ b/vsce/server/src/server.ts
@@ -33,6 +33,11 @@ import {
 	Hover,
 } from 'vscode-languageserver';
 
+// edit env variable to track extension usage; see
+// https://nodejs.org/api/process.html#processenv
+import { env } from "process";
+env.REACH_IDE = "1";
+
 // Do this import from vscode-languageserver/node instead of
 // vscode-languageserver to avoid
 // "Expected 2-3 arguments, but got 1.ts(2554)


### PR DESCRIPTION
Because we run `reach` commands both client-side, in `vsce/client/src/extension.ts`, and server-side, in `vsce/server/src/server.ts`, we need to modify the environment variable in both of these files to properly track usage of our Visual Studio extension.