### PR TITLE
fix xref bug I added

### DIFF
--- a/docs/dev/generator.js
+++ b/docs/dev/generator.js
@@ -205,8 +205,9 @@ const processXRefs = ({here}) => (tree) => {
       if ( c0v && c0v.startsWith("{#") ) {
         const cp = c0v.indexOf("} ", 2);
         t = c0v.slice(2, cp);
-        v = c0v.slice(cp+2) + cs.slice(1).map((x) => x.value).join(' ');
-        xrefPut('h', t, { title: v, path: `${h}#${t}` });
+        v = c0v.slice(cp+2);
+        const xrefTitle = v + cs.slice(1).map((x) => x.value).join(' ');
+        xrefPut('h', t, { title: xrefTitle, path: `${h}#${t}` });
       }
       if ( t === 'on-this-page' ) {
         fail(here, 'uses reserved id', t);


### PR DESCRIPTION
In commit 60be9bbda1f1eb0e95060b2da01c52343d1a2c8f I fixed seclinks
that had empty titles, but I made some title headers have duplicate
words because the `v` that I changed was used later in a way I hadn't
paid attention to.  This fixes my mistake.

Screenshot before:
![2022-02-16-121220_161x92_scrot](https://user-images.githubusercontent.com/4922506/154338458-6925ad2b-7b73-4259-8b4d-2f77f9e3612e.png)

Screenshot after:
![2022-02-16-121258_180x70_scrot](https://user-images.githubusercontent.com/4922506/154338559-c6fdd8e7-4450-4cd6-8fd9-d2f64c0a9b17.png)
