### PR TITLE
add `Terminal` type inference in `extension.ts`

### DIFF
--- a/vsce/client/src/extension.ts
+++ b/vsce/client/src/extension.ts
@@ -11,7 +11,15 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as path from 'path';
-import { workspace, ExtensionContext, commands, window, env, Uri } from 'vscode';
+import {
+	commands,
+	env,
+	ExtensionContext,
+	Terminal,
+	Uri,
+	window,
+	workspace,
+} from 'vscode';
 import { exec } from 'child_process';
 import { initButtons } from './buttons';
 
@@ -28,7 +36,7 @@ const COMMANDS = require('../../data/commands.json');
 
 let client: LanguageClient;
 
-var terminal;
+var terminal: Terminal;
 
 const fs = require('fs');
 const url = require('url');


### PR DESCRIPTION
This changes just makes it so that I have type inference for `terminal` in `extension.ts`.

It makes it so that I can get this

![Screen Shot 2022-01-21 at 3 53 30 PM](https://user-images.githubusercontent.com/43425812/150614522-8813be3a-2744-4880-8c6f-32020a03088b.png)

instead of this

![Screen Shot 2022-01-21 at 3 54 02 PM](https://user-images.githubusercontent.com/43425812/150614553-ba777e6a-5709-4950-a300-1bfb8326c87b.png)