### PR TITLE
docs: move 'use strict' into statement section

### DIFF
--- a/docs/src/rsh/compute/index.md
+++ b/docs/src/rsh/compute/index.md
@@ -291,22 +291,6 @@ For example, `{!rsh} Int`s
 and `{!rsh} Array`s are valid values to throw, but a function is not.
 A `{!rsh} throw` must have an empty tail.
 
-### Expression statements
-
-```reach
-4;
-f(2, true);
-```
-
-An expression, `{!rsh} E`, in a statement position is equivalent to the block statement `{!rsh} { return E; }`.
-
-## {#ref-programs-compute-exprs} Expressions
-
-This section describes the expressions which are allowed in any Reach context.
-There are a large variety of different @{defn("expressions")} in Reach programs.
-
-The remainder of this section enumerates each kind of expression.
-
 ### 'use strict'
 
 @{ref("rsh", "'use strict'")}
@@ -354,6 +338,22 @@ const foo = (mo) =>
 void foo(MObj.Some({ b : true }));
 void foo(MObj.None());
 ```
+
+### Expression statements
+
+```reach
+4;
+f(2, true);
+```
+
+An expression, `{!rsh} E`, in a statement position is equivalent to the block statement `{!rsh} { return E; }`.
+
+## {#ref-programs-compute-exprs} Expressions
+
+This section describes the expressions which are allowed in any Reach context.
+There are a large variety of different @{defn("expressions")} in Reach programs.
+
+The remainder of this section enumerates each kind of expression.
 
 ### `unstrict`
 


### PR DESCRIPTION
<!--
Hey! Thanks so much!
-->

## Summary

The docs currently say that `"use strict"` is an expression, which raised questions in my mind about what happens when it's in contexts like function arguments, and whether an intended use of a literal string that accidentally had the same text would trigger strict evaluation, etc.  According to @chrisnevers (and my quick perusal based on his comment), `"use strict"` is actually treated as a statement.

This moves it in the docs so hopefully other people don't have such worries about the semantics of a string expression that happens to match, or how it works if used in the middle of a large expression where the evaluation order isn't obvious.

<!-- Explain what you're trying to do in this pull request -->

<!-- DESIGN: Does this code have some deeper design concept that motivates it that is hard to understand just by reading the code? -->

<!-- TESTING: How did you test this? Is there a new example? Do you have some test scenario you're using? -->

<!-- DOCS: Should there be a documentation or changelog update with this code? -->
