### PR TITLE
fix grammatical error in `console.log` statement

### DIFF
--- a/vsce/server/src/server.ts
+++ b/vsce/server/src/server.ts
@@ -407,7 +407,7 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
 
 connection.onDidChangeWatchedFiles(_change => {
 	// Monitored files have change in VSCode
-	connection.console.log('We received an file change event');
+	connection.console.log('We received a file change event.');
 });
 
 export interface ErrorLocation {


### PR DESCRIPTION
This goes all the way back to [the initial commit](https://github.com/reach-sh/reach-lang/commit/58dc9b33150a0db2e795ae0c3f415bb47b97cc24#diff-07987d7242bba59edb32683bfa35b0a67e29a5916e1546c3b256894ef9ce5eaeR257).