### PR TITLE
Added formatWithDecimals to stdlib iface, test program, improved docs

### DIFF
--- a/docs/src/frontend/index.md
+++ b/docs/src/frontend/index.md
@@ -985,9 +985,9 @@ The following exports are for dealing with network tokens.
 standardUnit // string
 atomicUnit // string
 minimumBalance // atomicUnitAmount
-parseCurrency(standardUnitAmount, int) => atomicUnitAmount
-formatCurrency(atomicUnitAmount, int) => string  // display amount in standard unit
-formatWithDecimals(atomicUnitAmount, int, tokenDecimals: int) => string  // display amount in standard unit (decimal value) of a token
+parseCurrency(standardUnitAmount: int) => atomicUnitAmount
+formatCurrency(atomicUnitAmount: int) => string  // display amount in standard unit
+formatWithDecimals(atomicUnitAmount: int, tokenDecimals: int) => string  // display amount of atomic unit with custom decimal place
 ```
 
 These functions handle amounts in a network's standard unit and its atomic unit.
@@ -1005,7 +1005,7 @@ BigNumber is used to represet values in WEI.
 Quantities of a network token should always be passed into Reach
 in the token's atomic unit.
 
-`{!js} bigNumberify` is transparently applied to `{!js} formatCurrency`'s first argument.
+`{!js} bigNumberify` is transparently applied to `{!js} formatCurrency`'s and `{!js} formatWithDecimals`'s first arguments.
 
 ---
 @{ref("js", "formatAddress")}

--- a/examples/formatWithDecimals-demo/index.mjs
+++ b/examples/formatWithDecimals-demo/index.mjs
@@ -1,0 +1,25 @@
+import {loadStdlib} from '@reach-sh/stdlib';
+import * as backend from './build/index.main.mjs';
+const stdlib = loadStdlib(process.env);
+
+const startingBalance = stdlib.parseCurrency(100);
+const [accAlice, accCreator] =
+  await stdlib.newTestAccounts(2, startingBalance);
+
+const neosatoshi = await stdlib.launchToken(accCreator, "neosatoshi", "NEO");
+await accAlice.tokenAccept(neosatoshi.id);
+
+const fmt = (amt) => `${stdlib.formatWithDecimals(amt, 0)} NEO = `
+                   + `${stdlib.formatWithDecimals(amt, 3)} kilo-NEO = `
+                   + `${stdlib.formatWithDecimals(amt, 6)} mega-NEO`
+
+const mintNeosatoshi = async (amt) => {
+  await neosatoshi.mint(accAlice, amt);
+  console.log(`Minting ${fmt(amt)}`);
+  console.log(`Alice now has ${fmt(await stdlib.balanceOf(accAlice, neosatoshi.id))}`);
+}
+
+await mintNeosatoshi(1);
+await mintNeosatoshi(50);
+await mintNeosatoshi(500000000);
+await mintNeosatoshi(100);

--- a/examples/formatWithDecimals-demo/index.rsh
+++ b/examples/formatWithDecimals-demo/index.rsh
@@ -1,0 +1,6 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  // index.rsh not used
+  init();
+});

--- a/hie.yaml
+++ b/hie.yaml
@@ -15,8 +15,8 @@ cradle:
               component: "reach:test:reach-test"
             - path: "./hs/app/reachc"
               component: "reach:exe:reachc"
-            - path: "./hs/app/gen-reach"
-              component: "reach:exe:gen-reach"
+            - path: "./hs/app/reach"
+              component: "reach:exe:reach"
 
 # XXX Once hie-bios is upgraded to 0.7.0
 # cradle:

--- a/hs/hie.yaml
+++ b/hs/hie.yaml
@@ -6,5 +6,5 @@ cradle:
       component: "reach:reach-test"
     - path: "./app/reachc"
       component: "reach:exe:reachc"
-    - path: "./app/gen-reach"
-      component: "reach:exe:gen-reach"
+    - path: "./app/reach"
+      component: "reach:exe:reach"

--- a/js/stdlib/ts/CFX.ts
+++ b/js/stdlib/ts/CFX.ts
@@ -50,6 +50,7 @@ export const {
   minimumBalance,
   formatCurrency,
   formatAddress,
+  formatWithDecimals,
   unsafeGetMnemonic,
   launchToken,
   reachStdlib,

--- a/js/stdlib/ts/ETH.ts
+++ b/js/stdlib/ts/ETH.ts
@@ -50,6 +50,7 @@ export const {
   minimumBalance,
   formatCurrency,
   formatAddress,
+  formatWithDecimals,
   unsafeGetMnemonic,
   launchToken,
   reachStdlib,

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -25,6 +25,7 @@ import {
   NotifySend,
   j2s,
   j2sf,
+  handleFormat,
 } from './shared_impl';
 import {
   bigNumberify,
@@ -1064,22 +1065,7 @@ const minimumBalance: BigNumber = zeroBn;
  * @example  formatCurrency(bigNumberify('100000000000000000000')); // => '100'
  */
 function formatCurrency(amt: any, decimals: number = standardDigits): string {
-  // Recall that 1 WEI = 10e18 ETH
-  if (!(Number.isInteger(decimals) && 0 <= decimals)) {
-    throw Error(`Expected decimals to be a nonnegative integer, but got ${decimals}.`);
-  }
-  // Truncate
-  decimals = Math.min(decimals, standardDigits);
-  const decimalsToForget = standardDigits - decimals;
-  const divAmt = bigNumberify(amt)
-    .div(bigNumberify(10).pow(decimalsToForget));
-  const amtStr = real_ethers.utils.formatUnits(divAmt, decimals);
-  // If the str ends with .0, chop it off
-  if (amtStr.slice(amtStr.length - 2) == ".0") {
-    return amtStr.slice(0, amtStr.length - 2);
-  } else {
-    return amtStr;
-  }
+  return handleFormat(amt, decimals, 18);
 }
 
 /**

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -74,7 +74,7 @@ export type {
 import type { // =>
   Stdlib_Backend
 } from './interfaces';
-import { setQueryLowerBound, getQueryLowerBound } from './shared_impl';
+import { setQueryLowerBound, getQueryLowerBound, formatWithDecimals } from './shared_impl';
 export { setQueryLowerBound, getQueryLowerBound };
 
 // ****************************************************************************
@@ -1173,6 +1173,7 @@ const ethLike = {
   minimumBalance,
   formatCurrency,
   formatAddress,
+  formatWithDecimals,
   unsafeGetMnemonic,
   launchToken,
   reachStdlib,

--- a/js/stdlib/ts/interfaces.ts
+++ b/js/stdlib/ts/interfaces.ts
@@ -156,6 +156,7 @@ export interface Stdlib_User<Provider, ProviderEnv, ProviderName, Token, Contrac
   minimumBalance: BigNumber
   formatCurrency: (amt: BigNumber, decimals: number) => string
   formatAddress: (acc: Account|string) => string
+  formatWithDecimals: (amt: unknown, decimals: number) => string
   unsafeGetMnemonic: (acc: Account) => string
   launchToken: (acc: Account, name: string, sym: string, opts?:LaunchTokenOpts) => any
   reachStdlib: Stdlib_Backend<Ty>

--- a/js/stdlib/ts/shared_impl.ts
+++ b/js/stdlib/ts/shared_impl.ts
@@ -1011,3 +1011,54 @@ export const makeSigningMonitor = <A,B>(): [SetSigningMonitor, NotifySend<A,B>] 
   };
   return [ setSigningMonitor, notifySend ];
 };
+
+/** @example lpad('asdf', '0', 6); // => '00asdf' */
+const lpad = (str: string, padChar: string, nChars: number) => {
+  const padding = padChar.repeat(Math.max(nChars - str.length, 0));
+  return padding + str;
+}
+
+/** @example rdrop('asfdfff', 'f'); // => 'asfd' */
+const rdrop = (str: string, char: string) => {
+  while (str[str.length - 1] === char) {
+    str = str.slice(0, str.length - 1);
+  }
+  return str;
+}
+
+/** @example ldrop('007', '0'); // => '7' */
+const ldrop = (str: string, char: string) => {
+  while (str[0] === char) {
+    str = str.slice(1);
+  }
+  return str;
+}
+
+// Helper to<BigNumber> -> string formatting function used in a couple of places
+// amt = the number to format
+// decimals = number of digits from the right to put the decimal point
+// splitValue = number of digits to keep after the decimal point
+// Example: handleFormat(1234567, 4, 2) => "123.45"
+export const handleFormat = (amt: unknown, decimals: number, splitValue: number = 6): string => {
+  if (!(Number.isInteger(decimals) && 0 <= decimals)) {
+    throw Error(`Expected decimals to be a nonnegative integer, but got ${decimals}.`);
+  }
+  if (!(Number.isInteger(splitValue) && 0 <= splitValue)) {
+    throw Error(`Expected split value to be a nonnegative integer, but got ${decimals}.`);
+  }
+  const amtStr = bigNumberify(amt).toString();
+  const splitAt = Math.max(amtStr.length - splitValue, 0);
+  const lPredropped = amtStr.slice(0, splitAt);
+  const l = ldrop(lPredropped, '0') || '0';
+  if (decimals === 0) { return l; }
+
+  const rPre = lpad(amtStr.slice(splitAt), '0', splitValue);
+  const rSliced = rPre.slice(0, decimals);
+  const r = rdrop(rSliced, '0');
+
+  return r ? `${l}.${r}` : l;
+}
+
+export const formatWithDecimals = (amt: unknown, decimals: number): string => {
+  return handleFormat(amt, decimals, decimals)
+}

--- a/test.sh
+++ b/test.sh
@@ -128,7 +128,12 @@ cdot () {
 
 #######
 
-cdot users/algo-govt/index.rsh
+jb
+ci ETH formatWithDecimals-demo
+ci ALGO formatWithDecimals-demo
+exit
+
+c users/algo-govt/index.rsh
 exit 0
 (cd users/algo-govt && ./test.sh)
 exit 0


### PR DESCRIPTION
Here's core-1146. I was a bit confused by the stdlib interfaces.ts hierarchy; I moved formatWithDecimals and its requisite functions to shared_impl.ts, then I added it to the Stdlib_User iface. Then, ETH_like and ALGO both import and re-export it. Let me know if there is a better place to put it.

Also added a small test program to show it in action. 