### PR TITLE
implemented stdlib.balancesOf

### DIFF
--- a/docs/src/frontend/index.md
+++ b/docs/src/frontend/index.md
@@ -304,14 +304,13 @@ Promises the balance of network tokens (or non-network tokens if `{!js} token` i
 ---
 @{ref("js", "balancesOf")}
 ```js
-balancesOf(acc, tokens) => Promise<Array<BigNumber>>
+balancesOf(acc: Account, tokens: Array<Token | null>) => Promise<Array<BigNumber>>
 ```
 Promises an array of balances that corresponds with the provided array of tokens, `{!js} tokens`,
-for a given account `{!js} acc`. If `{!js} tokens` contains a `{!js} null`, the corresponding position in the output
-array will contain the account's balance of network tokens.
-
-This function is more efficient for getting multiple token balances than repeated calls to
-`{!js} balanceOf`.
+for a given account `{!js} acc`.
+If `{!js} tokens` contains a `{!js} null`,
+the corresponding position in the output array will contain the account's balance of network tokens.
+This function is more efficient for getting multiple token balances than repeated calls to `{!js} balanceOf`.
 
 ---
 @{ref("js", "minimumBalanceOf")}

--- a/docs/src/frontend/index.md
+++ b/docs/src/frontend/index.md
@@ -302,6 +302,18 @@ balanceOf(acc, token?) => Promise<BigNumber>
 Promises the balance of network tokens (or non-network tokens if `{!js} token` is provided) held by the account given by a Reach account abstraction provided by the `{!js} acc` argument.
 
 ---
+@{ref("js", "balancesOf")}
+```js
+balancesOf(acc, tokens) => Promise<Array<BigNumber>>
+```
+Promises an array of balances that corresponds with the provided array of tokens, `{!js} tokens`,
+for a given account `{!js} acc`. If `{!js} tokens` contains a `{!js} null`, the corresponding position in the output
+array will contain the account's balance of network tokens.
+
+This function is more efficient for getting multiple token balances than repeated calls to
+`{!js} balanceOf`.
+
+---
 @{ref("js", "minimumBalanceOf")}
 ```js
 minimumBalanceOf(acc) => Promise<BigNumber>

--- a/examples/donation-balancesOf/index.mjs
+++ b/examples/donation-balancesOf/index.mjs
@@ -1,0 +1,74 @@
+import {loadStdlib} from '@reach-sh/stdlib';
+import * as backend from './build/index.main.mjs';
+import launchToken from '@reach-sh/stdlib/launchToken.mjs';
+
+const stdlib = loadStdlib(process.env);
+
+(async () => {
+  // Make accounts
+  const startingBalance = stdlib.parseCurrency(100);
+  const [ accAlice, accBob, accCreator ] =
+    await stdlib.newTestAccounts(3, startingBalance);
+
+  // Create tokens
+  const chicken = await launchToken(stdlib, accCreator, "chicken", "CKN");
+  const egg = await launchToken(stdlib, accCreator, "egg", "EGG");
+
+  // On ALGO, Alice & Bob's accounts have to accept CKN and EGG before they can receive it
+  // Note: this costs algo because it's recorded on the blockchain
+  if (stdlib.connector == 'ALGO') {
+    await accAlice.tokenAccept(chicken.id);
+    await accAlice.tokenAccept(egg.id);
+    await accBob.tokenAccept(chicken.id);
+    await accBob.tokenAccept(egg.id);
+  }
+
+  // Give Alice some CKN and EGG tokens
+  const aliceStartingCkn = stdlib.parseCurrency(200);
+  const aliceStartingEgg = stdlib.parseCurrency(300);
+  await chicken.mint(accAlice, aliceStartingCkn);
+  await egg.mint(accAlice, aliceStartingEgg);
+
+  const doDonation = async (donatedCkn, donatedEgg) => {
+    const fmt = (x) => stdlib.formatCurrency(x, 4);
+    const balancesMessage = async (account) => {
+      // ===========================================================================================
+      // Here we are calling the new balancesOf to efficiently retrieve the balances of ============
+      // multiple tokens for some account at once ==================================================
+      const [nwt, ckn, egg_] = await stdlib.balancesOf(account, [null, chicken.id, egg.id]);
+      return `${fmt(nwt)} ${stdlib.standardUnit}, ${fmt(ckn)} CKN, ${fmt(egg_)} EGG`;
+    };
+
+    console.log('\n');
+    console.log(`Alice has ${await balancesMessage(accAlice)}`);
+    console.log(`  Bob has ${await balancesMessage(accBob)}`);
+
+    // Alice launches the donation contract, and Bob joins
+    const ctcAlice = accAlice.contract(backend);
+    const ctcBob = accBob.contract(backend, ctcAlice.getInfo());
+
+    // Alice and Bob provide frontend interfaces so the contract can take place
+    await Promise.all([
+      backend.Alice(ctcAlice, {
+        getTokenIds: () => { return [chicken.id, egg.id]; },
+        getDonation: () => {
+          console.log(`Alice wants to donate ${fmt(donatedCkn)} CKN and ${fmt(donatedEgg)} EGG`);
+          return [donatedCkn, donatedEgg];
+        },
+      }),
+
+      backend.Bob(ctcBob, {
+        showDonation: (recvCkn, recvEgg) => {
+          console.log(`Bob sees that he will receive ${fmt(recvCkn)} CKN and ${fmt(recvEgg)} EGG`);
+        }
+      }),
+    ]);
+
+    console.log(`Alice now has ${await balancesMessage(accAlice)}`);
+    console.log(`  Bob now has ${await balancesMessage(accBob)}`);
+  };
+
+  await doDonation(stdlib.parseCurrency(1), stdlib.parseCurrency(2));
+  await doDonation(stdlib.parseCurrency(5), stdlib.parseCurrency(10));
+  await doDonation(stdlib.parseCurrency(100), stdlib.parseCurrency(200));
+})();

--- a/examples/donation-balancesOf/index.mjs
+++ b/examples/donation-balancesOf/index.mjs
@@ -1,74 +1,63 @@
 import {loadStdlib} from '@reach-sh/stdlib';
 import * as backend from './build/index.main.mjs';
-import launchToken from '@reach-sh/stdlib/launchToken.mjs';
 
 const stdlib = loadStdlib(process.env);
 
-(async () => {
-  // Make accounts
-  const startingBalance = stdlib.parseCurrency(100);
-  const [ accAlice, accBob, accCreator ] =
-    await stdlib.newTestAccounts(3, startingBalance);
+// Make accounts
+const startingBalance = stdlib.parseCurrency(100);
+const [ accAlice, accBob, accCreator ] =
+  await stdlib.newTestAccounts(3, startingBalance);
 
-  // Create tokens
-  const chicken = await launchToken(stdlib, accCreator, "chicken", "CKN");
-  const egg = await launchToken(stdlib, accCreator, "egg", "EGG");
+// Create tokens make Alice and Bob's accounts accept them
+const chicken = await stdlib.launchToken(accCreator, "chicken", "CKN");
+const egg = await stdlib.launchToken(accCreator, "egg", "EGG");
+await accAlice.tokenAccept(chicken.id);
+await accAlice.tokenAccept(egg.id);
+await accBob.tokenAccept(chicken.id);
+await accBob.tokenAccept(egg.id);
 
-  // On ALGO, Alice & Bob's accounts have to accept CKN and EGG before they can receive it
-  // Note: this costs algo because it's recorded on the blockchain
-  if (stdlib.connector == 'ALGO') {
-    await accAlice.tokenAccept(chicken.id);
-    await accAlice.tokenAccept(egg.id);
-    await accBob.tokenAccept(chicken.id);
-    await accBob.tokenAccept(egg.id);
-  }
+// Give Alice some CKN and EGG tokens
+const aliceStartingCkn = stdlib.parseCurrency(200);
+const aliceStartingEgg = stdlib.parseCurrency(300);
+await chicken.mint(accAlice, aliceStartingCkn);
+await egg.mint(accAlice, aliceStartingEgg);
 
-  // Give Alice some CKN and EGG tokens
-  const aliceStartingCkn = stdlib.parseCurrency(200);
-  const aliceStartingEgg = stdlib.parseCurrency(300);
-  await chicken.mint(accAlice, aliceStartingCkn);
-  await egg.mint(accAlice, aliceStartingEgg);
-
-  const doDonation = async (donatedCkn, donatedEgg) => {
-    const fmt = (x) => stdlib.formatCurrency(x, 4);
-    const balancesMessage = async (account) => {
-      // ===========================================================================================
-      // Here we are calling the new balancesOf to efficiently retrieve the balances of ============
-      // multiple tokens for some account at once ==================================================
-      const [nwt, ckn, egg_] = await stdlib.balancesOf(account, [null, chicken.id, egg.id]);
-      return `${fmt(nwt)} ${stdlib.standardUnit}, ${fmt(ckn)} CKN, ${fmt(egg_)} EGG`;
-    };
-
-    console.log('\n');
-    console.log(`Alice has ${await balancesMessage(accAlice)}`);
-    console.log(`  Bob has ${await balancesMessage(accBob)}`);
-
-    // Alice launches the donation contract, and Bob joins
-    const ctcAlice = accAlice.contract(backend);
-    const ctcBob = accBob.contract(backend, ctcAlice.getInfo());
-
-    // Alice and Bob provide frontend interfaces so the contract can take place
-    await Promise.all([
-      backend.Alice(ctcAlice, {
-        getTokenIds: () => { return [chicken.id, egg.id]; },
-        getDonation: () => {
-          console.log(`Alice wants to donate ${fmt(donatedCkn)} CKN and ${fmt(donatedEgg)} EGG`);
-          return [donatedCkn, donatedEgg];
-        },
-      }),
-
-      backend.Bob(ctcBob, {
-        showDonation: (recvCkn, recvEgg) => {
-          console.log(`Bob sees that he will receive ${fmt(recvCkn)} CKN and ${fmt(recvEgg)} EGG`);
-        }
-      }),
-    ]);
-
-    console.log(`Alice now has ${await balancesMessage(accAlice)}`);
-    console.log(`  Bob now has ${await balancesMessage(accBob)}`);
+const fmt = (x) => stdlib.formatCurrency(x, 4);
+const doDonation = async (donatedCkn, donatedEgg) => {
+  const balancesMessage = async (account) => {
+    const [nwt, ckn, egg_] = await stdlib.balancesOf(account, [null, chicken.id, egg.id]);
+    return `${fmt(nwt)} ${stdlib.standardUnit}, ${fmt(ckn)} CKN, ${fmt(egg_)} EGG`;
   };
 
-  await doDonation(stdlib.parseCurrency(1), stdlib.parseCurrency(2));
-  await doDonation(stdlib.parseCurrency(5), stdlib.parseCurrency(10));
-  await doDonation(stdlib.parseCurrency(100), stdlib.parseCurrency(200));
-})();
+  console.log('\n');
+  console.log(`Alice has ${await balancesMessage(accAlice)}`);
+  console.log(`  Bob has ${await balancesMessage(accBob)}`);
+
+  // Alice launches the donation contract, and Bob joins
+  const ctcAlice = accAlice.contract(backend);
+  const ctcBob = accBob.contract(backend, ctcAlice.getInfo());
+
+  // Alice and Bob provide frontend interfaces so the contract can take place
+  await Promise.all([
+    backend.Alice(ctcAlice, {
+      getTokenIds: () => { return [chicken.id, egg.id]; },
+      getDonation: () => {
+        console.log(`Alice wants to donate ${fmt(donatedCkn)} CKN and ${fmt(donatedEgg)} EGG`);
+        return [donatedCkn, donatedEgg];
+      },
+    }),
+
+    backend.Bob(ctcBob, {
+      showDonation: (recvCkn, recvEgg) => {
+        console.log(`Bob sees that he will receive ${fmt(recvCkn)} CKN and ${fmt(recvEgg)} EGG`);
+      }
+    }),
+  ]);
+
+  console.log(`Alice now has ${await balancesMessage(accAlice)}`);
+  console.log(`  Bob now has ${await balancesMessage(accBob)}`);
+};
+
+await doDonation(stdlib.parseCurrency(1), stdlib.parseCurrency(2));
+await doDonation(stdlib.parseCurrency(5), stdlib.parseCurrency(10));
+await doDonation(stdlib.parseCurrency(100), stdlib.parseCurrency(200));

--- a/examples/donation-balancesOf/index.rsh
+++ b/examples/donation-balancesOf/index.rsh
@@ -1,0 +1,35 @@
+'reach 0.1';
+'use strict';
+
+export const main = Reach.App(() => {
+  const A = Participant('Alice', {
+    // Alice tells the contract the token IDs of CKN and EGG
+    getTokenIds: Fun([], Tuple(Token, Token)),
+    // Alice tells the contract how much CKN and EGG she will donate to Bob
+    getDonation: Fun([], Tuple(UInt, UInt)),
+  });
+  const B = Participant('Bob', {
+    // Bob is shown the amount of donated CKN and EGG (just for informational purposes)
+    showDonation: Fun([UInt, UInt], Null),
+  });
+  init();
+
+  A.only(() => {
+    const [ckn, egg] = declassify(interact.getTokenIds());
+    const [donatedCkn, donatedEgg] = declassify(interact.getDonation());
+    assume(ckn != egg);
+  });
+  A.publish(ckn, egg, donatedCkn, donatedEgg);
+  commit();
+
+  A.pay([[donatedCkn, ckn], [donatedEgg, egg]]);
+  commit();
+
+  B.interact.showDonation(donatedCkn, donatedEgg);
+  B.publish();
+
+  transfer([[donatedCkn, ckn], [donatedEgg, egg]]).to(B);
+  commit();
+
+  exit();
+});

--- a/js/stdlib/ts/CFX.ts
+++ b/js/stdlib/ts/CFX.ts
@@ -24,6 +24,7 @@ export const {
   setWalletFallback,
   walletFallback,
   balanceOf,
+  balancesOf,
   minimumBalanceOf,
   transfer,
   connectAccount,

--- a/js/stdlib/ts/ETH.ts
+++ b/js/stdlib/ts/ETH.ts
@@ -24,6 +24,7 @@ export const {
   setWalletFallback,
   walletFallback,
   balanceOf,
+  balancesOf,
   minimumBalanceOf,
   transfer,
   connectAccount,

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -319,18 +319,39 @@ const makeHasLogFor = ( getCtcAddress: (() => Address), iface:Interface, i:numbe
 
 const { randomUInt, hasRandom } = makeRandom(32);
 
-const balanceOf = async (acc: Account | Address, token: Token|false = false): Promise<BigNumber> => {
-  let addressable = (typeof acc == 'string') ? acc : acc.networkAccount;
-  if (!addressable) {
-    throw Error(`Cannot get the address of: ${acc}`);
-  }
-  return balanceOfNetworkAccount(addressable, token);
-};
-
 const minimumBalanceOf = async (acc: Account | Address): Promise<BigNumber> => {
   void acc;
   return zeroBn;
 };
+
+const balanceOf = async (acc: Account | Address, token?: Token): Promise<BigNumber> => {
+  return (await balancesOf(acc, [token || null]))[0];
+};
+
+const balancesOf = async (acc: Account | Address, tokens: Array<Token|null>): Promise<Array<BigNumber>> => {
+  // Implementation stolen from old balanceOf and balanceOfNetworkAccount
+
+  // Address = string. If given an Address, use it as the address and networkAccount.
+  // If given an Account, extract the address and networkAccount from it.
+  const [address, networkAccount] = (typeof acc == 'string')
+                                  ? [acc, { address: acc }]
+                                  : [await getAddr(acc), acc.networkAccount];
+
+  const balanceOfSingleToken = async (token: Token | null) => {
+    if (token) {
+      return await balanceOf_token(networkAccount, address, token);
+    } else {
+      if (networkAccount.getBalance) {
+        return bigNumberify(await networkAccount.getBalance());
+      } else {
+        const provider = await getProvider();
+        return bigNumberify(await provider.getBalance(address));
+      }
+    }
+  };
+
+  return await Promise.all(tokens.map(balanceOfSingleToken));
+}
 
 const balanceOfNetworkAccount = async (networkAccount: any, token: Token|false = false) => {
   if ( ! token && networkAccount.getBalance ) {
@@ -1143,6 +1164,7 @@ const ethLike = {
   randomUInt,
   hasRandom,
   balanceOf,
+  balancesOf,
   minimumBalanceOf,
   transfer,
   connectAccount,

--- a/js/stdlib/ts/interfaces.ts
+++ b/js/stdlib/ts/interfaces.ts
@@ -129,6 +129,7 @@ export interface Stdlib_User<Provider, ProviderEnv, ProviderName, Token, Contrac
   hasRandom: { random: () => BigNumber }
   hasConsoleLogger: { log: (...a: any) => void }
   balanceOf: (acc: Account, token?: Token) => Promise<BigNumber>
+  balancesOf: (acc: Account, tokens: Array<Token | null>) => Promise<Array<BigNumber>>
   minimumBalanceOf: (acc:Account) => Promise<BigNumber>
   transfer: (from: Account, to: Account, val?: BigNumber, token?: Token) => Promise<unknown>
   connectAccount: (networkAccount: NetworkAccount) => Promise<Account>


### PR DESCRIPTION
Add `balancesOf` to stdlib, a function that is more efficient for retrieving multiple token balances at once than repeated calls to `balanceOf`. Also add a small example, `examples/donation-balancesOf`, that uses it.