### PR TITLE
Fix seclinks with empty titles.

### DIFF
--- a/docs/dev/generator.js
+++ b/docs/dev/generator.js
@@ -98,6 +98,9 @@ const xrefPut = (s, t, v) => {
       fail(`Duplicated xref`, s, t, e, v);
     }
   }
+  if ( v.title == "" ){
+    fail(`Xref insertion with empty title`, s, t, v)
+  }
   const parts = t.split(".");
   for (let i = 1; i < parts.length; i++){
     const prefix = parts.slice(0,i).join(".");
@@ -202,7 +205,7 @@ const processXRefs = ({here}) => (tree) => {
       if ( c0v && c0v.startsWith("{#") ) {
         const cp = c0v.indexOf("} ", 2);
         t = c0v.slice(2, cp);
-        v = c0v.slice(cp+2);
+        v = c0v.slice(cp+2) + cs.slice(1).map((x) => x.value).join(' ');
         xrefPut('h', t, { title: v, path: `${h}#${t}` });
       }
       if ( t === 'on-this-page' ) {
@@ -337,6 +340,9 @@ const processMd = async ({baseConfig, relDir, in_folder, iPath, oPath}) => {
 
   const seclink = (t) => {
     const { path, title } = xrefGet('h', t);
+    if (title == "") {
+      fail("seclink with empty title linked to: ", path)
+    }
     return `[${title}](${path})`;
   };
 


### PR DESCRIPTION
We have some section headings where (part of) the title of the section
is in backticks, like `this`.  When processing section headings like
that that define anchors for `seclink`, the backtick splits the text
into different list elements.  Previously we only used the first
element in a list to generate the title used for references, and thus
for `seclink`.  This resulted in links with empty text in the anchor.
The links could be discovered using the web inspector, but were
invisible and unclickable on the page.  Also, everywhere `seclink` is
used, some text output is expected gramatically at the use site.

This patch changes the processing to include backticked words and text
following them to be included in the title.  This makes previously
empty `seclink`s visible, legible, and clickable.

It also adds a couple of guard rails with `fail` if any empty titles
for xrefs make it through this improved processing in the future.
