### PR TITLE
update `server/package.json` vers after CORE-867

### DIFF
--- a/vsce/server/package.json
+++ b/vsce/server/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "reach-lsp-server",
+	"name": "@reach-sh/reach-lsp-server",
 	"description": "Reach Language Server",
-	"version": "0.0.1",
+	"version": "0.1.7-rc.3",
 	"author": "Reach Platform, Inc.",
 	"license": "EPL-2.0",
 	"engines": {


### PR DESCRIPTION
CORE-867 is about publishing our language server to `npm`. I was able to do that yesterday; this change just synchronizes the `server/package.json` version to match the version with which I published the `npm` package for our language server.