### PR TITLE
Add source info to state errors

### DIFF
--- a/hs/src/Reach/APICut.hs
+++ b/hs/src/Reach/APICut.hs
@@ -346,8 +346,8 @@ apc hc eWho = \case
   p -> return p
 
 apicut :: PLProg -> IO PLProg
-apicut (PLProg at plo dli dex epps cp) = do
+apicut (PLProg at plo dli dex ssm epps cp) = do
   let EPPs apis em = epps
   em' <- mapWithKeyM (apc plo) em
   let epps' = EPPs apis em'
-  return $ PLProg at plo dli dex epps' cp
+  return $ PLProg at plo dli dex ssm epps' cp

--- a/hs/src/Reach/AST/DK.hs
+++ b/hs/src/Reach/AST/DK.hs
@@ -53,7 +53,7 @@ data DKTail
       }
   | DK_If SrcLoc DLArg DKTail DKTail
   | DK_Switch SrcLoc DLVar (SwitchCases DKTail)
-  | DK_FromConsensus SrcLoc SrcLoc DKTail
+  | DK_FromConsensus SrcLoc SrcLoc [SLCtxtFrame] DKTail
   | DK_While
       { dk_w_at :: SrcLoc
       , dk_w_asn :: DLAssignment
@@ -76,7 +76,7 @@ instance Pretty DKTail where
       prettyToConsensus__ ("?" :: String) dk_tc_send dk_tc_recv dk_tc_mtime
     DK_If _at ca t f -> prettyIfp ca t f
     DK_Switch _at ov csm -> prettySwitch ov csm
-    DK_FromConsensus _at _ret_at k ->
+    DK_FromConsensus _at _ret_at _fs k ->
       prettyCommit <> hardline <> pretty k
     DK_While _at asn inv cond body k ->
       prettyWhile asn inv cond (pretty body) <> hardline <> pretty k

--- a/hs/src/Reach/AST/DL.hs
+++ b/hs/src/Reach/AST/DL.hs
@@ -100,7 +100,7 @@ data DLSStmt
       , dls_tc_recv :: DLRecv DLStmts
       , dls_tc_mtime :: Maybe (DLTimeArg, DLStmts)
       }
-  | DLS_FromConsensus SrcLoc DLStmts
+  | DLS_FromConsensus SrcLoc [SLCtxtFrame] DLStmts
   | DLS_While
       { dls_w_at :: SrcLoc
       , dls_w_asn :: DLAssignment
@@ -141,7 +141,7 @@ instance Pretty DLSStmt where
         prettyOnly who (ns onlys)
       DLS_ToConsensus {..} ->
         prettyToConsensus__ ("?" :: String) dls_tc_send dls_tc_recv dls_tc_mtime
-      DLS_FromConsensus _ more ->
+      DLS_FromConsensus _ _ more ->
         prettyCommit <> hardline <> render_dls more
       DLS_While _ asn inv cond body ->
         prettyWhile asn inv cond $ render_dls body
@@ -174,7 +174,7 @@ instance SrcLocOf DLSStmt where
     DLS_Unreachable a _ _ -> a
     DLS_Only a _ _ -> a
     DLS_ToConsensus {..} -> dls_tc_at
-    DLS_FromConsensus a _ -> a
+    DLS_FromConsensus a _ _ -> a
     DLS_While {..} -> dls_w_at
     DLS_Continue a _ -> a
     DLS_FluidSet a _ _ -> a

--- a/hs/src/Reach/AST/LL.hs
+++ b/hs/src/Reach/AST/LL.hs
@@ -14,7 +14,7 @@ data LLConsensus
   = LLC_Com DLStmt LLConsensus
   | LLC_If SrcLoc DLArg LLConsensus LLConsensus
   | LLC_Switch SrcLoc DLVar (SwitchCases LLConsensus)
-  | LLC_FromConsensus SrcLoc SrcLoc LLStep
+  | LLC_FromConsensus SrcLoc SrcLoc [SLCtxtFrame] LLStep
   | LLC_While
       { llc_w_at :: SrcLoc
       , llc_w_asn :: DLAssignment
@@ -32,7 +32,7 @@ instance SrcLocOf LLConsensus where
     LLC_Com s _ -> srclocOf s
     LLC_If a _ _ _ -> a
     LLC_Switch a _ _ -> a
-    LLC_FromConsensus a _ _ -> a
+    LLC_FromConsensus a _ _ _ -> a
     LLC_While {..} -> llc_w_at
     LLC_Continue a _ -> a
     LLC_ViewIs a _ _ _ _ -> a
@@ -42,7 +42,7 @@ instance Pretty LLConsensus where
     LLC_Com x k -> prettyCom x k
     LLC_If _at ca t f -> prettyIfp ca t f
     LLC_Switch _at ov csm -> prettySwitch ov csm
-    LLC_FromConsensus _at _ret_at k ->
+    LLC_FromConsensus _at _ret_at _fs k ->
       prettyCommit <> hardline <> pretty k
     LLC_While _at asn inv cond body k ->
       prettyWhile asn inv cond (pretty body) <> hardline <> pretty k

--- a/hs/src/Reach/AST/PL.hs
+++ b/hs/src/Reach/AST/PL.hs
@@ -299,15 +299,17 @@ data PLOpts = PLOpts
 instance HasCounter PLOpts where
   getCounter (PLOpts {..}) = plo_counter
 
+type StateSrcMap = M.Map Int (SrcLoc, [SLCtxtFrame])
+
 data PLProg
-  = PLProg SrcLoc PLOpts DLInit DLExports EPPs CPProg
+  = PLProg SrcLoc PLOpts DLInit DLExports StateSrcMap EPPs CPProg
   deriving (Eq)
 
 instance HasCounter PLProg where
-  getCounter (PLProg _ plo _ _ _ _) = getCounter plo
+  getCounter (PLProg _ plo _ _ _ _ _) = getCounter plo
 
 instance Pretty PLProg where
-  pretty (PLProg _ _ dli dex ps cp) =
+  pretty (PLProg _ _ dli dex _ ps cp) =
     "#lang pl" <> hardline
       <> pretty dex
       <> hardline

--- a/hs/src/Reach/AddCounts.hs
+++ b/hs/src/Reach/AddCounts.hs
@@ -297,8 +297,8 @@ instance AC ViewInfo where
     ViewInfo vs <$> ac_vi vi
 
 instance AC PLProg where
-  ac (PLProg at plo dli dex epps cp) =
-    PLProg at plo dli <$> ac dex <*> ac epps <*> ac cp
+  ac (PLProg at plo dli dex ssm epps cp) =
+    PLProg at plo dli <$> ac dex <*> pure ssm <*> ac epps <*> ac cp
 
 instance AC DLSend where
   ac = viaVisit
@@ -354,8 +354,8 @@ instance AC LLConsensus where
       csm' <- ac csm
       ac_visit c
       return $ LLC_Switch at c csm'
-    LLC_FromConsensus at1 at2 s ->
-      LLC_FromConsensus at1 at2 <$> ac s
+    LLC_FromConsensus at1 at2 fs s ->
+      LLC_FromConsensus at1 at2 fs <$> ac s
     LLC_While {..} -> do
       k' <- ac llc_w_k
       body' <- ac llc_w_body

--- a/hs/src/Reach/Backend/JS.hs
+++ b/hs/src/Reach/Backend/JS.hs
@@ -1008,7 +1008,7 @@ reachBackendVersion :: Int
 reachBackendVersion = 10
 
 jsPIProg :: ConnectorResult -> PLProg -> App Doc
-jsPIProg cr (PLProg _ _ dli dexports (EPPs {..}) (CPProg _ vi _ devts _)) = do
+jsPIProg cr (PLProg _ _ dli dexports ssm (EPPs {..}) (CPProg _ vi _ devts _)) = do
   let DLInit {..} = dli
   let preamble =
         vsep
@@ -1022,6 +1022,7 @@ jsPIProg cr (PLProg _ _ dli dexports (EPPs {..}) (CPProg _ vi _ devts _)) = do
   partsp <- mapM (uncurry (jsPart dli)) $ M.toAscList epps_m
   cnpsp <- mapM (uncurry jsCnp) $ HM.toList cr
   let connMap = M.fromList [(name, "_" <> pretty name) | name <- HM.keys cr]
+  ssmDoc <- mapM (\x -> jsAssertInfo (fst x) (snd x) Nothing) ssm
   exportsp <- jsExports dexports
   viewsp <-
     local (\e -> e {ctxt_maps = dli_maps}) $
@@ -1038,7 +1039,7 @@ jsPIProg cr (PLProg _ _ dli dexports (EPPs {..}) (CPProg _ vi _ devts _)) = do
           mempty
           epps_apis
   eventsp <- jsEvents devts
-  return $ vsep $ [preamble, exportsp, eventsp, viewsp, mapsp] <> partsp <> cnpsp <> [jsObjectDef "_Connectors" connMap, jsObjectDef "_Participants" partMap, jsObjectDef "_APIs" apiMap]
+  return $ vsep $ [preamble, exportsp, eventsp, viewsp, mapsp] <> partsp <> cnpsp <> [jsObjectDef "_stateSourceMap" ssmDoc, jsObjectDef "_Connectors" connMap, jsObjectDef "_Participants" partMap, jsObjectDef "_APIs" apiMap]
 
 backend_js :: Backend
 backend_js outn crs pl = do

--- a/hs/src/Reach/CollectTypes.hs
+++ b/hs/src/Reach/CollectTypes.hs
@@ -174,7 +174,7 @@ instance CollectsTypes LLConsensus where
   cts (LLC_Com m k) = cts m <> cts k
   cts (LLC_If _ c t f) = cts c <> cts t <> cts f
   cts (LLC_Switch _ v csm) = cts v <> cts csm
-  cts (LLC_FromConsensus _ _ k) = cts k
+  cts (LLC_FromConsensus _ _ _ k) = cts k
   cts (LLC_While _ asn inv cond body k) = cts asn <> cts inv <> cts cond <> cts body <> cts k
   cts (LLC_Continue _ asn) = cts asn
   cts (LLC_ViewIs _ _ _ a k) = cts a <> cts k

--- a/hs/src/Reach/Connector/ALGO.hs
+++ b/hs/src/Reach/Connector/ALGO.hs
@@ -2448,7 +2448,7 @@ analyzeViews (vs, vis) = vsit
 
 compile_algo :: CompilerToolEnv -> Disp -> PLProg -> IO ConnectorInfo
 compile_algo env disp pl = do
-  let PLProg _at plo dli _ _ cpp = pl
+  let PLProg _at plo dli _ _ _ cpp = pl
   let CPProg at vsi ai _ (CHandlers hm) = cpp
   let ai_sm = M.fromList $ map capi $ M.toAscList ai
   let vsiTop = analyzeViews vsi

--- a/hs/src/Reach/Connector/ETH_Solidity.hs
+++ b/hs/src/Reach/Connector/ETH_Solidity.hs
@@ -1430,7 +1430,7 @@ createAPIRng env =
       return $ fromMaybe (impossible "createAPIRng") $ solStruct "ApiRng" fields
 
 solPLProg :: PLProg -> IO (ConnectorInfoMap, Doc)
-solPLProg (PLProg _ plo dli _ _ (CPProg at (vs, vi) ai _ hs)) = do
+solPLProg (PLProg _ plo dli _ _ _ (CPProg at (vs, vi) ai _ hs)) = do
   let DLInit {..} = dli
   let ctxt_handler_num = 0
   ctxt_varm <- newIORef mempty

--- a/hs/src/Reach/DeJump.hs
+++ b/hs/src/Reach/DeJump.hs
@@ -83,7 +83,7 @@ instance DeJump CHandler where
     return $ C_Handler ch_at ch_int ch_from ch_last ch_svs ch_msg ch_timev ch_secsv ch_body'
 
 dejump :: PLProg -> IO PLProg
-dejump (PLProg at plo dli dex epps cp) = do
+dejump (PLProg at plo dli dex ssm epps cp) = do
   let PLOpts {..} = plo
   let CPProg cat vi ai devts (CHandlers hs) = cp
   let go h@(C_Loop {}) =
@@ -97,4 +97,4 @@ dejump (PLProg at plo dli dex epps cp) = do
         flip runReaderT (Env {..}) $ dj h
   hs' <- mapM go hs
   let cp' = CPProg cat vi ai devts (CHandlers hs')
-  return $ PLProg at plo dli dex epps cp'
+  return $ PLProg at plo dli dex ssm epps cp'

--- a/hs/src/Reach/EraseLogic.hs
+++ b/hs/src/Reach/EraseLogic.hs
@@ -138,8 +138,8 @@ instance Erase LLConsensus where
       csm' <- el csm
       v' <- el v
       return $ LLC_Switch at v' csm'
-    LLC_FromConsensus at1 at2 s ->
-      LLC_FromConsensus at1 at2 <$> el s
+    LLC_FromConsensus at1 at2 fs s ->
+      LLC_FromConsensus at1 at2 fs <$> el s
     LLC_While at asn inv cond body k -> do
       k' <- el k
       cond' <- el cond

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -5099,6 +5099,7 @@ findStmtTrampoline = \case
   SLV_Prim SLPrim_committed -> Just $ \_ ks -> do
     ensure_mode SLM_ConsensusStep "commit"
     sco <- e_sco <$> ask
+    fs <- e_stack <$> ask
     at <- withAt id
     st <- readSt id
     setSt $
@@ -5110,7 +5111,7 @@ findStmtTrampoline = \case
     (steplifts, cr) <-
       captureLifts $
         locSco sco' $ evalStmt ks
-    saveLift $ DLS_FromConsensus at steplifts
+    saveLift $ DLS_FromConsensus at fs steplifts
     return $ cr
   SLV_Prim SLPrim_inited -> Just $ \_ ks -> do
     ensure_mode SLM_AppInit "init"

--- a/hs/src/Reach/Freshen.hs
+++ b/hs/src/Reach/Freshen.hs
@@ -219,7 +219,7 @@ instance Freshen LLConsensus where
     LLC_Com s k -> LLC_Com <$> fu s <*> fu k
     LLC_If at c t f -> LLC_If at <$> fu c <*> fu t <*> fu f
     LLC_Switch at v csm -> LLC_Switch at <$> fu v <*> fu csm
-    LLC_FromConsensus x y k -> LLC_FromConsensus x y <$> fu k
+    LLC_FromConsensus x y fs k -> LLC_FromConsensus x y fs <$> fu k
     LLC_While at asn inv cond body k ->
       LLC_While at <$> fu_v asn <*> fu inv <*> fu cond <*> fu body <*> fu k
     LLC_Continue at asn -> LLC_Continue at <$> fu asn

--- a/hs/src/Reach/Interference.hs
+++ b/hs/src/Reach/Interference.hs
@@ -150,7 +150,7 @@ color s gInter asn0 = do
   readIORef asnr
 
 colorProgram :: PLProg -> IO ColorGraphs
-colorProgram (PLProg _ _ _ _ _ (CPProg _ _ _ _ (CHandlers handlers))) = do
+colorProgram (PLProg _ _ _ _ _ _ (CPProg _ _ _ _ (CHandlers handlers))) = do
   e_tv <- newIORef mempty
   e_ti <- newIORef mempty
   flip runReaderT (Env {..}) $ makeInterferenceGraph handlers

--- a/hs/src/Reach/Linearize.hs
+++ b/hs/src/Reach/Linearize.hs
@@ -150,7 +150,7 @@ dk1 k s =
       let recv' = recv {dr_k = cs'}
       let go (ta, time_ss) = (,) ta <$> dk_ k time_ss
       DK_ToConsensus at send recv' <$> mapM go mtime
-    DLS_FromConsensus at ss -> DK_FromConsensus at at <$> dk_ k ss
+    DLS_FromConsensus at fs ss -> DK_FromConsensus at at fs <$> dk_ k ss
     DLS_While at asn inv_b cond_b body -> do
       let body' = dk_top at body
       let block = dk_block at
@@ -308,8 +308,8 @@ instance LiftCon DKTail where
       DK_ToConsensus at send <$> (noLifts $ lc recv) <*> lc mtime
     DK_If at c t f -> DK_If at c <$> lc t <*> lc f
     DK_Switch at v csm -> DK_Switch at v <$> lc csm
-    DK_FromConsensus at1 at2 k ->
-      captureLifts at1 $ DK_FromConsensus at1 at2 <$> lc k
+    DK_FromConsensus at1 at2 fs k ->
+      captureLifts at1 $ DK_FromConsensus at1 at2 fs <$> lc k
     DK_While at asn inv cond body k ->
       DK_While at asn inv cond <$> lc body <*> lc k
     DK_Continue at asn -> return $ DK_Continue at asn
@@ -467,8 +467,8 @@ df_con = \case
         fluidSet FV_baseWaitTime tct $
           fluidSet FV_baseWaitSecs tcs $
             df_con t
-  DK_FromConsensus at1 at2 t -> do
-    LLC_FromConsensus at1 at2 <$> df_step t
+  DK_FromConsensus at1 at2 fs t -> do
+    LLC_FromConsensus at1 at2 fs <$> df_step t
   DK_ViewIs at vn vk mva k -> do
     mva' <- maybe (return $ Nothing) (\eb -> Just <$> df_eb eb) mva
     k' <- df_con k

--- a/hs/src/Reach/Optimize.hs
+++ b/hs/src/Reach/Optimize.hs
@@ -679,8 +679,8 @@ instance Optimize LLConsensus where
       optWhile (\asn' cond' body' k' -> LLC_While at asn' inv' cond' body' k') asn cond body k
     LLC_Continue at asn ->
       LLC_Continue at <$> opt asn
-    LLC_FromConsensus at1 at2 s ->
-      LLC_FromConsensus at1 at2 <$> (maybeClearMaps $ focus_all $ opt s)
+    LLC_FromConsensus at1 at2 fs s ->
+      LLC_FromConsensus at1 at2 fs <$> (maybeClearMaps $ focus_all $ opt s)
     LLC_ViewIs at vn vk a k ->
       LLC_ViewIs at vn vk <$> opt a <*> opt k
   gcs = \case
@@ -689,7 +689,7 @@ instance Optimize LLConsensus where
     LLC_Switch _ _ csm -> gcsSwitch csm
     LLC_While _ _ _ cond body k -> gcs cond >> gcs body >> gcs k
     LLC_Continue {} -> return ()
-    LLC_FromConsensus _ _ s -> gcs s
+    LLC_FromConsensus _ _ _ s -> gcs s
     LLC_ViewIs _ _ _ _ k -> gcs k
 
 _opt_dbg :: Show a => App a -> App a
@@ -850,10 +850,10 @@ instance Optimize EPPs where
   gcs (EPPs {..}) = gcs epps_m
 
 instance Optimize PLProg where
-  opt (PLProg at plo dli dex epps cp) = do
+  opt (PLProg at plo dli dex ssm epps cp) = do
     local (updateClearMaps $ plo_untrustworthyMaps plo) $
-      PLProg at plo dli <$> opt dex <*> opt epps <*> opt cp
-  gcs (PLProg _ _ _ _ epps cp) = gcs epps >> gcs cp
+      PLProg at plo dli <$> opt dex <*> pure ssm <*> opt epps <*> opt cp
+  gcs (PLProg _ _ _ _ _ epps cp) = gcs epps >> gcs cp
 
 optimize_ :: (Optimize a) => Counter -> a -> IO a
 optimize_ c t = do

--- a/hs/src/Reach/Sanitize.hs
+++ b/hs/src/Reach/Sanitize.hs
@@ -131,7 +131,7 @@ instance Sanitize LLConsensus where
     LLC_Switch _ ov csm -> LLC_Switch sb ov (sani csm)
     LLC_While _ asn inv cond body k -> LLC_While sb (sani asn) (sani inv) (sani cond) (sani body) (sani k)
     LLC_Continue _ asn -> LLC_Continue sb (sani asn)
-    LLC_FromConsensus _ _ s -> LLC_FromConsensus sb sb (sani s)
+    LLC_FromConsensus _ _ fs s -> LLC_FromConsensus sb sb fs (sani s)
     LLC_ViewIs _ vn vk a k -> LLC_ViewIs sb vn vk (sani a) (sani k)
 
 instance Sanitize DLPayAmt where

--- a/hs/src/Reach/Simulator/Core.hs
+++ b/hs/src/Reach/Simulator/Core.hs
@@ -699,7 +699,7 @@ instance Interp LLConsensus where
       let (switch_binding, _, cons) = saferMaybe "LLC_Switch" $ M.lookup k switch_cases
       addToStore switch_binding v
       interp cons
-    LLC_FromConsensus _at1 _at2 step -> do
+    LLC_FromConsensus _at1 _at2 _fs step -> do
       incrNWtime 1
       incrNWsecs 1
       interp step

--- a/hs/src/Reach/StateDiagram.hs
+++ b/hs/src/Reach/StateDiagram.hs
@@ -84,7 +84,7 @@ instance HasEdges CPProg where
   getEdges (CPProg _ _ _ _ hs) = getEdges hs
 
 instance HasEdges PLProg where
-  getEdges (PLProg _ _ _ _ _ cp) = getEdges cp
+  getEdges (PLProg _ _ _ _ _ _ cp) = getEdges cp
 
 setSanitize :: Ord a => [a] -> [a]
 setSanitize = S.toList . S.fromList

--- a/hs/src/Reach/UnrollLoops.hs
+++ b/hs/src/Reach/UnrollLoops.hs
@@ -159,7 +159,7 @@ instance Unroll LLConsensus where
     LLC_Com m k -> ul_m LLC_Com m k
     LLC_If at c t f -> LLC_If at c <$> ul t <*> ul f
     LLC_Switch at ov csm -> LLC_Switch at ov <$> ul csm
-    LLC_FromConsensus at at' s -> LLC_FromConsensus at at' <$> ul s
+    LLC_FromConsensus at at' fs s -> LLC_FromConsensus at at' fs <$> ul s
     LLC_While at asn inv cond body k ->
       LLC_While at asn <$> ul inv <*> ul cond <*> ul body <*> ul k
     LLC_Continue at asn -> return $ LLC_Continue at asn
@@ -223,8 +223,8 @@ instance Unroll EPPs where
   ul (EPPs {..}) = EPPs <$> pure epps_apis <*> pure epps_m
 
 instance Unroll PLProg where
-  ul (PLProg at opts dli dex ep cp) =
-    PLProg at opts dli <$> ul dex <*> ul ep <*> ul cp
+  ul (PLProg at opts dli dex ssm ep cp) =
+    PLProg at opts dli <$> ul dex <*> pure ssm <*> ul ep <*> ul cp
 
 data UnrollWrapper a
   = UnrollWrapper Counter a

--- a/hs/src/Reach/Verify/Knowledge.hs
+++ b/hs/src/Reach/Verify/Knowledge.hs
@@ -320,7 +320,7 @@ kgq_n ctxt = \case
         ctxtNewScope ctxt' $
           kgq_a_only ctxt' ov' oa
             >> kgq_n ctxt' n
-  LLC_FromConsensus _ _ k ->
+  LLC_FromConsensus _ _ _ k ->
     kgq_s ctxt k
   LLC_While _ asn _ (DLBlock _ _ cond_l ca) body k ->
     kgq_asn_def ctxt asn

--- a/hs/src/Reach/Verify/SMT.hs
+++ b/hs/src/Reach/Verify/SMT.hs
@@ -1319,7 +1319,7 @@ smt_n = \case
     mapM_ (ctxtNewScope . go) [(True, t), (False, f)]
   LLC_Switch at ov csm ->
     smtSwitch SM_Consensus at ov csm smt_n
-  LLC_FromConsensus at _ s -> do
+  LLC_FromConsensus at _ _ s -> do
     um <- asks ctxt_untrustworthyMaps
     when um $ smtMapRefresh at
     smt_s s

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -25,6 +25,7 @@ import {
 } from './version';
 import {
   CurrencyAmount, OnProgress,
+  apiStateMismatchError,
   IViewLib, IBackend, IBackendViewInfo, IBackendViewsInfo,
   IRecvArgs, ISendRecvArgs,
   IAccount, IContract, IRecv,
@@ -77,6 +78,7 @@ import {
   bytestringyNet,
 } from './ALGO_compiled';
 export type { Token } from './ALGO_compiled';
+import {  } from './shared_backend';
 import type { MapRefT, MaybeRep } from './shared_backend'; // =>
 import { window, process, updateProcessEnv } from './shim';
 import { sha512_256 } from 'js-sha512';
@@ -1309,7 +1311,7 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
         debug('getState');
         return await getState_(getC, (vibna:BigNumber) => {
           if ( vibne.eq(vibna) ) { return vtys; }
-          throw Error(`Expected state ${vibne}, got ${vibna}`);
+          throw apiStateMismatchError(bin, vibne, vibna);
         });
       };
 

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -5,6 +5,7 @@ import {
 } from './shared_backend';
 import type { MaybeRep, MapRefT } from './shared_backend'; // =>
 import {
+  apiStateMismatchError,
   replaceableThunk,
   debug,
   stdContract, stdVerifyContract,
@@ -544,7 +545,7 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
         const [ vibna, vsbs ] = await ethersC["_reachCurrentState"]();
         debug(`getState`, { vibne, vibna, vsbs });
         if ( ! vibne.eq(vibna) ) {
-          throw Error(`expected state ${vibne}, got ${vibna}`);
+          throw apiStateMismatchError(bin, vibne, vibna);
         }
         const ty = T_Tuple(tys);
         const res = decodeEm(ty, vsbs);

--- a/js/stdlib/ts/shared_backend.ts
+++ b/js/stdlib/ts/shared_backend.ts
@@ -38,7 +38,7 @@ const objectIsEmpty = (obj: any) =>
   && Object.keys(obj).length === 0
   && Object.getPrototypeOf(obj) === Object.prototype);
 
-const formatAssertInfo = (ai:any = {}) => {
+export const formatAssertInfo = (ai:any = {}) => {
   let msg = '';
   if ( typeof ai === 'string' ) {
     msg = `: ${ai}`;

--- a/js/stdlib/ts/shared_impl.ts
+++ b/js/stdlib/ts/shared_impl.ts
@@ -14,6 +14,7 @@ import {
   checkedBigNumberify,
   bytesEq,
   assert,
+  formatAssertInfo,
 } from './shared_backend';
 import type { MapRefT } from './shared_backend'; // =>
 import { process } from './shim';
@@ -113,6 +114,7 @@ export type IBackend<ConnectorTy extends AnyBackendTy> = {
   _getMaps: (stdlib:Object) => IBackendMaps<ConnectorTy>,
   _Participants: {[n: string]: any},
   _APIs: {[n: string]: any | {[n: string]: any}},
+  _stateSourceMap: {[key: number]: any},
   _getEvents: (stdlib:Object) => ({ [n:string]: [any] })
 };
 
@@ -1062,3 +1064,14 @@ export const handleFormat = (amt: unknown, decimals: number, splitValue: number 
 export const formatWithDecimals = (amt: unknown, decimals: number): string => {
   return handleFormat(amt, decimals, decimals)
 }
+
+export const apiStateMismatchError = (bin: IBackend<any>, es: BigNumber, as: BigNumber) : Error => {
+  const formatLoc = (s:BigNumber) =>
+    formatAssertInfo(bin._stateSourceMap[s.toNumber()]);
+  const el = formatLoc(es);
+  const al = formatLoc(as);
+  return Error(`Expected the DApp to be in state ${es}, but it was actually in state ${as}.\n`
+    + `\nState ${es} corresponds to the commit() at ${el}`
+    + `\nState ${as} corresponds to the commit() at ${al}`
+    + (el == al ? "\n(This means that the commit() is in the continuation of an effect.)" : ""));
+};


### PR DESCRIPTION
This is just a work in progress first draft, the first thing got got working end-to-end, not really ready for merge.  But I thought I would get some feedback about the Haskell code so far.  Is this more-or-less the direction you wanted this to go, @jeapostrophe ?  I added an extra field to PLProg for the map because I'm not really sure what the other things are yet.  None of them look like a good place to stuff this info, and all of them seemed to involve a similar footprint of boilerplate pattern matching (and reconstruction) editing.

Right now it prints something like `Error: Bob.payMe errored with Error: Expected state 2 at /home/wgh/s/mk/reach-lang/examples/api-call-fail/index.rsh:26:11:after expr stmt semicolon, got 1 at /home/wgh/s/mk/reach-lang/examples/api-call-fail/index.rsh:26:11:after expr stmt semicolon`, which obviously needs to be cleaned up, still needs the static language stack so it can disambiguate different states with the same source location.