### PR TITLE
CORE-1016 change comments to try to improve types

### DIFF
--- a/js/stdlib/ts/ask.ts
+++ b/js/stdlib/ts/ask.ts
@@ -13,10 +13,26 @@ const ask_ = async (q: string): Promise<string> => {
   });
 };
 
-// The validator arg should:
-// * return anything but `undefined` on success.
-// * throw an Error on failure
-// The validator's output will be returned.
+/**
+ * is an asynchronous function that asks a question on the
+ * console.
+ *
+ * @param {string} question presented to user on console
+ * @param {function=} validator should
+ * - return anything but `undefined` on success.
+ * - return an `Error` on failure.
+ * @returns a `Promise` for the first result `validator`
+ * done not error on.
+ * @example
+ * ```ts
+ * const isAisha = await ask(
+ *  'Are you Aisha?',
+ *  validator
+ * );
+ * const person = isAisha ? 'Aisha' : 'Benjamin';
+ * ```
+ * @see https://docs.reach.sh/frontend/#p_153
+ */
 export const ask = async <T>(question: string, validator?: ((s: string) => T)): Promise<T> => {
   // Not sure how to require T=string if validator is undefined.
   // This is not type safe.


### PR DESCRIPTION
If we do `import { ask } from "@reach-sh/stdlib/ask.mjs";`, we don't get nice TypeScript type inference.

As a workaround, we might be able to get _some_ type inference by replacing the comments we have currently with [`jsdoc`](https://jsdoc.app/) comments.

### Current type inference

```ts
(alias) var ask: (question: any, validator: any) => any
import ask
```

![Screen Shot 2022-01-20 at 3 44 56 PM](https://user-images.githubusercontent.com/43425812/150439850-24e952ef-8e2f-4467-8c14-7d162d20f411.png)

### If we add this change, we get something like this.

```ts
(alias) var ask: (question: string, validator?: Function | undefined) => any
import ask
is an asynchronous function that asks a question on the console.

@param question — presented to user on console

@param validator
should

return anything but undefined on success.
return an Error on failure.
@returns
a Promise for the first result validator done not error on.

@example
const isAisha = await ask(
 'Are you Aisha?',
 validator
);
const person = isAisha ? 'Aisha' : 'Benjamin';
@see — https://docs.reach.sh/frontend/#p_153
```

![Screen Shot 2022-01-20 at 3 57 51 PM](https://user-images.githubusercontent.com/43425812/150441066-24811c3d-7896-4a49-ae30-1832e14e91cd.png)

![Screen Shot 2022-01-20 at 3 58 11 PM](https://user-images.githubusercontent.com/43425812/150441095-10e71461-920d-4aa2-89af-617806a4e193.png)