### PR TITLE
Fix RPC Server Error: TypeError: Cannot read property 'readable' of undefined  at IncomingMessage._read (_http_incoming.js:120:19)

### DIFF
--- a/js/js-deps/package.json
+++ b/js/js-deps/package.json
@@ -25,10 +25,11 @@
   },
   "dependencies": {
     "@msgpack/msgpack": "^2.5.1",
-    "algosdk": "^1.12.0",
     "@randlabs/myalgo-connect": "^1.1.1",
+    "@types/spdy": "^3.4.5",
     "@walletconnect/client": "^1.6.5",
     "algorand-walletconnect-qrcode-modal": "^1.6.1",
+    "algosdk": "^1.12.0",
     "await-timeout": "^0.6.0",
     "ethers": "^5.4.7",
     "express": "^4.17.1",
@@ -39,6 +40,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "^4.0.3",
+    "spdy": "^4.0.2",
     "wait-port": "^0.2.9"
   },
   "author": "reach.sh",

--- a/js/stdlib/package.mo.json
+++ b/js/stdlib/package.mo.json
@@ -45,7 +45,9 @@
     "js-conflux-sdk": "git+https://github.com/reach-sh/js-conflux-sdk#v1_6_0_blockNumber",
     "jsbi": "^3.1.6",
     "node-fetch": "^2.6.1",
-    "wait-port": "^0.2.9"
+    "wait-port": "^0.2.9",
+    "spdy": "^4.0.2",
+    "@types/spdy": "^3.4.5"
   },
   "repository": {
     "type": "git",

--- a/js/stdlib/ts/rpc_server.ts
+++ b/js/stdlib/ts/rpc_server.ts
@@ -1,4 +1,4 @@
-import { createSecureServer       } from 'http2';
+import spdy from 'spdy';
 import { randomBytes              } from 'crypto';
 import { readFileSync, existsSync } from 'fs';
 import { resolve                  } from 'path';
@@ -446,7 +446,7 @@ export const serveRpc = async (backend: any) => {
     Object.assign(opts, { passphrase });
 
   // @ts-ignore
-  createSecureServer(opts, app)
+  spdy.createServer(opts, app)
     .listen(process.env.REACH_RPC_PORT, () =>
-      debug(`I am alive`));
+      debug(`I am alive (with spdy)`));
 };


### PR DESCRIPTION
## Summary

When attempting to work through the reach-sh guides I found that the RPC Server `reach rpc-server` would not handle any requests. Any request would crash rpc server with the following output:

```
$ sh serve.sh 
Warning! Using development RPC key: REACH_RPC_KEY=opensesame.
Warning! The current TLS certificate is only suitable for development purposes.
Verifying knowledge assertions
Verifying for generic connector
  Verifying when ALL participants are honest
  Verifying when NO participants are honest
  Verifying when ONLY "Alice" is honest
  Verifying when ONLY "Bob" is honest
Checked 17 theorems; No failures!

> @reach-sh/rpc-server@ app /app
> node --experimental-modules --unhandled-rejections=strict index.mjs

2022-01-01T17:41:08.488Z DEBUG: address_ethToCfx call 0x0000000000000000000000000000000000000000
2022-01-01T17:41:08.563Z DEBUG: I am alive
_http_incoming.js:120
  if (this.socket.readable)
                  ^

TypeError: Cannot read property 'readable' of undefined
    at IncomingMessage._read (_http_incoming.js:120:19)
    at IncomingMessage.Readable.read (internal/streams/readable.js:481:10)
    at resume_ (internal/streams/readable.js:977:12)
    at processTicksAndRejections (internal/process/task_queues.js:82:21)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @reach-sh/rpc-server@ app: `node --experimental-modules --unhandled-rejections=strict index.mjs`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @reach-sh/rpc-server@ app script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2022-01-01T17_41_10_606Z-debug.log
```
In the above crash, I attempted to perform the following request:
```
curl -ik -X POST -H 'X-API-Key: opensesame' -H 'Content-Type: application/json; charset=utf-8' https://127.0.0.1:3000/stdlib/parseCurrency -d '[4]'
```


I did some investigation and found this issue for express library: https://github.com/expressjs/express/issues/3388 

Apparently, the current version of express (v4) is not compatible with http2. Suggestions are to upgrade to express v5 or use spdy for http2. Since v5 is still in alpha stage, decided to use the more stable spdy library in place of http2.


### DESIGN
There are no fundamental design changes or impact from this change.

### TESTING
I used the following test scenario (On mac Mojave 10.14.6):
1. Using project [complete the reach-tut for rock paper scissors ](https://github.com/jeremygiberson/reach-tut/releases/tag/rpc-server-issue) 
2. start rpc-server `sh ./serve.sh`
```
$ REACH_DEBUG=* REACH_RPC_PORT=3000 REACH_CONNECTOR_MODE=ETH ~/reach rpc-server
Warning! Using development RPC key: REACH_RPC_KEY=opensesame.
Warning! The current TLS certificate is only suitable for development purposes.
Verifying knowledge assertions
Verifying for generic connector
  Verifying when ALL participants are honest
  Verifying when NO participants are honest
  Verifying when ONLY "Alice" is honest
  Verifying when ONLY "Bob" is honest
Checked 17 theorems; No failures!

> @reach-sh/rpc-server@ app /app
> node --experimental-modules --unhandled-rejections=strict index.mjs

2022-01-01T18:49:49.943Z DEBUG: address_ethToCfx call 0x0000000000000000000000000000000000000000
2022-01-01T18:49:50.021Z DEBUG: I am alive (with spdy)
```
3. Issue a curl request to to rpc server:
```
$ curl -ik -X POST -H 'X-API-Key: opensesame' -H 'Content-Type: application/json; charset=utf-8' https://127.0.0.1:3000/stdlib/parseCurrency -d '[4]'
HTTP/2 200 
content-type: application/json; charset=utf-8
content-length: 47
etag: W/"2f-Vu0VXEJaX6DEbqJzyQltFH8v+4Q"

{"type":"BigNumber","hex":"0x3782dace9d900000"}
```

### DOCS
This is a trivial change to the internals of rpc-server operation that doesn't warrant any documentation updates.

