### PR TITLE
docs: add externalRef form

### DIFF
--- a/docs/dev/generator.js
+++ b/docs/dev/generator.js
@@ -411,6 +411,14 @@ const processMd = async ({baseConfig, relDir, in_folder, iPath, oPath}) => {
     return s.outerHTML;
   };
 
+  const externalRef = (scope, symbol, url) => {
+    xrefPut(scope, symbol, {
+      title: `${scope}: ${symbol}`,
+      path: url,
+    });
+    return "";
+  };
+
   const directive_note = (node) => {
     const data = node.data;
     data.hName = "div";
@@ -455,7 +463,7 @@ const processMd = async ({baseConfig, relDir, in_folder, iPath, oPath}) => {
     return r.join(`\n`);
   };
 
-  const expanderEnv = { seclink, defn, workshopDeps, workshopInit, workshopWIP, errver, ref, directive_note, directive_testQ, directive_testA, generateIndex };
+  const expanderEnv = { seclink, defn, workshopDeps, workshopInit, workshopWIP, errver, externalRef, ref, directive_note, directive_testQ, directive_testA, generateIndex };
 
   const expanderDirective = () => (tree) => {
     visit(tree, (node) => {

--- a/docs/src/search/index.md
+++ b/docs/src/search/index.md
@@ -13,3 +13,14 @@ hasPageHeader: false
     <ol id="search-results-list"></ol>
   </div>
 </div>
+
+@{externalRef("js", "async", "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function")}
+@{externalRef("js", "await", "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await")}
+@{externalRef("js", "import", "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import")}
+@{externalRef("js", "export", "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export")}
+@{externalRef("js", "let", "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let")}
+@{externalRef("js", "var", "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var")}
+@{externalRef("js", "const", "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const")}
+
+
+@{externalRef("js", "componentDidMount", "https://reactjs.org/docs/react-component.html#componentdidmount")}


### PR DESCRIPTION
This allows, for example, Javascript code blocks to consistently link
to external reference material, such as the MDN or React
documentation.

This commit includes a few externalRef uses mostly to test it.  We
could add an exhaustive number of externalRefs, but that's probably a
lot of work.  I'm not sure which identifiers would be most helpful to
link.

While `externalRef` augments the reference database, it returns
nothing to the document itself, and thus has no immediate effect on
the containing document.  So it doesn't really matter which page these
are in to make the effect.  I stuffed these references in the search
page, because it seemed like the most reasonable place to stuff them
in without making a blank new page.