### PR TITLE
CORE-950 update error code link to match new links

### DIFF
--- a/vsce/server/src/server.ts
+++ b/vsce/server/src/server.ts
@@ -376,7 +376,7 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
 	connection.sendDiagnostics({ uri: textDocument.uri, diagnostics });
 
 	function addDiagnostic(element: ErrorLocation, message: string, details: string, severity: DiagnosticSeverity, code: string | undefined, suggestions: string[], source: string) {
-		const href = `https://docs.reach.sh/${code}.html`;
+		const href = `https://docs.reach.sh/rsh/errors/#${code}`;
 		let diagnostic: Diagnostic = {
 			severity: severity,
 			range: element.range,


### PR DESCRIPTION
The old error code link actually still works, because of the automatic redirection. We're updating the link anyway!

https://user-images.githubusercontent.com/43425812/147985478-440a68ac-03d9-41fa-8788-76a865cc7020.mp4