### PR TITLE
fix hyperlinking for dotted identifiers

### DIFF
--- a/docs/dev/generator.js
+++ b/docs/dev/generator.js
@@ -585,7 +585,9 @@ const processMd = async ({baseConfig, relDir, in_folder, iPath, oPath}) => {
   const linkifySpans = (elem, language) => {
     const activePrefixes = [];
     const linkifySpan = (s, language) => {
-      const text = s.textContent;
+      const text = s.textContent.startsWith(".") ?
+            s.textContent.substring(1) :
+            s.textContent;
       const prefixedTexts = activePrefixes.map((p) => p + "." + text);
       prefixedTexts.push(text);
       const refs = prefixedTexts.map((t) => xrefGetMaybe(language, t));


### PR DESCRIPTION
I think that when I changed the highlighter style to the one that uses
CSS variables to enable dark mode, it started attaching the "." on
method chains to the span text used for linking.  This patch
normalizes spans that start with ".", fixing the problem.