### PR TITLE
Core 966 create dockerfile to help automate extension publishing

### DIFF
--- a/vsce/Dockerfile
+++ b/vsce/Dockerfile
@@ -1,0 +1,28 @@
+# Start with an image that has Node.js.
+FROM node:16.13.0
+
+# create a WORKDIR to prevent
+# ERROR EPERM: operation not permitted
+WORKDIR /extension-publishing-helper-dir
+
+# copy current directory to image
+COPY . .
+
+# this is to avoid sh: 1: tsc: not found
+# DO NOT do "RUN npm install"! This
+# installs ALL dependencies, instead of
+# just the bare minimum necessary to
+# publish the extension. This could
+# easily increase the build time of this
+# step anywhere from 10x to 20x.
+RUN npm install -g typescript
+
+# install tool for extension publishing
+RUN npm install -g vsce
+
+# Publish our Visual Studio extension!
+# It is very important to use ["vsce"]
+# instead of, say, vsce. Running this
+# command fails if used without the
+# brackets [] and quotation marks "".
+ENTRYPOINT ["vsce"]

--- a/vsce/Makefile
+++ b/vsce/Makefile
@@ -1,8 +1,7 @@
 ROOT = ..
 
-# We can derive Reach's Visual Studio Code extension's
-# version using the VERSION file, which can be found
-# in the root directory.
+# We can derive the extension's version number using
+# the VERSION file from the appropriate directory.
 include $(ROOT)/VERSION
 
 # the next line is so this Makefile can do arithmetic
@@ -13,6 +12,9 @@ SHELL=/bin/bash
 # See https://stackoverflow.com/a/15978322.
 VSCE_VER := $$(($$(($$(($(MAJOR)+1))*1000)) + $(MINOR))).$(PATCH).$(DRAFT)
 
+# We don't need this next part for extension publishing!
+# This is just to build package.json after getting files
+# from the compiler.
 package.json: base.package.json
 # Replace base.package.json with package.json, first, in
 # case we updated package.json since we last made
@@ -22,5 +24,9 @@ package.json: base.package.json
 
 publish:
 	@echo "Now attempting to publish version $(VSCE_VER)"
-	@echo "of Reach's Visual Studio Code extension."
-	vsce publish $(VSCE_VER)
+	@echo "of our extension..."
+# Give the extension version to the script, so it can,
+# in turn, give the appropriate version number to Docker.
+# This is easier than passing the VERSION file from this
+# directory's parent directory to Docker.
+	VER=$(VSCE_VER) ./extensionPublishingHelper.sh

--- a/vsce/extensionPublishingHelper.sh
+++ b/vsce/extensionPublishingHelper.sh
@@ -1,3 +1,8 @@
+#!/bin/sh
+# ^-- SC2148: Tips depend on target
+# shell and yours is unknown. Add a
+# shebang or a 'shell' directive.
+
 echo "Building Docker image to publish"
 echo "version $VER of our extension..."
 # Give the new image a tag of "img".

--- a/vsce/extensionPublishingHelper.sh
+++ b/vsce/extensionPublishingHelper.sh
@@ -17,4 +17,6 @@ docker build -t img .
 # organization's name.
 echo "Running Docker image to publish"
 echo "version $VER of our extension..."
-docker run img publish $VER -p $PAT
+# ^--^ SC2086: Double quote to prevent
+# globbing and word splitting.
+docker run img publish "$VER" -p "$PAT"

--- a/vsce/extensionPublishingHelper.sh
+++ b/vsce/extensionPublishingHelper.sh
@@ -1,0 +1,20 @@
+echo "Building Docker image to publish"
+echo "version $VER of our extension..."
+# Give the new image a tag of "img".
+docker build -t img .
+
+# Give "publish $VER -p $PAT" all
+# as arguments to vsce, which is the
+# tool we use to publish our extension.
+# We need the "publish" argument to
+# publish our extension at all.
+# We need the "$VER" argument to have
+# our extension's version synchronize
+# with the rest of our versioning.
+# We need the "-p $PAT" arguments to
+# have the permissions necessary to
+# publish this extension under our
+# organization's name.
+echo "Running Docker image to publish"
+echo "version $VER of our extension..."
+docker run img publish $VER -p $PAT

--- a/vsce/extensionPublishingHelper.sh
+++ b/vsce/extensionPublishingHelper.sh
@@ -3,20 +3,20 @@ echo "version $VER of our extension..."
 # Give the new image a tag of "img".
 docker build -t img .
 
-# Give "publish $VER -p $PAT" all
-# as arguments to vsce, which is the
+# Give publish, "$VER", -p and "$KEY"
+# all as arguments to vsce, which is the
 # tool we use to publish our extension.
 # We need the "publish" argument to
 # publish our extension at all.
 # We need the "$VER" argument to have
 # our extension's version synchronize
 # with the rest of our versioning.
-# We need the "-p $PAT" arguments to
-# have the permissions necessary to
+# We need the -p and "$KEY" arguments
+# to have the permissions necessary to
 # publish this extension under our
 # organization's name.
 echo "Running Docker image to publish"
 echo "version $VER of our extension..."
 # ^--^ SC2086: Double quote to prevent
 # globbing and word splitting.
-docker run img publish "$VER" -p "$PAT"
+docker run img publish "$VER" -p "$KEY"


### PR DESCRIPTION
Here is one result of using these files locally. I edited `../VERSION` to prevent an accidental "real" publish.

```
hamir@Reach:~/repositories/reach-lang/vsce$ KEY=hiddenAzureDevOpsPersonalAccessToken make publish
Now attempting to publish version 1001.6.9
of our extension...
VER=$(($(($((0+1))*1000)) + 1)).6.9 ./extensionPublishingHelper.sh
Building Docker image to publish
version 1001.6.9 of our extension...
[+] Building 5.6s (10/10) FINISHED                                                                                                         
 => [internal] load build definition from Dockerfile                                                                                  0.1s
 => => transferring dockerfile: 38B                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                     0.1s
 => => transferring context: 2B                                                                                                       0.0s
 => [internal] load metadata for docker.io/library/node:16.13.0                                                                       4.9s
 => [internal] load build context                                                                                                     0.5s
 => => transferring context: 628.61kB                                                                                                 0.4s
 => [1/5] FROM docker.io/library/node:16.13.0@sha256:580a0850049c59a48f06090edd48c9f966c5e6572bbbabc369ba3ecbc4855dba                 0.0s
 => CACHED [2/5] WORKDIR /extension-publishing-helper-dir                                                                             0.0s
 => CACHED [3/5] COPY . .                                                                                                             0.0s
 => CACHED [4/5] RUN npm install -g typescript                                                                                        0.0s
 => CACHED [5/5] RUN npm install -g vsce                                                                                              0.0s
 => exporting to image                                                                                                                0.1s
 => => exporting layers                                                                                                               0.0s
 => => writing image sha256:98d636de88672de3807dc2af1f627d836aeb1f0fdb3968c2e0fac056ccd41c3f                                          0.0s
 => => naming to docker.io/library/img                                                                                                0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
Running Docker image to publish
version 1001.6.9 of our extension...
Executing prepublish script 'npm run vscode:prepublish'...

> reach-ide@1001.7.3 vscode:prepublish
> npm run compile


> reach-ide@1001.7.3 compile
> tsc -b

v1001.6.9
This extension consists of 422 files, out of which 229 are JavaScript files. For performance reasons, you should bundle your extension: https://aka.ms/vscode-bundle-extension . You should also exclude unnecessary files by adding them to your .vscodeignore: https://aka.ms/vscode-vscodeignore
 INFO  Publishing 'reachsh.reach-ide v1001.6.9'...
 ERROR  reachsh.reach-ide v1001.6.9 already exists.
make: *** [Makefile:28: publish] Error 1
hamir@Reach:~/repositories/reach-lang/vsce$ 
```
![image](https://user-images.githubusercontent.com/43425812/148853824-88f1be2f-3dd1-49bf-94d0-bc56ff0f4599.png)
