### PR TITLE
doc cross references - allow dependent identifiers like fork.case

### DIFF
--- a/docs/src/rsh/step/index.md
+++ b/docs/src/rsh/step/index.md
@@ -218,7 +218,7 @@ This overwriting applies even if `{!rsh} Alice` wins and `{!rsh} Alice` is a par
 
 ### `fork`
 
-@{ref("rsh", "fork")}@{ref("rsh", "paySpec")}
+@{ref("rsh", "fork")}@{ref("rsh", "fork.case")}@{ref("rsh", "paySpec")}
 ```reach
 fork()
 .case(Alice, (() => ({


### PR DESCRIPTION
<!--
Hey! Thanks so much!
-->

## Summary

Here is a screenshot:

![doc-hyperlink-fork case](https://user-images.githubusercontent.com/4922506/151426164-c187829f-17c9-4c2b-8c95-2233accda341.png)

I added a reference anchor for `fork.case` to add the demo, but otherwise I'm not sure which identifiers we want this with, so currently this only does anything with the one identifier.  But when more are added they will work, and it works for arbitrary depth of `foo.bar.baz.quux` nesting.  But note that it's not very accurate -- if a code snippet includes `fork` and then later includes a `case` that's not really related to fork, it will mis-link the `case` identifier to `fork.case`.

<!-- Explain what you're trying to do in this pull request -->

<!-- DESIGN: Does this code have some deeper design concept that motivates it that is hard to understand just by reading the code? -->

<!-- TESTING: How did you test this? Is there a new example? Do you have some test scenario you're using? -->

<!-- DOCS: Should there be a documentation or changelog update with this code? -->
