### PR TITLE
wip exception based implementation of core-579

### DIFF
--- a/hs/src/Reach/AST/Base.hs
+++ b/hs/src/Reach/AST/Base.hs
@@ -13,7 +13,7 @@ import qualified Data.List as List
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import GHC.Generics
-import GHC.Stack (HasCallStack)
+import GHC.Stack (callStack, HasCallStack, prettyCallStack)
 import Language.JavaScript.Parser
 import Reach.JSOrphans ()
 import Reach.Pretty
@@ -22,6 +22,7 @@ import Reach.UnsafeUtil
 import Reach.Util (makeErrCode)
 import Safe (atMay)
 import qualified System.Console.Pretty as TC
+import Control.Exception (Exception, throw)
 
 --- Source Information
 data ReachSource
@@ -95,15 +96,6 @@ instance Show ImpossibleError where
 instance Pretty ImpossibleError where
   pretty = viaShow
 
-data CompilationError = CompilationError
-  { ce_suggestions :: [String]
-  , ce_errorMessage :: String
-  , ce_position :: [Int]
-  , ce_offendingToken :: Maybe String
-  , ce_errorCode :: String
-  }
-  deriving (Show, Generic, ToJSON)
-
 class ErrorMessageForJson a where
   errorMessageForJson :: Show a => a -> String
   errorMessageForJson = show
@@ -162,26 +154,53 @@ getErrorMessage mCtx src isWarning ce = do
       <> hardline
       <> docsUrl
 
-makeErrorJson :: (ErrorSuggestions a, ErrorMessageForJson a, Show a, HasErrorCode a) => SrcLoc -> a -> [Char]
-makeErrorJson src err =
-  map w2c $
-    LB.unpack $
-      encode $
-        CompilationError
-          { ce_suggestions = snd $ errorSuggestions err,
-            ce_offendingToken = fst $ errorSuggestions err,
-            ce_errorMessage = errorMessageForJson err,
-            ce_position = srcloc_line_col src,
-            ce_errorCode = makeErrCode (errPrefix err) (errIndex err)
-          }
+
+data CompilationError = CompilationError
+  { ce_suggestions :: [String]
+  , ce_errorMessage :: String
+  , ce_position :: [Int]
+  , ce_offendingToken :: Maybe String
+  , ce_errorCode :: String
+  }
+  deriving (Show, Generic, ToJSON)
+
+makeCompilationError :: (ErrorSuggestions a, ErrorMessageForJson a, Show a, HasErrorCode a) => SrcLoc -> a -> CompilationError
+makeCompilationError src err =
+  CompilationError
+    { ce_suggestions = snd $ errorSuggestions err
+    , ce_offendingToken = fst $ errorSuggestions err
+    , ce_errorMessage = errorMessageForJson err
+    , ce_position = srcloc_line_col src
+    , ce_errorCode = makeErrCode (errPrefix err) (errIndex err)
+    }
+
+encodeJSONString :: ToJSON a => a -> String
+encodeJSONString = map w2c . LB.unpack . encode
+
+makeErrorJson :: (ErrorSuggestions a, ErrorMessageForJson a, Show a, HasErrorCode a) => SrcLoc -> a -> String
+makeErrorJson src err = encodeJSONString $ makeCompilationError src err
+
+data CompileErrorException = CompileErrorException
+  { cee_error :: CompilationError
+  , cee_pretty :: String
+  }
+
+instance Show CompileErrorException where
+  show =
+    case unsafeIsErrorFormatJson of
+      True -> ("error: " ++) . encodeJSONString
+      False -> cee_pretty
+
+instance Exception CompileErrorException
+
+instance ToJSON CompileErrorException where
+  toJSON = toJSON . cee_error
+
 expect_throw :: (HasErrorCode a, Show a, ErrorMessageForJson a, ErrorSuggestions a) => HasCallStack => Maybe ([SLCtxtFrame]) -> SrcLoc -> a -> b
-expect_throw mCtx src ce =
-  case unsafeIsErrorFormatJson of
-    True ->
-      error $
-        "error: "
-          ++ makeErrorJson src ce
-    False -> error $ getErrorMessage mCtx src False ce
+expect_throw mCtx src err = throw CompileErrorException {..}
+  where
+    cee_pretty = getErrorMessage mCtx src False err ++ "\n" ++ prettyCallStack callStack
+    cee_error = makeCompilationError src err
 
 expect_thrown :: (HasErrorCode a, Show a, ErrorMessageForJson a, ErrorSuggestions a) => HasCallStack => SrcLoc -> a -> b
 expect_thrown = expect_throw Nothing


### PR DESCRIPTION
WIP implementation of core-579, still with caveman prints and debugging code. Uploaded for comment on style.

An example that shows the json object that would be uploaded vs what would be printed to the user (everything immediately after the json) 
![image](https://user-images.githubusercontent.com/1377477/154100230-49d3b105-2c3c-4603-978b-64f1f568707a.png)
