### PR TITLE
DCT-124 let readers type `/` to immediately search

### DIFF
--- a/docs/src/base.html
+++ b/docs/src/base.html
@@ -8,7 +8,18 @@
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-149147406-2"></script>
   <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'UA-149147406-2');</script>
+  <script>
+    window.addEventListener("keydown", keyboardEvent => {
+      // Grab the code from the keyboard event.
+      const { code } = keyboardEvent;
 
+      // If the reader pressed the "Slash" key,
+      // "activate" search! I.e., click the search icon.
+      if (code === "Slash") {
+        document.getElementById("search-icon").click();
+      }
+    });
+  </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/png" href="/assets/favicon.png">
   <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css">
@@ -49,7 +60,10 @@
         </div>
 
         <div class="navbar-nav ms-1 ms-lg-2" style="cursor: pointer;">
-          @{menuItem('search', '<i class="fas fa-search fa-lg"></i>')}
+          @{menuItem(
+            'search',
+            '<i class="fas fa-search fa-lg" id="search-icon"></i>'
+          )}
         </div>
 
       </div>


### PR DESCRIPTION
https://user-images.githubusercontent.com/43425812/149848275-5d240a0f-c5ce-41a7-92b7-01545e3a8dc2.mp4

Of course, users don't _have_ to use an onscreen keyboard to do this, like in the above video.

I just did it that way to demonstrate which key activates the shortcut.