### PR TITLE
delete unused imports from `extension.ts`

### DIFF
--- a/vsce/client/src/extension.ts
+++ b/vsce/client/src/extension.ts
@@ -11,7 +11,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as path from 'path';
-import { workspace, ExtensionContext, commands, window, env, ViewColumn, Uri, WorkspaceFolder } from 'vscode';
+import { workspace, ExtensionContext, commands, window, env, Uri } from 'vscode';
 import { exec } from 'child_process';
 import { initButtons } from './buttons';
 


### PR DESCRIPTION
This change removes unused imports `ViewColumn` and `WorkspaceFolder`.

`WorkspaceFolder` came in commit [4793bc4337d9251bbd3cb8a3469295ade7163493](https://github.com/reach-sh/reach-lang/commit/4793bc4337d9251bbd3cb8a3469295ade7163493#diff-7a736f242c9ec6ce495d76737ed4e3998552a465a3f1964021591cbd680bac90R11), but that commit uses `workspace.workspaceFolders`, and not `WorkspaceFolder`.

`ViewColumn` came in commit [c63bda7877e67368f0921d9301fda2adb3826541](https://github.com/reach-sh/reach-lang/commit/c63bda7877e67368f0921d9301fda2adb3826541#diff-7a736f242c9ec6ce495d76737ed4e3998552a465a3f1964021591cbd680bac90R11), but [only shows up in the `import` statement](https://github.com/reach-sh/reach-lang/blob/c63bda7877e67368f0921d9301fda2adb3826541/reach-ide/client/src/extension.ts).

In other words, it should be safe to delete both of these imports.