### PR TITLE
Update tools\index.md

### DIFF
--- a/docs/src/tool/index.md
+++ b/docs/src/tool/index.md
@@ -33,9 +33,9 @@ Reach has a few sub-commands, each with their own options.
 
 However, all commands support the following options:
 
-+ The environment variable `REACH_VERSION` signifies what version of Reach to use.
++ The environment variable `@{ref("cmd", "REACH_VERSION")}` signifies what version of Reach to use.
 
-Although normally expressed in a [semantic versioning](##guide-versions)-friendly format, e.g. `v0.1` or `v0.1.6`, `REACH_VERSION` also supports:
+Although normally expressed in a [semantic versioning](##guide-versions)-friendly format, e.g. `v0.1` or `v0.1.6`, `@{ref("cmd", "REACH_VERSION")}` also supports:
 + Hashes such as [639fa565](https://hub.docker.com/layers/reachsh/reach/639fa565/images/sha256-e72fbb183e559a6f531302843c1d4debb499c9286e0ca4839ae66023c7ba2296?context=explore).
 
 Valid hashes may be obtained by running:
@@ -60,7 +60,7 @@ Tip: try entering your desired year in the filter box to skip other tag types.
 
 Reach will interpret this to mean the most recent stable [major](##guide-versions) version.
 
-When using the semantic versioning form of `REACH_VERSION` the preceding `v` character is optional.
+When using the semantic versioning form of `@{ref("cmd", "REACH_VERSION")}` the preceding `v` character is optional.
 In other words, `v0.1.6` is equivalent to `0.1.6`.
 
 # {#ref-usage-compile} `reach compile`
@@ -80,7 +80,7 @@ If no `EXPORT` is provided, then all the exported `{!rsh} Reach.Apps` will be co
 If there are no `{!rsh} Reach.Apps` exported, then the program will be compiled as a library, where its exports are available to other Reach programs and frontends.
 The output name of a library is the same as if it exported a `{!rsh} Reach.App` named `default`.
 
-`reach compile` supports the following options:
+`@{ref("cmd", "compile")}reach compile` supports the following options:
 
 + `-o`/`--output` `OUTPUT` --- Writes compiler output files to `OUTPUT`, which defaults to a directory named `build` in the same directory as `SOURCE`.
 

--- a/docs/src/tool/index.md
+++ b/docs/src/tool/index.md
@@ -250,7 +250,7 @@ $ REACH_CONNECTOR_MODE=ALGO ./reach devnet
 
 + `--await-background` --- Run in the background and await availability.
 
-For more information on envirionmental variables and `{!cmd} REACH_CONNECTOR_MODE`, refer to (##ref-usage-run). 
+For more information on environmental variables and `{!cmd} REACH_CONNECTOR_MODE`, refer to [reach run](##ref-usage-run). 
 
 For more information on devnet options, refer to [Networks](##ref-networks).
 

--- a/docs/src/tool/index.md
+++ b/docs/src/tool/index.md
@@ -60,7 +60,7 @@ Tip: try entering your desired year in the filter box to skip other tag types.
 
 Reach will interpret this to mean the most recent stable [major](##guide-versions) version.
 
-When using the semantic versioning form of `@{ref("cmd", "REACH_VERSION")}` the preceding `v` character is optional.
+When using the semantic versioning form of `{!cmd} REACH_VERSION` the preceding `v` character is optional.
 In other words, `v0.1.6` is equivalent to `0.1.6`.
 
 # {#ref-usage-compile} `reach compile`
@@ -76,8 +76,8 @@ and each `EXPORT` is an exported `{!rsh} Reach.App`.
 
 If no `SOURCE` is provided, then `index.rsh` is used.
 
-If no `EXPORT` is provided, then all the exported `{!rsh} Reach.Apps` will be compiled.
-If there are no `{!rsh} Reach.Apps` exported, then the program will be compiled as a library, where its exports are available to other Reach programs and frontends.
+If no `EXPORT` is provided, then all the exported `{!rsh} Reach.App`s will be compiled.
+If there are no `{!rsh} Reach.App`s exported, then the program will be compiled as a library, where its exports are available to other Reach programs and frontends.
 The output name of a library is the same as if it exported a `{!rsh} Reach.App` named `default`.
 
 `@{ref("cmd", "compile")}reach compile` supports the following options:
@@ -145,11 +145,11 @@ It then
 
 + Compiles your program with Reach.
 + Builds a Docker image named `reachsh/reach-app-APP:latest` that depends on the Reach JavaScript standard library.
-+ Executes a container based upon that image while connected to the network determined by `REACH_CONNECTOR_MODE`.
++ Executes a container based upon that image while connected to the network determined by `{!cmd} REACH_CONNECTOR_MODE`.
 
 `reach run` supports the following options:
 
-+ The mandatory environment variable `REACH_CONNECTOR_MODE` specifies which context to run in.
++ The mandatory environment variable `{!cmd} REACH_CONNECTOR_MODE` specifies which context to run in.
 The options are:
 
 + `ETH-live`, which uses a live Ethereum network node, specified by the environment variable `ETH_NODE_URI`.
@@ -200,12 +200,12 @@ This assumes
 It then
 
 + Compiles your program with Reach
-+ Runs the appropriate devnet based on `REACH_CONNECTOR_MODE`
++ Runs the appropriate devnet based on `{!cmd} REACH_CONNECTOR_MODE`
 + Mounts the current directory into `/app/src/` in the `reachsh/react-runner` Docker image and runs it.
 
 `reach react` supports the following options:
 
-+ The mandatory environment variable `REACH_CONNECTOR_MODE` specifies which context to run in.
++ The mandatory environment variable `{!cmd} REACH_CONNECTOR_MODE` specifies which context to run in.
 The options are:
 
 + `ETH`, which runs a Dockerized private Ethereum network which may be used. The app can use any Ethereum network.
@@ -238,8 +238,8 @@ $ reach devnet
 ```
 
 :::note
-If running `reach devnet`, it is recommended to permanently set `REACH_CONNECTOR_MODE` to the desired consensus network. 
-If you did not set this when you originally ran `reach config`, then you can run `reach devnet` with the argument `REACH_CONNECTOR_MODE=[OPTION]` as in the following command.
+If running `reach devnet`, it is recommended to permanently set `{!cmd} REACH_CONNECTOR_MODE` to the desired consensus network. 
+If you did not set this when you originally ran `reach config`, then you can run `reach devnet` with the argument `{!cmd} REACH_CONNECTOR_MODE=[OPTION]` as in the following command.
 :::
 
 ```cmd
@@ -250,7 +250,7 @@ $ REACH_CONNECTOR_MODE=ALGO ./reach devnet
 
 + `--await-background` --- Run in the background and await availability.
 
-The mandatory environment variable `REACH_CONNECTOR_MODE` specifies which devnet to run.
+The mandatory environment variable `{!cmd} REACH_CONNECTOR_MODE` specifies which devnet to run.
 The options are:
 
 + `ETH`, which runs an Ethereum devnet on `localhost:8545`
@@ -387,7 +387,7 @@ Reach recommends tuning your default workflow settings by executing
 $ reach config
 ```
 
-Using `reach config` is advisable when running Reach for the first time since it will set the `REACH_CONNECTOR_MODE` environment variable, which is required when executing some other sub-commands (e.g. `reach run`).
+Using `reach config` is advisable when running Reach for the first time since it will set the `{!cmd} REACH_CONNECTOR_MODE` environment variable, which is required when executing some other sub-commands (e.g. `reach run`).
 
 `reach config` presents users with a guided menu which automatically creates an `env` file and suggests subsequent steps to activate and make it permanent.
 This `env` file exports environment variable settings and is intended to be `source`d by users' shells.

--- a/docs/src/tool/index.md
+++ b/docs/src/tool/index.md
@@ -1,6 +1,10 @@
 # {#ref} Tool
 
-This document describes the `reach` tool: how to install it and how to use it.
+This document describes the `reach` tool: how to install it and how to use it. All commands on this page assume that Reach is installed in your project repository, but if it is installed in your `PATH`, remove <b>./</b> in front of the reach commands as in the following:
+
+```cmd
+$ reach update
+```
 
 # {#ref-install} Installation
 
@@ -10,7 +14,7 @@ The best way to install Docker on Mac and Windows is with [Docker Desktop](https
 :::note
 You probably already have `make` installed.
 For example, OS X and many other POSIX systems come with `make`, but some versions of Linux do not include it by default and will require you to install it.
-If you're on Ubuntu, you can run `sudo apt install make` to get it.
+If you are on Ubuntu, you can run `sudo apt install make` to get it.
 :::
 
 You can install Reach by running:
@@ -65,10 +69,10 @@ In other words, `v0.1.6` is equivalent to `0.1.6`.
 
 # {#ref-usage-compile} `reach compile`
 
-You compile your Reach code by executing
+Compile the Reach code by executing
 
 ```cmd
-$ reach compile SOURCE EXPORT ...
+$ ./reach compile SOURCE EXPORT ...
 ```
 
 where `SOURCE` is your source file,
@@ -105,24 +109,30 @@ named `default`.
 + The environment variable `REACH_DEBUG`, if set to any non-empty value, enables debug messages from the Reach compiler, which will appear in the console.
   This debug information includes: the estimated cost of the contract on Algorand.
   This variable automatically enabled `--intermediate-files`.
+  
+  A `reach compile` usage example is available in [Overview](##over-compile). 
 
-## {#ref-usage-init} `reach init`
+# {#ref-usage-init} `reach init`
 
-You can create template `index.rsh` and `index.mjs` files for a simple Reach app by running
+Running `reach init` creates the `index.rsh` and `index.mjs` template files required for a basic Reach DApp. This allows you to open the files and start writing code. The `index.rsh` file is the DApp and is written in Reach, and the `index.mjs` file is the frontend of the DApp and is written in JavaScript.
+
+To run `reach init`, use the following command: 
 
 ```cmd
-$ reach init
+$ ./reach init
 ```
 
 # {#ref-usage-run} `reach run`
 
-You can run a simple Reach application by executing
+The `reach run` command with no argumenst starts the `index` application in the current directory by default, but you can set a different directory, application name, or both.
+
+The `reach run` command uses the following syntax:
 
 ```cmd
-$ reach run [APP or DIR] [ARGS]
+$ ./reach run [APP or DIR] [ARGS]
 ```
 
-`APP` represents a Reach module name without its extension (e.g. "index" by default).
+`APP` represents a Reach module name without its extension (e.g. "index" by default). 
 
 If no `APP` or `DIR` is provided then `index` in the current working directory is assumed.
 
@@ -166,7 +176,7 @@ The `Dockerfile` can be modified to introduce new dependencies, services, or fil
 You can halt all Dockerized Reach apps and devnets by running
 
 ```cmd
-$ reach down
+$ ./reach down
 ```
 
 # {#ref-usage-scaffold} `reach scaffold`
@@ -174,7 +184,7 @@ $ reach down
 You can create templated `Dockerfile` and `package.json` files for a simple Reach app by running
 
 ```cmd
-$ reach scaffold
+$ ./reach scaffold
 ```
 
 The files created are the same as those used temporarily by `reach run`.
@@ -184,7 +194,7 @@ The files created are the same as those used temporarily by `reach run`.
 You can run a simple React app by executing
 
 ```cmd
-$ reach react
+$ ./reach react
 ```
 
 This assumes
@@ -226,20 +236,39 @@ may be used in any JavaScript project like any other JavaScript file and library
 
 # {#ref-usage-devnet} `reach devnet`
 
-You can run a private Reach devnet by executing
+You can run a private Reach devnet by executing the following command:
 
 ```cmd
-$ reach devnet
+$ ./reach devnet
+```
+
+:::note
+If running `reach devnet`, it is recommended to permanently set `REACH_CONNECTOR_MODE` to the desired consensus network. If you did not set this when you originally ran `reach config`, then you can run `reach devnet` with the argument`REACH_CONNECTOR_MODE=[OPTION]` as in the following command.
+:::
+
+```cmd
+$ REACH_CONNECTOR_MODE=ALGO ./reach devnet
 ```
 
 `reach devnet` supports the following options:
 
-+ `--await-background` --- Run in background and await availability.
-+ The mandatory environment variable `REACH_CONNECTOR_MODE` specifies which devnet to run.
++ `--await-background` --- Run in the background and await availability.
+
+  The mandatory environment variable `REACH_CONNECTOR_MODE` specifies which devnet to run.
 The options are:
 
 + `ETH`, which runs an Ethereum devnet on `localhost:8545`
++ `ETH-browser`, which runs an Ethereum devnet on `localhost:8545`
++ `ETH-devnet`, which runs an Ethereum devnet on `localhost:8545`
++ `ETH-live`, which runs an Ethereum devnet on `localhost:8545`
 + `ALGO`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
++ `ALGO-browser`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
++ `ALGO-devnet`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
++ `ALGO-live`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
++ `CFX`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
++ `CFX-browser`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
++ `CFX-devnet`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
++ `CFX-live`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
 
 + The environment variable `REACH_DEBUG` enables some additional debugging information for the Algorand devnet, which is accessible via http://localhost:9392
 
@@ -248,7 +277,7 @@ The options are:
 The sub-command
 
 ```cmd
-$ reach rpc-server
+$ ./reach rpc-server
 ```
 
 starts an instance of the [Reach RPC Server](##ref-backends-rpc) using all of the same options and defaults as `reach run`.
@@ -277,10 +306,10 @@ It defaults to `rpc-demo`.
 
 # {#ref-usage-rpc-run} `reach rpc-run`
 
-The sub-command
+The following sub-command
 
 ```cmd
-$ reach rpc-run CMD
+$ ./reach rpc-run CMD
 ```
 
 is a convenient means of launching a pre-configured RPC server and
@@ -292,55 +321,56 @@ development API key), and sets `REACH_RPC_TLS_REJECT_UNVERIFIED` to
 Consider this example from the @{seclink("tut-7-rpc")} tutorial:
 
 ```cmd
-$ reach rpc-run python3 -u ./index.py
+$ ./reach rpc-run python3 -u ./index.py
 ```
 
 # {#ref-usage-docker-reset} `reach docker-reset`
 
-You can easily kill and remove all Docker containers by executing
+This command removes all containers and volumes from Docker. If you have any personal containers, those containers will also be removed. Containers can then be restarted in your Docker Images list. It does not uninstall any Docker images.
 
 ```cmd
-$ reach docker-reset
+$ ./reach docker-reset
 ```
 
 This can be a useful thing to try if your Docker containers stop responding to requests or otherwise misbehave, or if you have updated your Reach images (with `reach update`) but those changes are not taking effect.
-This command is a loose approximation of "turning Docker off and on again."
 It will affect all Docker containers on your machine, not just those created by Reach.
 
 # {#ref-usage-upgrade} `reach upgrade`
 
-You can upgrade your Reach installation by executing
+This command downloads the most recent `reachsh/reach-cli` Docker image only.
 
 ```cmd
-$ reach upgrade
+$ ./reach upgrade
 ```
 
-This may change the default version used by `reach` commands.
+This might change the default version used by `reach` commands.
 
 # {#ref-usage-update} `reach update`
 
-You can update the Docker images used by your Reach installation by executing
+This command downloads and installs the most recent versions of the Reach Docker image. It does not start the Docker images once installed.
 
 ```cmd
-$ reach update
+$ ./reach update
 ```
 
-This may change the patch version used by `reach` commands.
+This might change the patch version used by `reach` commands.
 
 # {#ref-usage-version} `reach version`
 
-You can see what version of Reach you have installed by running
+Check which version of the Reach command-line tool is currently installed. This returns both the semantic version (such as `0.1.7`) and the hashes version (such as [639fa565](https://hub.docker.com/layers/reachsh/reach/639fa565/images/sha256-e72fbb183e559a6f531302843c1d4debb499c9286e0ca4839ae66023c7ba2296?context=explore)). This is helpful when making sure an upgrade to a new version is complete.
 
 ```cmd
-$ reach version
+$ ./reach version
 ```
+
+This is less precise than `reach hashes`, but gives you an idea of which features are, or are not, available in your build version.
 
 # {#ref-usage-hashes} `reach hashes`
 
-You can see which exact versions of Reach Docker images you are using by running
+Check which version of each Reach Docker image is installed. This command returns the hash version of each image in an 8 digit alpha-numeric code (such as [639fa565](https://hub.docker.com/layers/reachsh/reach/639fa565/images/sha256-e72fbb183e559a6f531302843c1d4debb499c9286e0ca4839ae66023c7ba2296?context=explore)). 
 
 ```cmd
-$ reach hashes
+$ ./reach hashes
 ```
 
 This is more precise, but less readable, than `reach version`,
@@ -351,7 +381,7 @@ in that each hash refers to the git commit used to build the image.
 Reach recommends tuning your default workflow settings by executing
 
 ```cmd
-$ reach config
+$ ./reach config
 ```
 
 Using `reach config` is advisable when running Reach for the first time since it will set the `REACH_CONNECTOR_MODE` environment variable, which is required when executing some other sub-commands (e.g. `reach run`).
@@ -359,4 +389,4 @@ Using `reach config` is advisable when running Reach for the first time since it
 `reach config` presents users with a guided menu which automatically creates an `env` file and suggests subsequent steps to activate and make it permanent.
 This `env` file exports environment variable settings and is intended to be `source`d by users' shells.
 
-If an `env` file already exists, `reach config` will offer to back it up before proceeding.
+If an `env` file already exists, `reach config` offers to back it up before proceeding.

--- a/docs/src/tool/index.md
+++ b/docs/src/tool/index.md
@@ -33,9 +33,9 @@ Reach has a few sub-commands, each with their own options.
 
 However, all commands support the following options:
 
-+ The environment variable `@{ref("cmd", "REACH_VERSION")}` signifies what version of Reach to use.
++ The environment variable `{!cmd} REACH_VERSION` signifies what version of Reach to use.
 
-Although normally expressed in a [semantic versioning](##guide-versions)-friendly format, e.g. `v0.1` or `v0.1.6`, `@{ref("cmd", "REACH_VERSION")}` also supports:
+Although normally expressed in a [semantic versioning](##guide-versions)-friendly format, e.g. `v0.1` or `v0.1.6`, `{!cmd} REACH_VERSION` also supports:
 + Hashes such as [639fa565](https://hub.docker.com/layers/reachsh/reach/639fa565/images/sha256-e72fbb183e559a6f531302843c1d4debb499c9286e0ca4839ae66023c7ba2296?context=explore).
 
 Valid hashes may be obtained by running:
@@ -250,23 +250,7 @@ $ REACH_CONNECTOR_MODE=ALGO ./reach devnet
 
 + `--await-background` --- Run in the background and await availability.
 
-The mandatory environment variable `{!cmd} REACH_CONNECTOR_MODE` specifies which devnet to run.
-The options are:
-
-+ `ETH`, which runs an Ethereum devnet on `localhost:8545`
-+ `ETH-browser`, which runs an Ethereum devnet on `localhost:8545`
-+ `ETH-devnet`, which runs an Ethereum devnet on `localhost:8545`
-+ `ETH-live`, which runs an Ethereum devnet on `localhost:8545`
-+ `ALGO`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
-+ `ALGO-browser`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
-+ `ALGO-devnet`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
-+ `ALGO-live`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
-+ `CFX`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
-+ `CFX-browser`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
-+ `CFX-devnet`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
-+ `CFX-live`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
-
-+ The environment variable `REACH_DEBUG` enables some additional debugging information for the Algorand devnet, which is accessible via http://localhost:9392
+For more information on envirionmental variables and `{!cmd} REACH_CONNECTOR_MODE`, refer to (##ref-usage-run). 
 
 For more information on devnet options, refer to [Networks](##ref-networks).
 

--- a/docs/src/tool/index.md
+++ b/docs/src/tool/index.md
@@ -1,10 +1,6 @@
 # {#ref} Tool
 
-This document describes the `reach` tool: how to install it and how to use it. All commands on this page assume that Reach is installed in your project repository, but if it is installed in your `PATH`, remove <b>./</b> in front of the reach commands as in the following:
-
-```cmd
-$ reach update
-```
+This document describes the `reach` tool: how to install it and how to use it. 
 
 # {#ref-install} Installation
 
@@ -69,10 +65,10 @@ In other words, `v0.1.6` is equivalent to `0.1.6`.
 
 # {#ref-usage-compile} `reach compile`
 
-Compile the Reach code by executing
+Compile Reach code by executing
 
 ```cmd
-$ ./reach compile SOURCE EXPORT ...
+$ reach compile SOURCE EXPORT ...
 ```
 
 where `SOURCE` is your source file,
@@ -114,25 +110,25 @@ named `default`.
 
 # {#ref-usage-init} `reach init`
 
-Running `reach init` creates the `index.rsh` and `index.mjs` template files required for a basic Reach DApp. This allows you to open the files and start writing code. The `index.rsh` file is the DApp and is written in Reach, and the `index.mjs` file is the frontend of the DApp and is written in JavaScript.
-
-To run `reach init`, use the following command: 
+This creates the `index.rsh` and `index.mjs` template files required for a basic Reach DApp. 
+It allows you to open the files and start writing code. 
+The `index.rsh` file is the DApp and is written in Reach, and the `index.mjs` file is the frontend of the DApp and is written in JavaScript.
 
 ```cmd
-$ ./reach init
+$ reach init
 ```
 
 # {#ref-usage-run} `reach run`
 
-The `reach run` command with no argumenst starts the `index` application in the current directory by default, but you can set a different directory, application name, or both.
+The `reach run` command with no arguments starts the `index` application in the current directory by default, but you can set a different directory, application name, or both.
 
-The `reach run` command uses the following syntax:
+The `reach run` command uses the following interface:
 
 ```cmd
-$ ./reach run [APP or DIR] [ARGS]
+$ reach run [APP or DIR] [ARGS]
 ```
 
-`APP` represents a Reach module name without its extension (e.g. "index" by default). 
+`APP` represents a Reach module name without its extension (e.g. "index" by default).
 
 If no `APP` or `DIR` is provided then `index` in the current working directory is assumed.
 
@@ -176,7 +172,7 @@ The `Dockerfile` can be modified to introduce new dependencies, services, or fil
 You can halt all Dockerized Reach apps and devnets by running
 
 ```cmd
-$ ./reach down
+$ reach down
 ```
 
 # {#ref-usage-scaffold} `reach scaffold`
@@ -184,7 +180,7 @@ $ ./reach down
 You can create templated `Dockerfile` and `package.json` files for a simple Reach app by running
 
 ```cmd
-$ ./reach scaffold
+$ reach scaffold
 ```
 
 The files created are the same as those used temporarily by `reach run`.
@@ -194,7 +190,7 @@ The files created are the same as those used temporarily by `reach run`.
 You can run a simple React app by executing
 
 ```cmd
-$ ./reach react
+$ reach react
 ```
 
 This assumes
@@ -239,45 +235,28 @@ may be used in any JavaScript project like any other JavaScript file and library
 You can run a private Reach devnet by executing the following command:
 
 ```cmd
-$ ./reach devnet
+$ reach devnet
 ```
 
 :::note
-If running `reach devnet`, it is recommended to permanently set `REACH_CONNECTOR_MODE` to the desired consensus network. If you did not set this when you originally ran `reach config`, then you can run `reach devnet` with the argument`REACH_CONNECTOR_MODE=[OPTION]` as in the following command.
+If running `reach devnet`, it is recommended to permanently set `REACH_CONNECTOR_MODE` to the desired consensus network. 
+If you did not set this when you originally ran `reach config`, then you can run `reach devnet` with the argument `REACH_CONNECTOR_MODE=[OPTION]` as in the following command.
 :::
 
 ```cmd
 $ REACH_CONNECTOR_MODE=ALGO ./reach devnet
 ```
 
-`reach devnet` supports the following options:
-
-+ `--await-background` --- Run in the background and await availability.
-
-  The mandatory environment variable `REACH_CONNECTOR_MODE` specifies which devnet to run.
-The options are:
-
-+ `ETH`, which runs an Ethereum devnet on `localhost:8545`
-+ `ETH-browser`, which runs an Ethereum devnet on `localhost:8545`
-+ `ETH-devnet`, which runs an Ethereum devnet on `localhost:8545`
-+ `ETH-live`, which runs an Ethereum devnet on `localhost:8545`
-+ `ALGO`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
-+ `ALGO-browser`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
-+ `ALGO-devnet`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
-+ `ALGO-live`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
-+ `CFX`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
-+ `CFX-browser`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
-+ `CFX-devnet`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
-+ `CFX-live`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
+For more information on devnet options, refer to [Algorand](##ref-network-algo), [Conflux](##ref-network-cfx), or [Ethereum](##ref-network-eth).
 
 + The environment variable `REACH_DEBUG` enables some additional debugging information for the Algorand devnet, which is accessible via http://localhost:9392
 
 # {#ref-usage-rpc-server} `reach rpc-server`
 
-The sub-command
+The following command
 
 ```cmd
-$ ./reach rpc-server
+$ reach rpc-server
 ```
 
 starts an instance of the [Reach RPC Server](##ref-backends-rpc) using all of the same options and defaults as `reach run`.
@@ -306,10 +285,10 @@ It defaults to `rpc-demo`.
 
 # {#ref-usage-rpc-run} `reach rpc-run`
 
-The following sub-command
+The following command
 
 ```cmd
-$ ./reach rpc-run CMD
+$ reach rpc-run CMD
 ```
 
 is a convenient means of launching a pre-configured RPC server and
@@ -321,15 +300,15 @@ development API key), and sets `REACH_RPC_TLS_REJECT_UNVERIFIED` to
 Consider this example from the @{seclink("tut-7-rpc")} tutorial:
 
 ```cmd
-$ ./reach rpc-run python3 -u ./index.py
+$ reach rpc-run python3 -u ./index.py
 ```
 
 # {#ref-usage-docker-reset} `reach docker-reset`
 
-This command removes all containers and volumes from Docker. If you have any personal containers, those containers will also be removed. Containers can then be restarted in your Docker Images list. It does not uninstall any Docker images.
+This command removes all containers and volumes from Docker. If you have any personal containers, those containers will also be removed. Containers can then be restarted. It does not remove any Docker images.
 
 ```cmd
-$ ./reach docker-reset
+$ reach docker-reset
 ```
 
 This can be a useful thing to try if your Docker containers stop responding to requests or otherwise misbehave, or if you have updated your Reach images (with `reach update`) but those changes are not taking effect.
@@ -337,30 +316,30 @@ It will affect all Docker containers on your machine, not just those created by 
 
 # {#ref-usage-upgrade} `reach upgrade`
 
-This command downloads the most recent `reachsh/reach-cli` Docker image only.
+This command downloads the most recent `reach` tool.
 
 ```cmd
-$ ./reach upgrade
+$ reach upgrade
 ```
 
 This might change the default version used by `reach` commands.
 
 # {#ref-usage-update} `reach update`
 
-This command downloads and installs the most recent versions of the Reach Docker image. It does not start the Docker images once installed.
+You can update the Docker images used by your Reach installation by executing
 
 ```cmd
-$ ./reach update
+$ reach update
 ```
 
 This might change the patch version used by `reach` commands.
 
 # {#ref-usage-version} `reach version`
 
-Check which version of the Reach command-line tool is currently installed. This returns both the semantic version (such as `0.1.7`) and the hashes version (such as [639fa565](https://hub.docker.com/layers/reachsh/reach/639fa565/images/sha256-e72fbb183e559a6f531302843c1d4debb499c9286e0ca4839ae66023c7ba2296?context=explore)). This is helpful when making sure an upgrade to a new version is complete.
+Check which version of the Reach command-line tool is currently installed. This returns the semantic version (such as `0.1.7`).
 
 ```cmd
-$ ./reach version
+$ reach version
 ```
 
 This is less precise than `reach hashes`, but gives you an idea of which features are, or are not, available in your build version.
@@ -370,7 +349,7 @@ This is less precise than `reach hashes`, but gives you an idea of which feature
 Check which version of each Reach Docker image is installed. This command returns the hash version of each image in an 8 digit alpha-numeric code (such as [639fa565](https://hub.docker.com/layers/reachsh/reach/639fa565/images/sha256-e72fbb183e559a6f531302843c1d4debb499c9286e0ca4839ae66023c7ba2296?context=explore)). 
 
 ```cmd
-$ ./reach hashes
+$ reach hashes
 ```
 
 This is more precise, but less readable, than `reach version`,
@@ -381,7 +360,7 @@ in that each hash refers to the git commit used to build the image.
 Reach recommends tuning your default workflow settings by executing
 
 ```cmd
-$ ./reach config
+$ reach config
 ```
 
 Using `reach config` is advisable when running Reach for the first time since it will set the `REACH_CONNECTOR_MODE` environment variable, which is required when executing some other sub-commands (e.g. `reach run`).

--- a/docs/src/tool/index.md
+++ b/docs/src/tool/index.md
@@ -72,13 +72,13 @@ $ reach compile SOURCE EXPORT ...
 ```
 
 where `SOURCE` is your source file,
-and each `EXPORT` is an exported Reach.App.
+and each `EXPORT` is an exported `{!rsh} Reach.App`.
 
 If no `SOURCE` is provided, then `index.rsh` is used.
 
-If no `EXPORT` is provided, then all the exported Reach.Apps will be compiled.
-If there are no Reach.Apps exported, then the program will be compiled as a library, where its exports are available to other Reach programs and frontends.
-The output name of a library is the same as if it exported a Reach.Appnamed `default`.
+If no `EXPORT` is provided, then all the exported `{!rsh} Reach.Apps` will be compiled.
+If there are no `{!rsh} Reach.Apps` exported, then the program will be compiled as a library, where its exports are available to other Reach programs and frontends.
+The output name of a library is the same as if it exported a `{!rsh} Reach.App` named `default`.
 
 `reach compile` supports the following options:
 
@@ -250,7 +250,7 @@ $ REACH_CONNECTOR_MODE=ALGO ./reach devnet
 
 + `--await-background` --- Run in the background and await availability.
 
-  The mandatory environment variable `REACH_CONNECTOR_MODE` specifies which devnet to run.
+The mandatory environment variable `REACH_CONNECTOR_MODE` specifies which devnet to run.
 The options are:
 
 + `ETH`, which runs an Ethereum devnet on `localhost:8545`
@@ -268,7 +268,7 @@ The options are:
 
 + The environment variable `REACH_DEBUG` enables some additional debugging information for the Algorand devnet, which is accessible via http://localhost:9392
 
-For more information on devnet options, refer to [Networks](##ref-networks)
+For more information on devnet options, refer to [Networks](##ref-networks).
 
 # {#ref-usage-rpc-server} `reach rpc-server`
 

--- a/docs/src/tool/index.md
+++ b/docs/src/tool/index.md
@@ -1,6 +1,6 @@
 # {#ref} Tool
 
-This document describes the `reach` tool: how to install it and how to use it. 
+This document describes the `reach` tool: how to install it and how to use it.
 
 # {#ref-install} Installation
 
@@ -76,10 +76,9 @@ and each `EXPORT` is an exported Reach.App.
 
 If no `SOURCE` is provided, then `index.rsh` is used.
 
-If no `EXPORT` is provided, then all the exported Reach.Apps will be compiled. If there are no
-Reach.Apps exported, then the program will be compiled as a library, where its exports are available
-to other Reach programs and frontends. The output name of a library is the same as if it exported a Reach.App
-named `default`.
+If no `EXPORT` is provided, then all the exported Reach.Apps will be compiled.
+If there are no Reach.Apps exported, then the program will be compiled as a library, where its exports are available to other Reach programs and frontends.
+The output name of a library is the same as if it exported a Reach.Appnamed `default`.
 
 `reach compile` supports the following options:
 
@@ -106,12 +105,12 @@ named `default`.
   This debug information includes: the estimated cost of the contract on Algorand.
   This variable automatically enabled `--intermediate-files`.
   
-  A `reach compile` usage example is available in [Overview](##over-compile). 
+A `reach compile` usage example is available in [Overview](##over-compile).
 
 # {#ref-usage-init} `reach init`
 
-This creates the `index.rsh` and `index.mjs` template files required for a basic Reach DApp. 
-It allows you to open the files and start writing code. 
+This creates the `index.rsh` and `index.mjs` template files required for a basic Reach DApp.
+It allows you to open the files and start writing code.
 The `index.rsh` file is the DApp and is written in Reach, and the `index.mjs` file is the frontend of the DApp and is written in JavaScript.
 
 ```cmd
@@ -247,9 +246,29 @@ If you did not set this when you originally ran `reach config`, then you can run
 $ REACH_CONNECTOR_MODE=ALGO ./reach devnet
 ```
 
-For more information on devnet options, refer to [Algorand](##ref-network-algo), [Conflux](##ref-network-cfx), or [Ethereum](##ref-network-eth).
+`reach devnet` supports the following options:
+
++ `--await-background` --- Run in the background and await availability.
+
+  The mandatory environment variable `REACH_CONNECTOR_MODE` specifies which devnet to run.
+The options are:
+
++ `ETH`, which runs an Ethereum devnet on `localhost:8545`
++ `ETH-browser`, which runs an Ethereum devnet on `localhost:8545`
++ `ETH-devnet`, which runs an Ethereum devnet on `localhost:8545`
++ `ETH-live`, which runs an Ethereum devnet on `localhost:8545`
++ `ALGO`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
++ `ALGO-browser`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
++ `ALGO-devnet`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
++ `ALGO-live`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
++ `CFX`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
++ `CFX-browser`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
++ `CFX-devnet`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
++ `CFX-live`, which runs an Algorand devnet on `localhost:4180` and an Algorand indexer on `localhost:8980`
 
 + The environment variable `REACH_DEBUG` enables some additional debugging information for the Algorand devnet, which is accessible via http://localhost:9392
+
+For more information on devnet options, refer to [Networks](##ref-networks)
 
 # {#ref-usage-rpc-server} `reach rpc-server`
 
@@ -305,7 +324,9 @@ $ reach rpc-run python3 -u ./index.py
 
 # {#ref-usage-docker-reset} `reach docker-reset`
 
-This command removes all containers and volumes from Docker. If you have any personal containers, those containers will also be removed. Containers can then be restarted. It does not remove any Docker images.
+This command removes all containers and volumes from Docker.
+If you have any personal containers, those containers will also be removed.
+Containers can then be restarted in your Docker Images list. It does not uninstall any Docker images.
 
 ```cmd
 $ reach docker-reset
@@ -336,7 +357,9 @@ This might change the patch version used by `reach` commands.
 
 # {#ref-usage-version} `reach version`
 
-Check which version of the Reach command-line tool is currently installed. This returns the semantic version (such as `0.1.7`).
+Check which version of the Reach command-line tool is currently installed.
+This returns both the semantic version (such as `0.1.7`) and the hashes version (such as [639fa565](https://hub.docker.com/layers/reachsh/reach/639fa565/images/sha256-e72fbb183e559a6f531302843c1d4debb499c9286e0ca4839ae66023c7ba2296?context=explore)).
+This is helpful when making sure an upgrade to a new version is complete.
 
 ```cmd
 $ reach version
@@ -346,7 +369,8 @@ This is less precise than `reach hashes`, but gives you an idea of which feature
 
 # {#ref-usage-hashes} `reach hashes`
 
-Check which version of each Reach Docker image is installed. This command returns the hash version of each image in an 8 digit alpha-numeric code (such as [639fa565](https://hub.docker.com/layers/reachsh/reach/639fa565/images/sha256-e72fbb183e559a6f531302843c1d4debb499c9286e0ca4839ae66023c7ba2296?context=explore)). 
+Check which version of each Reach Docker image is installed.
+This command returns the hash version of each image in an 8 digit alpha-numeric code (such as [639fa565](https://hub.docker.com/layers/reachsh/reach/639fa565/images/sha256-e72fbb183e559a6f531302843c1d4debb499c9286e0ca4839ae66023c7ba2296?context=explore)).
 
 ```cmd
 $ reach hashes


### PR DESCRIPTION
Updated tool page with more links, and more explicit information on some reach command-line commands, also switched the commands to the expected default ./reach commands

<!--
Hey! Thanks so much!
-->

## Summary

<!-- Explain what you're trying to do in this pull request -->

<!-- DESIGN: Does this code have some deeper design concept that motivates it that is hard to understand just by reading the code? -->

<!-- TESTING: How did you test this? Is there a new example? Do you have some test scenario you're using? -->

<!-- DOCS: Should there be a documentation or changelog update with this code? -->
