### PR TITLE
CORE-924: Add `verifyMuldiv`

### DIFF
--- a/docs/src/changelog/index.md
+++ b/docs/src/changelog/index.md
@@ -7,6 +7,7 @@ Versions and changes-within-versions are listed in reverse-chronological order: 
 
 Version 0.1.7 is the current Reach release candidate version.
 
++ 2021/12/23: Added `{!rsh} verifyMuldiv`.
 + 2021/12/23: `{!rsh} deploy` was renamed to `{!rsh} init`.
 + 2021/12/21: The backend interface to deployed contracts was updated, so old contracts will not work with this version.
 + 2021/12/21: The backend interface to the compiled objects was updated, so you'll need to recompile for this release.

--- a/docs/src/rsh/compute/index.md
+++ b/docs/src/rsh/compute/index.md
@@ -1798,6 +1798,29 @@ muldiv(a, b, c)
 The intermediate value may be larger than `{!rsh} UInt.max` if the connector supports wide arithmetic operations.
 The resulting quotient must be less than `{!rsh} UInt.max`.
 
+### `verifyMuldiv`
+
+:::note
+`verifyMuldiv` is required to verify `{!rsh} muldiv` when using `verifyArithmetic`
+:::
+
+@{ref("rsh", "verifyMuldiv")}
+```reach
+A.only(() => {
+  const { x, y, z} = declassify(interact.params);
+  verifyMuldiv(x, y, z);
+});
+A.publish(x, y, z);
+verifyMuldiv(x, y, z);
+const r = muldiv(x, y, z);
+```
+
+ `{!rsh} verifyMuldiv` generates a claim that the result of applying the same arguments to `{!rsh} muldiv` will not overflow.
+When used inside of a local step, it will generate an `{!rsh} assume` claim.
+When used inside of a consensus step, it will generate a `{!rsh} require` claim.
+When used inside of any other step, it will generate an `{!rsh} assert` claim.
+
+
 ### `sqrt`
 
 @{ref("rsh", "sqrt")}

--- a/hs/src/Reach/AST/Base.hs
+++ b/hs/src/Reach/AST/Base.hs
@@ -71,7 +71,7 @@ instance Pretty SrcLoc where
   pretty = viaShow
 
 data ImpossibleError
-  = Err_Impossible_InspectForall
+  = Err_Impossible_Inspect String
   deriving (Eq, Ord, Generic, ErrorMessageForJson, ErrorSuggestions)
 
 instance HasErrorCode ImpossibleError where
@@ -81,12 +81,12 @@ instance HasErrorCode ImpossibleError where
   -- If you delete a constructor, do NOT re-allocate the number.
   -- Add new error codes at the end.
   errIndex = \case
-    Err_Impossible_InspectForall -> 0
+    Err_Impossible_Inspect {} -> 0
 
 instance Show ImpossibleError where
   show = \case
-    Err_Impossible_InspectForall ->
-      "Cannot inspect value from `forall`"
+    Err_Impossible_Inspect f ->
+      "Cannot inspect value from `" <> f <> "`"
 
 instance Pretty ImpossibleError where
   pretty = viaShow

--- a/hs/src/Reach/AST/DLBase.hs
+++ b/hs/src/Reach/AST/DLBase.hs
@@ -609,7 +609,7 @@ instance PrettySubst DLExpr where
     DLE_Impossible _ _ err -> return $ "impossible" <> parens (pretty err)
     DLE_VerifyMuldiv _ cl as _ -> do
       as' <- render_dasM as
-      return $ "safeMulDiv" <> parens (viaShow cl) <> parens as'
+      return $ "verifyMuldiv" <> parens (viaShow cl) <> parens as'
     DLE_PrimOp _ IF_THEN_ELSE [c, t, el] -> do
       c' <- prettySubst c
       t' <- prettySubst t

--- a/hs/src/Reach/AST/DLBase.hs
+++ b/hs/src/Reach/AST/DLBase.hs
@@ -539,6 +539,7 @@ data DLExpr
   = DLE_Arg SrcLoc DLArg
   | DLE_LArg SrcLoc DLLargeArg
   | DLE_Impossible SrcLoc Int ImpossibleError
+  | DLE_VerifyMuldiv SrcLoc ClaimType [DLArg] ImpossibleError
   | DLE_PrimOp SrcLoc PrimOp [DLArg]
   | DLE_ArrayRef SrcLoc DLArg DLArg
   | DLE_ArraySet SrcLoc DLArg DLArg DLArg
@@ -606,6 +607,9 @@ instance PrettySubst DLExpr where
     DLE_Arg _ a -> prettySubst a
     DLE_LArg _ a -> prettySubst a
     DLE_Impossible _ _ err -> return $ "impossible" <> parens (pretty err)
+    DLE_VerifyMuldiv _ cl as _ -> do
+      as' <- render_dasM as
+      return $ "safeMulDiv" <> parens (viaShow cl) <> parens as'
     DLE_PrimOp _ IF_THEN_ELSE [c, t, el] -> do
       c' <- prettySubst c
       t' <- prettySubst t
@@ -718,6 +722,7 @@ instance IsPure DLExpr where
     DLE_Arg {} -> True
     DLE_LArg {} -> True
     DLE_Impossible {} -> True
+    DLE_VerifyMuldiv {} -> True
     DLE_PrimOp {} -> True
     DLE_ArrayRef {} -> True
     DLE_ArraySet {} -> True
@@ -754,6 +759,7 @@ instance IsLocal DLExpr where
     DLE_Arg {} -> True
     DLE_LArg {} -> True
     DLE_Impossible {} -> True
+    DLE_VerifyMuldiv {} -> True
     DLE_PrimOp {} -> True
     DLE_ArrayRef {} -> True
     DLE_ArraySet {} -> True

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -706,7 +706,6 @@ data SLPrimitive
   | SLPrim_Token_burn
   | SLPrim_Token_destroy
   | SLPrim_Token_destroyed
-  | SLPrim_muldiv
   | SLPrim_didPublish
   | SLPrim_unstrict
   | SLPrim_polyNeq
@@ -715,6 +714,7 @@ data SLPrimitive
   | SLPrim_EmitLog
   | SLPrim_Event
   | SLPrim_event_is (Maybe SLPart) SLVar [SLType]
+  | SLPrim_verifyMuldiv
   deriving (Eq, Generic)
 
 instance Equiv SLPrimitive where

--- a/hs/src/Reach/Backend/JS.hs
+++ b/hs/src/Reach/Backend/JS.hs
@@ -305,6 +305,8 @@ jsExpr = \case
     jsLargeArg la
   DLE_Impossible at _ err ->
     expect_thrown at err
+  DLE_VerifyMuldiv at _ _ err ->
+    expect_thrown at err
   DLE_PrimOp _ p as ->
     jsPrimApply p <$> mapM jsArg as
   DLE_ArrayRef _ aa ia -> do

--- a/hs/src/Reach/CollectCounts.hs
+++ b/hs/src/Reach/CollectCounts.hs
@@ -129,6 +129,7 @@ instance Countable DLExpr where
     DLE_Arg _ a -> counts a
     DLE_LArg _ a -> counts a
     DLE_Impossible {} -> mempty
+    DLE_VerifyMuldiv _ _ as _ -> counts as
     DLE_PrimOp _ _ as -> counts as
     DLE_ArrayRef _ aa ea -> counts [aa, ea]
     DLE_ArraySet _ aa ia va -> counts [aa, ia, va]

--- a/hs/src/Reach/CollectTypes.hs
+++ b/hs/src/Reach/CollectTypes.hs
@@ -108,6 +108,7 @@ instance CollectsTypes DLExpr where
     DLE_Arg _ a -> cts a
     DLE_LArg _ la -> cts $ largeArgTypeOf la
     DLE_Impossible {} -> mempty
+    DLE_VerifyMuldiv _ _ as _ -> cts as
     DLE_PrimOp _ p as -> cts p <> cts as
     DLE_ArrayRef _ a i -> cts a <> cts i
     DLE_ArraySet _ a i v -> cts a <> cts i <> cts v

--- a/hs/src/Reach/Connector/ALGO.hs
+++ b/hs/src/Reach/Connector/ALGO.hs
@@ -1286,6 +1286,8 @@ ce = \case
   DLE_Arg _ a -> ca a
   DLE_LArg _ a -> cla a
   DLE_Impossible at _ err -> expect_thrown at err
+  DLE_VerifyMuldiv at _ _ err ->
+    expect_thrown at err
   DLE_PrimOp _ p args -> cprim p args
   DLE_ArrayRef at aa ia -> doArrayRef at aa True (Left ia)
   DLE_ArraySet at aa ia va -> do

--- a/hs/src/Reach/Connector/ETH_Solidity.hs
+++ b/hs/src/Reach/Connector/ETH_Solidity.hs
@@ -366,6 +366,7 @@ instance DepthOf DLExpr where
     DLE_Arg _ a -> depthOf a
     DLE_LArg _ a -> depthOf a
     DLE_Impossible {} -> return 0
+    DLE_VerifyMuldiv {} -> return 0
     DLE_PrimOp _ _ as -> add1 $ depthOf as
     DLE_ArrayRef _ x y -> add1 $ depthOf [x, y]
     DLE_ArraySet _ x y z -> depthOf [x, y, z]
@@ -569,6 +570,8 @@ solExpr sp = \case
   DLE_LArg {} ->
     impossible "large arg"
   DLE_Impossible at _ err ->
+    expect_thrown at err
+  DLE_VerifyMuldiv at _ _ err ->
     expect_thrown at err
   DLE_PrimOp _ p args -> do
     args' <- mapM solArg args

--- a/hs/src/Reach/Freshen.hs
+++ b/hs/src/Reach/Freshen.hs
@@ -110,6 +110,7 @@ instance Freshen DLExpr where
     DLE_Arg at a -> DLE_Arg at <$> fu a
     DLE_LArg at a -> DLE_LArg at <$> fu a
     e@(DLE_Impossible {}) -> return $ e
+    DLE_VerifyMuldiv at cl as err -> DLE_VerifyMuldiv at cl <$> fu as <*> pure err
     DLE_PrimOp at p as -> DLE_PrimOp at p <$> fu as
     DLE_ArrayRef at a b -> DLE_ArrayRef at <$> fu a <*> fu b
     DLE_ArraySet at a b c -> DLE_ArraySet at <$> fu a <*> fu b <*> fu c

--- a/hs/src/Reach/Optimize.hs
+++ b/hs/src/Reach/Optimize.hs
@@ -253,7 +253,7 @@ instance Optimize DLExpr where
     DLE_VerifyMuldiv at cl args err ->
       opt (DLE_PrimOp at MUL_DIV args) >>= \case
         DLE_PrimOp _ _ args' -> return $ DLE_VerifyMuldiv at cl args' err
-        _ -> impossible "opt: safeMulDiv"
+        _ -> impossible "opt: verifyMulDiv"
     DLE_PrimOp at p as -> do
       as' <- opt as
       let meh = return $ DLE_PrimOp at p as'

--- a/hs/src/Reach/Optimize.hs
+++ b/hs/src/Reach/Optimize.hs
@@ -250,6 +250,10 @@ instance Optimize DLExpr where
     DLE_LArg at a -> DLE_LArg at <$> opt a
     DLE_Impossible at tag lab ->
       return $ DLE_Impossible at tag lab
+    DLE_VerifyMuldiv at cl args err ->
+      opt (DLE_PrimOp at MUL_DIV args) >>= \case
+        DLE_PrimOp _ _ args' -> return $ DLE_VerifyMuldiv at cl args' err
+        _ -> impossible "opt: safeMulDiv"
     DLE_PrimOp at p as -> do
       as' <- opt as
       let meh = return $ DLE_PrimOp at p as'

--- a/hs/src/Reach/Sanitize.hs
+++ b/hs/src/Reach/Sanitize.hs
@@ -61,6 +61,7 @@ instance Sanitize DLExpr where
     DLE_Arg _ a -> DLE_Arg sb $ sani a
     DLE_LArg _ a -> DLE_LArg sb $ sani a
     DLE_Impossible _ t m -> DLE_Impossible sb t m
+    DLE_VerifyMuldiv _ cl as err -> DLE_VerifyMuldiv sb cl (sani as) err
     DLE_PrimOp _ f as -> DLE_PrimOp sb f (sani as)
     DLE_ArrayRef _ a i -> DLE_ArrayRef sb (sani a) (sani i)
     DLE_ArraySet _ a i v -> DLE_ArraySet sb (sani a) (sani i) (sani v)

--- a/hs/src/Reach/Simulator/Core.hs
+++ b/hs/src/Reach/Simulator/Core.hs
@@ -391,6 +391,7 @@ instance Interp DLExpr where
     DLE_Arg _at dlarg -> interp dlarg
     DLE_LArg _at dllargearg -> interp dllargearg
     DLE_Impossible at _int err -> expect_thrown at err
+    DLE_VerifyMuldiv at _ _ err -> expect_thrown at err
     DLE_PrimOp _at primop dlargs -> do
       evd_args <- mapM interp dlargs
       interpPrim (primop,evd_args)

--- a/hs/src/Reach/Subst.hs
+++ b/hs/src/Reach/Subst.hs
@@ -76,6 +76,7 @@ instance Subst DLExpr where
     DLE_Arg at a -> DLE_Arg at <$> subst a
     DLE_LArg at a -> DLE_LArg at <$> subst a
     e@(DLE_Impossible {}) -> return $ e
+    DLE_VerifyMuldiv at cl as err -> DLE_VerifyMuldiv at cl <$> subst as <*> pure err
     DLE_PrimOp at p as -> DLE_PrimOp at p <$> subst as
     DLE_ArrayRef at a b -> DLE_ArrayRef at <$> subst a <*> subst b
     DLE_ArraySet at a b c -> DLE_ArraySet at <$> subst a <*> subst b <*> subst c

--- a/hs/src/Reach/Verify/Knowledge.hs
+++ b/hs/src/Reach/Verify/Knowledge.hs
@@ -193,6 +193,7 @@ kgq_e ctxt mv = \case
   DLE_Arg _ a -> kgq_a_onlym ctxt mv a
   DLE_LArg _ la -> kgq_la ctxt mv la
   DLE_Impossible {} -> mempty
+  DLE_VerifyMuldiv {} -> mempty
   DLE_PrimOp _ _ as -> kgq_la ctxt mv (DLLA_Tuple as)
   DLE_ArrayRef _ a e -> kgq_la ctxt mv (DLLA_Tuple [a, e])
   DLE_ArraySet _ a e n -> kgq_la ctxt mv (DLLA_Tuple [a, e, n])

--- a/hs/src/Reach/Verify/SMT.hs
+++ b/hs/src/Reach/Verify/SMT.hs
@@ -280,6 +280,11 @@ smtDeclare_v v t l = do
   smtDeclare smt v (Atom s) l
   smtTypeInv t $ Atom v
 
+smtMulDiv :: [SExpr] -> App SExpr
+smtMulDiv = \case
+  [x, y, den] -> return $ smtApply "div" [ smtApply "*" [ x, y ], den ]
+  _ -> impossible "smtPrimOp: MUL_DIV args"
+
 smtPrimOp :: SrcLoc -> PrimOp -> [DLArg] -> [SExpr] -> App SExpr
 smtPrimOp at p dargs =
   case p of
@@ -305,10 +310,7 @@ smtPrimOp at p dargs =
     (BYTES_ZPAD xtra) -> \args -> do
       xtra' <- smt_la at $ bytesZeroLit xtra
       return $ smtApply "bytesAppend" (args <> [ xtra' ])
-    MUL_DIV ->
-      \case
-        [x, y, den] -> return $ smtApply "div" [ smtApply "*" [ x, y ], den ]
-        _ -> impossible "smtPrimOp: MUL_DIV args"
+    MUL_DIV -> smtMulDiv
     SELF_ADDRESS pn isClass _ ->
       case dargs of
         [] -> \_ ->
@@ -969,6 +971,11 @@ smt_e at_dv mdv de = do
     DLE_Arg at da -> bound at =<< smt_a at da
     DLE_LArg at dla -> bound at =<< smt_la at dla
     DLE_Impossible {} -> unbound at_dv
+    DLE_VerifyMuldiv at cl args _ -> do
+      args' <- mapM (smt_a at) args
+      md <- smtMulDiv args'
+      let lt = uint256_le md (Atom $ smtConstant DLC_UInt_max)
+      doClaim at [] cl lt Nothing
     DLE_PrimOp at cp args -> do
       let f = case cp of
                 SELF_ADDRESS {} -> \ se -> pathAddBound at mdv (Just $ SMTProgram de) se Witness

--- a/hs/t/y/verifyMuldiv.rsh
+++ b/hs/t/y/verifyMuldiv.rsh
@@ -1,0 +1,43 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const A = Participant('A', {
+    params: Object({
+      x: UInt,
+      y: UInt,
+      cx: UInt,
+      cy: UInt,
+    }),
+    show: Fun(true, Null),
+  });
+  setOptions({ verifyArithmetic: true });
+  deploy();
+
+  A.only(() => {
+    const params = declassify(interact.params);
+    assume(params.cx > 0);
+    assume(params.cy > 0);
+    assume(params.cx <= UInt.max / params.cy);
+    assume(params.x <= UInt.max);
+    assume(params.y <= UInt.max);
+    verifyMuldiv(params.x, params.y, params.cx * params.cy);
+  });
+  A.publish(params);
+
+  const { x, y, cx, cy } = params;
+
+  require(cx > 0);
+  require(cy > 0);
+  require(cx <= UInt.max / cy);
+  require(x <= UInt.max);
+  require(y <= UInt.max);
+  verifyMuldiv(x, y, cx * cy);
+
+  const j = muldiv(x, y, cx * cy);
+
+  require(j <= UInt.max);
+  A.interact.show(j);
+  commit();
+  verifyMuldiv(x, y, cx * cy);
+
+});

--- a/hs/t/y/verifyMuldiv.txt
+++ b/hs/t/y/verifyMuldiv.txt
@@ -1,0 +1,6 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+  Verifying when ONLY "A" is honest
+Checked 38 theorems; No failures!

--- a/hs/test/Reach/Test_Docs.hs
+++ b/hs/test/Reach/Test_Docs.hs
@@ -30,7 +30,7 @@ allErrorCodes =
   , (errPrefix (Linearize.Err_Unreachable ""), gconNum @Linearize.Error)
   , (errPrefix Err_Unauthorized, gconNum @PkgError)
   , (errPrefix Err_Parse_JSIdentNone, gconNum @ParserError)
-  , (errPrefix Err_Impossible_InspectForall, gconNum @ImpossibleError)
+  , (errPrefix (Err_Impossible_Inspect ""), gconNum @ImpossibleError)
   , (errPrefix Err_TransferNewToken, gconNum @AlgoError)
   , (errPrefix (API_NoIn ""), gconNum @APICutError)
   , (errPrefix W_ExternalObject, gconNum @Warning)


### PR DESCRIPTION
Add `verifyMuldiv` that is a context-sensitive claim that the result of `muldiv(x, y, z)` will not overflow. This expression will either add an  `assume` in local steps, `require` in consensus steps, or `assert` otherwise. 

In short, I think this is the easiest implementation (bundling the assertion within the expression) because otherwise EraseLogic would need to erase assume/require depending on whether they contain a `verifyMuldiv`. That info is not easily discoverable in EraseLogic, which iterates backwards through the computation. 