### PR TITLE
Just Opt verifyMulDiv Args

### DIFF
--- a/hs/src/Reach/Optimize.hs
+++ b/hs/src/Reach/Optimize.hs
@@ -276,9 +276,7 @@ instance Optimize DLExpr where
     DLE_Impossible at tag lab ->
       return $ DLE_Impossible at tag lab
     DLE_VerifyMuldiv at f cl args err ->
-      opt (DLE_PrimOp at MUL_DIV args) >>= \case
-        DLE_PrimOp _ _ args' -> return $ DLE_VerifyMuldiv at f cl args' err
-        ow -> return ow
+      DLE_VerifyMuldiv at f cl <$> opt args <*> pure err
     DLE_PrimOp at p as -> do
       as' <- opt as
       let meh = return $ DLE_PrimOp at p as'


### PR DESCRIPTION
We don't want to transform `verifyMulDiv` into any other operation because it has a specific verification purpose