### PR TITLE
remove unused `import`s to clean `server.ts`

### DIFF
--- a/vsce/server/src/server.ts
+++ b/vsce/server/src/server.ts
@@ -1,5 +1,3 @@
-import { stringify } from 'querystring';
-import { Url } from 'url';
 /* --------------------------------------------------------------------------------------------
  * Copyright for portions from https://github.com/microsoft/vscode-extension-samples/tree/master/lsp-sample
  * are held by (c) Microsoft Corporation. All rights reserved.


### PR DESCRIPTION
`import { stringify } from 'querystring';` came in [the initial commit](https://github.com/reach-sh/reach-lang/commit/58dc9b33150a0db2e795ae0c3f415bb47b97cc24#diff-07987d7242bba59edb32683bfa35b0a67e29a5916e1546c3b256894ef9ce5eaeR1). I only see it in the `import` statement; it appears we don't use it anywhere else.

`import { Url } from 'url';` came from [a later commit](https://github.com/reach-sh/reach-lang/commit/6411cbbc0c51bc1dc19eeb63bd35ac1e2ae5a021#diff-07987d7242bba59edb32683bfa35b0a67e29a5916e1546c3b256894ef9ce5eaeR2). That commit uses `URL` instead of `Url`.

Running the extension in development mode locally with these two `import`s removed works fine.