### PR TITLE
add min balance func

### DIFF
--- a/examples/minBalance/index.mjs
+++ b/examples/minBalance/index.mjs
@@ -1,0 +1,63 @@
+import { loadStdlib } from '@reach-sh/stdlib';
+import launchToken from '@reach-sh/stdlib/launchToken.mjs';
+import * as backend from './build/index.main.mjs'
+import assert from 'assert';
+
+const [, , infile] = process.argv;
+
+(async () => {
+
+    const stdlib = await loadStdlib();
+    const startingBalance = stdlib.parseCurrency(100);
+
+    const getBalance = async (who, tok) =>
+        stdlib.formatCurrency(await stdlib.balanceOf(who, tok), 4);
+
+    const getMinBalance = async (who) =>
+        stdlib.formatCurrency(await stdlib.minBalance(who))
+
+    // Alice mints a token (asset)
+    // Bob opts in to token (asset)
+    // Eve creates an app (app extra pages and global state)
+
+    const accAlice = await stdlib.newTestAccount(startingBalance);
+    const accBob = await stdlib.newTestAccount(startingBalance);
+    const accEve = await stdlib.newTestAccount(startingBalance);
+
+    const beforeAlice = await getBalance(accAlice);
+    const beforeBob = await getBalance(accBob);
+    const beforeAliceMin = await getMinBalance(accAlice);
+    const beforeBobMin = await getMinBalance(accBob);
+    const beforeEveMin = await getMinBalance(accEve);
+
+    const zorkmid = await launchToken(stdlib, accAlice, "zorkmid", "ZMD", { decimals: 6, supply: 1000000000 });
+    await accAlice.tokenAccept(zorkmid.id)
+    await accBob.tokenAccept(zorkmid.id)
+
+    const ctc = accAlice.contract(backend)
+    Promise.all([backend.Alice(ctc, {})])
+    const appId = await ctc.getInfo()
+    console.log({ appId })
+    const ctc2 = accBob.contract(backend, appId)
+    backend.Bob(ctc2, {})
+
+    const afterAlice = await getBalance(accAlice);
+    const afterBob = await getBalance(accBob);
+    const afterAliceMin = await getMinBalance(accAlice);
+    const afterBobMin = await getMinBalance(accBob);
+    const afterEveMin = await getMinBalance(accEve);
+
+    console.log({ beforeAlice, beforeAliceMin, beforeBobMin, beforeBob, beforeEveMin })
+    console.log({ afterAlice, afterAliceMin, afterBobMin, afterBob, afterEveMin })
+
+    assert(beforeBobMin === beforeAliceMin)
+    assert(beforeBobMin === beforeEveMin)
+    assert(beforeBobMin === '0.1')
+
+    assert(afterAliceMin === '0.4')
+    assert(afterBobMin === '0.2')
+    assert(afterEveMin === '0.1')
+
+    process.exit()
+
+})();

--- a/examples/minBalance/index.rsh
+++ b/examples/minBalance/index.rsh
@@ -1,43 +1,11 @@
 'reach 0.1';
 
-export const main = Reach.App(() => {
-  const shared = {
-    showToken: Fun(true, Null),
-    didTransfer: Fun([Bool, UInt], Null),
-  };
-  const A = Participant('Alice', {
-    getParams: Fun([], Object({
-      name: Bytes(32), symbol: Bytes(8),
-      url: Bytes(96), metadata: Bytes(32),
-      supply: UInt,
-      amt: UInt,
-    })),
-    ...shared,
-  });
-  const B = Participant('Bob', {
-    ...shared,
-  });
-  const C = Participant('Eve', {})
-  const D = Participant('Fab', {})
-  init();
-
-  A.publish();
-  
-  const m = new Map(UInt);
-  m[A] = 1;
-
-  D.set(A);
-
-  commit();
-
-  B.publish();
-  m[B] = 2
-  commit();
-
-  C.publish()
-  delete m[A]
-  delete m[B]
-  commit();
-
-  exit();
-});
+import { useConstructor } from '@nash-protocol/starter-kit:util.rsh'
+import { 
+  Participants as AppParticipants,
+  Views as AppViews, 
+  Api as AppApi, 
+  App 
+} from '@nash-protocol/voting:interface.rsh'
+export const main = Reach.App(() => 
+  App(useConstructor(AppParticipants, AppViews, AppApi)));

--- a/examples/minBalance/index.rsh
+++ b/examples/minBalance/index.rsh
@@ -1,0 +1,43 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const shared = {
+    showToken: Fun(true, Null),
+    didTransfer: Fun([Bool, UInt], Null),
+  };
+  const A = Participant('Alice', {
+    getParams: Fun([], Object({
+      name: Bytes(32), symbol: Bytes(8),
+      url: Bytes(96), metadata: Bytes(32),
+      supply: UInt,
+      amt: UInt,
+    })),
+    ...shared,
+  });
+  const B = Participant('Bob', {
+    ...shared,
+  });
+  const C = Participant('Eve', {})
+  const D = Participant('Fab', {})
+  init();
+
+  A.publish();
+  
+  const m = new Map(UInt);
+  m[A] = 1;
+
+  D.set(A);
+
+  commit();
+
+  B.publish();
+  m[B] = 2
+  commit();
+
+  C.publish()
+  delete m[A]
+  delete m[B]
+  commit();
+
+  exit();
+});

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -1769,11 +1769,11 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
 export const minBalance = async (acc: Account): Promise<BigNumber> => {
   const addr = extractAddr(acc);
   const ai = await getAccountInfo(addr);
-  let createdApps = ai['created-apps']??[]
-  let numByteSlice = (ai['apps-total-schema']??{})['num-byte-slice']??0
-  let numUInt = (ai['apps-total-schema']??{})['num-uint']??0
-  let assets = ai.assets??[]
-  let mBal = assets.length * 100000
+  const createdApps = ai['created-apps']??[]
+  const numByteSlice = (ai['apps-total-schema']??{})['num-byte-slice']??0
+  const numUInt = (ai['apps-total-schema']??{})['num-uint']??0
+  const assets = ai.assets??[]
+  const mBal = assets.length * 100000
     + (25000 + 3500) * numUInt
     + (25000 + 25000) * numByteSlice
     + (100000) * createdApps.length

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -1776,6 +1776,7 @@ export const minBalance = async (acc: Account): Promise<BigNumber> => {
   const addr = extractAddr(acc);
   const ai = await getAccountInfo(addr);
   const createdAppCount: BigNumber = bigNumberify((ai['created-apps']??[]).length) // between 0 and 50
+  const optinAppCount: BigNumber = bigNumberify((ai['apps-local-state']??[]).length) // between 0 and 50
   const numByteSlice: BigNumber = bigNumberify((ai['apps-total-schema']??{})['num-byte-slice']??0) // depends
   const numUInt: BigNumber = bigNumberify((ai['apps-total-schema']??{})['num-uint']??0) // depends
   const assetCount:BigNumber = bigNumberify((ai.assets??[]).length) // between 0 and 1000
@@ -1783,13 +1784,15 @@ export const minBalance = async (acc: Account): Promise<BigNumber> => {
   accMinBalance = assets.length * AppFlatOptInMinBalance
   + (SchemaMinBalancePerEntry + SchemaUintMinBalance) * numUInt
   + (SchemaMinBalancePerEntry + SchemaBytesMinBalance) * numByteSlice
-  + (AppFlatParamsMinBalance) * createdApps.length
+  + (AppFlatParamsMinBalance) * createdAppCount
+  + (AppFlatOptInMinBalance) * optinAppCount
   + MinBalance
   */
   const accMinBalance: BigNumber = assetCount.mul(appFlatOptInMinBalance)
     .add(schemaMinBalancePerEntry.add(schemaUintMinBalance).mul(numUInt))
     .add(schemaMinBalancePerEntry.add(schemaBytesMinBalance).mul(numByteSlice))
     .add(appFlatParamsMinBalance.mul(createdAppCount))
+    .add(appFlatOptInMinBalance.mul(optinAppCount))
     .add(minimumBalance)
     debug(`minBalance`, accMinBalance)
     return accMinBalance

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -1767,19 +1767,25 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
 };
 
 export const minBalance = async (acc: Account): Promise<BigNumber> => {
+  const SchemaMinBalancePerEntry: BigNumber = 25000
+  const SchemaBytesMinBalance: BigNumber = 25000
+  const SchemaUintMinBalance: BigNumber = 3500
+  const AppFlatParamsMinBalance: BigNumber = 100000
+  const AppFlatOptInMinBalance: BigNumber = 100000
+  const MinBalance: BigNumber = 100000
   const addr = extractAddr(acc);
   const ai = await getAccountInfo(addr);
-  const createdApps = ai['created-apps']??[]
-  const numByteSlice = (ai['apps-total-schema']??{})['num-byte-slice']??0
-  const numUInt = (ai['apps-total-schema']??{})['num-uint']??0
-  const assets = ai.assets??[]
-  const mBal = assets.length * 100000
-    + (25000 + 3500) * numUInt
-    + (25000 + 25000) * numByteSlice
-    + (100000) * createdApps.length
-    + 100000
-    debug(`minBalance`, mBal)
-    return bigNumberify(mBal)
+  const createdApps = ai['created-apps']??[] // between 0 and 50
+  const numByteSlice = (ai['apps-total-schema']??{})['num-byte-slice']??0 // depends
+  const numUInt = (ai['apps-total-schema']??{})['num-uint']??0 // depends
+  const assets = ai.assets??[] // between 0 and 1000
+  const accMinBalance: BigNumber = assets.length * AppFlatOptInMinBalance
+    + (SchemaMinBalancePerEntry + SchemaUintMinBalance) * numUInt
+    + (SchemaMinBalancePerEntry + SchemaBytesMinBalance) * numByteSlice
+    + (AppFlatParamsMinBalance) * createdApps.length
+    + MinBalance
+    debug(`minBalance`, accMinBalance)
+    return accMinBalance
 }
 
 const balanceOfM = async (acc: Account, token: Token|false = false): Promise<BigNumber|false> => {

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -1798,8 +1798,6 @@ const balanceOfM = async (acc: Account, token: Token|false = false): Promise<Big
   }
 };
 
-
-
 export const balanceOf = async (acc: Account, token: Token|false = false): Promise<BigNumber> => {
   const r = await balanceOfM(acc, token);
   if ( r === false ) {

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -177,11 +177,11 @@ type AppSchema = {
   "num-uint": number
 }
 type AccountInfo = {
-  'assets': Array<AccountAssetInfo>,
   'amount': number,
-  'apps-local-state': Array<AppState>
-  'apps-total-schema': AppSchema,
-  'created-apps': Array<AppInfo>
+  'assets'?: Array<AccountAssetInfo>,
+  'apps-local-state'?: Array<AppState>
+  'apps-total-schema'?: AppSchema,
+  'created-apps'?: Array<AppInfo>
 };
 type IndexerAccountInfoRes = {
   'current-round': number,
@@ -1769,10 +1769,10 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
 export const minBalance = async (acc: Account): Promise<BigNumber> => {
   const addr = extractAddr(acc);
   const ai = await getAccountInfo(addr);
-  let createdApps = ai['created-apps']
-  let numByteSlice = ai['apps-total-schema']['num-byte-slice']
-  let numUInt = ai['apps-total-schema']['num-uint']
-  let assets = ai.assets
+  let createdApps = ai['created-apps']??[]
+  let numByteSlice = (ai['apps-total-schema']??{})['num-byte-slice']??0
+  let numUInt = (ai['apps-total-schema']??{})['num-uint']??0
+  let assets = ai.assets??[]
   let mBal = assets.length * 100000
     + (25000 + 3500) * numUInt
     + (25000 + 25000) * numByteSlice

--- a/test.sh
+++ b/test.sh
@@ -69,6 +69,7 @@ ci () {
   printf "\nCI %s %s\n" "$MODE" "$WHICH"
   (cd "examples/$WHICH"
   ${REACH} clean
+  ${REACH} compile --install-pkgs
   ${REACH} compile --intermediate-files
   make build
   REACH_DEBUG=1 REACH_CONNECTOR_MODE="$MODE" ${REACH} run

--- a/test.sh
+++ b/test.sh
@@ -26,13 +26,29 @@ err () {
   fc "hs/t/n/$1.rsh"
 }
 
+jbi() {
+  local i="${1}"
+  test ! -d "'${ROOT}'${i}" || {
+    (cd "${_}" && make build)
+  }
+}
+
 jb () {
+<<<<<<< HEAD
   #(cd "$ROOT"/js/js-deps && make build)
   (cd "$ROOT"/js/stdlib && make build)
   (cd "$ROOT"/js/runner && make build)
   #(cd "$ROOT"/js/rpc-server && make build)
   #(cd "$ROOT"/js/react-runner && make build)
   # (cd "$ROOT"/js && make build)
+=======
+  jbi /js/js-deps
+  jbi /js/stdlib
+  jbi /js/runner
+  #jbi /js/rpc-server
+  jbi /js/react-runner
+  #jbi /js
+>>>>>>> 60cce754d (add min balance func)
 }
 
 one () {
@@ -52,7 +68,6 @@ ci () {
   WHICH="$2"
   printf "\nCI %s %s\n" "$MODE" "$WHICH"
   (cd "examples/$WHICH"
-
   ${REACH} clean
   ${REACH} compile --intermediate-files
   make build
@@ -122,9 +137,14 @@ cdot () {
 #######
 
 #jb
-
 c users/duoswap-core/index.rsh
 c users/algo-govt/index.rsh
+jb; ci ALGO minBalance; exit 0
+cdot examples/overview/index.rsh
+cdot examples/rps-8-interact/index.rsh
+cdot users/duoswap-core/index.rsh
+exit 0
+cdot users/xbacked-contracts/src/master_vault.rsh
 exit 0
 
 c --install-pkgs users/xbacked-contracts/src/master_vault.rsh


### PR DESCRIPTION
<!--
Hey! Thanks so much!
-->

## Summary

<!-- Explain what you're trying to do in this pull request -->

In ALGO, a portion of accounts is made not available based on account usage of apps and storage on the network. The `stdlib.minBalance(acc)` function computes amount that an account may use in a future transaction.

<!-- DESIGN: Does this code have some deeper design concept that motivates it that is hard to understand just by reading the code? -->

Min balance calculations use the following as a reference:
https://developer.algorand.org/docs/get-details/dapps/smart-contracts/apps/#minimum-balance-requirement-for-a-smart-contract

<!-- TESTING: How did you test this? Is there a new example? Do you have some test scenario you're using? -->

Function is accompanied by an `minBalance` in `examples`.

<!-- DOCS: Should there be a documentation or changelog update with this code? -->

Yes, I believe it should be added to the change long and docs as a ALGO specific feature.