### PR TITLE
change q-and-a background color

### DIFF
--- a/docs/src/assets/styles.css
+++ b/docs/src/assets/styles.css
@@ -546,7 +546,7 @@ div.note {
 }
 
 div.q-and-a {
-  background: #F5F5DC;
+  background: #F5DCDC;
   margin-left: 2em;
   padding: 0em 0.5em;
   cursor: pointer;


### PR DESCRIPTION
Currently `q-and-a` blocks look identical to `note` blocks.  This is
particularly an issue for “true or false” statements that are not
clearly questions.  The tutorial has `q-and-a` blocks that make false
statements but that look identical to `note` blocks which offer
authoritative guidance.  I'm not going to suggest that I have the best
aesthetic sense for what the style should be, but it should absolutely
be different from `note`.

Ideally `q-and-a` blocks could also come with an explicit label that
shows that they have a question, not just implicit styling to show
that it's a question.

This really bothered me the other day when I was reading through tutorial stuff, so I decided to find the CSS at least.