### PR TITLE
Core-1147 cleanup and officially support launchToken

### DIFF
--- a/docs/src/changelog/index.md
+++ b/docs/src/changelog/index.md
@@ -7,7 +7,7 @@ Versions and changes-within-versions are listed in reverse-chronological order: 
 
 Version 0.1.8 is the current Reach release candidate version.
 
-+ 2022/02/28: Added `{!js} url`, `{!js} metadataHash`, and `{!js} clawback` options, as well as frontend documentation, for token minting.
++ 2022/02/28: Added `{!js} launchToken` for token minting in frontends.
 + 2022/02/25: Added support for tracking `{!rsh} Token` information—such as balance, supply, and whether its destroyed—dynamically.
 + 2022/02/25: Added `{!cmd} reach info`.
 + 2022/02/25: Removed `{!cmd} reach upgrade` (subsumed by `{!cmd} reach update`).

--- a/docs/src/changelog/index.md
+++ b/docs/src/changelog/index.md
@@ -7,6 +7,7 @@ Versions and changes-within-versions are listed in reverse-chronological order: 
 
 Version 0.1.8 is the current Reach release candidate version.
 
++ 2022/02/28: Added `{!js} url`, `{!js} metadataHash`, and `{!js} clawback` options, as well as frontend documentation, for token minting.
 + 2022/02/25: Added support for tracking `{!rsh} Token` information—such as balance, supply, and whether its destroyed—dynamically.
 + 2022/02/25: Added `{!cmd} reach info`.
 + 2022/02/25: Removed `{!cmd} reach upgrade` (subsumed by `{!cmd} reach update`).

--- a/docs/src/frontend/index.md
+++ b/docs/src/frontend/index.md
@@ -1079,5 +1079,7 @@ The default is the maximum possible on the network.
 The default is no url.
 + `{!js} metadataHash` Algorand only. A hash of some metadata that is relevant to your asset.
 The default is no metadata hash.
++ `{!js} clawback` Algorand only. Address that can claw back holdings of the token.
+The default is no clawback address.
 
 For more information on Algorand-only options, see https://developer.algorand.org/docs/get-details/transactions/transactions/#asset-parameters.

--- a/docs/src/frontend/index.md
+++ b/docs/src/frontend/index.md
@@ -1060,3 +1060,24 @@ ask.done() => null
 ```
 
 Read the [Interaction and Independence](##tut-8) section the Rock, Paper, Scissors tutorial for a longer use case example of the `{!js} ask` object.
+
+---
+@{ref("js", "launchToken")}
+```js
+launchToken(accCreator: Account, name: string, sym: string, opts?: LaunchTokenOpts) => Promise<object>
+```
+
+Launches a new token with the given `{!js} name` and unit symbol `{!js} sym`.
+Launched on the network by `{!js} accCreator`.
+
+Possible options to provide in `{!js} opts` include:
++ `{!js} decimals` The number of digits to use after the decimal point when displaying the asset.
+The default is the same as the network token.
++ `{!js} supply` The total number of atomic token units to create.
+The default is the maximum possible on the network.
++ `{!js} url` Algorand only. A URL where more information about the asset can be retrieved.
+The default is no url.
++ `{!js} metadataHash` Algorand only. A hash of some metadata that is relevant to your asset.
+The default is no metadata hash.
+
+For more information on Algorand-only options, see https://developer.algorand.org/docs/get-details/transactions/transactions/#asset-parameters.

--- a/docs/src/frontend/index.md
+++ b/docs/src/frontend/index.md
@@ -1067,19 +1067,21 @@ Read the [Interaction and Independence](##tut-8) section the Rock, Paper, Scisso
 launchToken(accCreator: Account, name: string, sym: string, opts?: LaunchTokenOpts) => Promise<object>
 ```
 
-Launches a new token with the given `{!js} name` and unit symbol `{!js} sym`.
+Launches a non-network token with the given `{!js} name` and unit symbol `{!js} sym`.
 Launched on the network by `{!js} accCreator`.
 
 Possible options to provide in `{!js} opts` include:
-+ `{!js} decimals` The number of digits to use after the decimal point when displaying the asset.
++ `{!js} decimals` The number of digits to use after the decimal point when displaying the non-network token.
 The default is the same as the network token.
 + `{!js} supply` The total number of atomic token units to create.
 The default is the maximum possible on the network.
-+ `{!js} url` Algorand only. A URL where more information about the asset can be retrieved.
+
+Algorand-only options:
++ `{!js} url` A URL where more information about the non-network token can be retrieved.
 The default is no url.
-+ `{!js} metadataHash` Algorand only. A hash of some metadata that is relevant to your asset.
++ `{!js} metadataHash` A hash of some metadata that is relevant to your non-network token.
 The default is no metadata hash.
-+ `{!js} clawback` Algorand only. Address that can claw back holdings of the token.
++ `{!js} clawback` Address that can claw back holdings of the token.
 The default is no clawback address.
 
 For more information on Algorand-only options, see https://developer.algorand.org/docs/get-details/transactions/transactions/#asset-parameters.

--- a/docs/src/frontend/index.md
+++ b/docs/src/frontend/index.md
@@ -1075,13 +1075,14 @@ Possible options to provide in `{!js} opts` include:
 The default is the same as the network token.
 + `{!js} supply` The total number of atomic token units to create.
 The default is the maximum possible on the network.
-
-Algorand-only options:
 + `{!js} url` A URL where more information about the non-network token can be retrieved.
 The default is no url.
 + `{!js} metadataHash` A hash of some metadata that is relevant to your non-network token.
 The default is no metadata hash.
+
+Algorand-only options:
 + `{!js} clawback` Address that can claw back holdings of the token.
 The default is no clawback address.
 
-For more information on Algorand-only options, see https://developer.algorand.org/docs/get-details/transactions/transactions/#asset-parameters.
+For more information on Algorand-only options, see
+https://developer.algorand.org/docs/get-details/transactions/transactions/#asset-parameters.

--- a/examples/signingMonitor/index.mjs
+++ b/examples/signingMonitor/index.mjs
@@ -26,7 +26,7 @@ const stepsInProgram = 3;
 console.log(reqs);
 const actual = reqs.length;
 const expected = {
-  'ALGO': (stepsInProgram + 1 /*alloc*/ + 2 /*optin*/ + 3 /*newTestAccount*/),
+  'ALGO': (stepsInProgram + 1 /*alloc*/ + 2 /*optin*/ + 3 /*newTestAccount*/ + 1 /*launchToken*/),
   'CFX': stepsInProgram,
   'ETH': stepsInProgram + 3 /*newTestAccount?*/,
 }[stdlib.connector];

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -2187,7 +2187,7 @@ export const launchToken = async (accCreator: Account, name: string, sym: string
   if (!assetIndex) throw Error(`${sym} no asset-index!`);
   const id = bigNumberify(assetIndex);
 
-  const mint = (accTo: Account, amt: unknown) => transfer(accCreator, accTo, amt, id);
+  const mint = (accTo: Account, amt: any) => transfer(accCreator, accTo, amt, id);
   const optOut = async (accFrom: Account, accTo: Account = accCreator) => {
     // Opting out = sending all of your current balance to accTo
     const addrFrom = accFrom.networkAccount.addr;

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -2150,7 +2150,7 @@ const makeAssetCreateTxn = (
   name: string,
   url: string,
   metadataHash: string,
-  clawback: Address,
+  clawback: Address | undefined,
   params: TxnParams,
 ): Transaction => {
   return algosdk.makeAssetCreateTxnWithSuggestedParamsFromObject({
@@ -2173,7 +2173,7 @@ export const launchToken = async (accCreator: Account, name: string, sym: string
   const decimals = opts.decimals ?? 6;
   const url = opts.url ?? '';
   const metadataHash = opts.metadataHash ?? '';
-  const clawback = opts.clawback ? protect(T_Address, opts.clawback) as string : '';
+  const clawback = opts.clawback ? protect(T_Address, opts.clawback) as string : undefined;
   const params = await getTxnParams('launchToken');
 
   const txnResult = await sign_and_send_sync(

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -2173,7 +2173,7 @@ export const launchToken = async (accCreator: Account, name: string, sym: string
   const decimals = opts.decimals ?? 6;
   const url = opts.url ?? '';
   const metadataHash = opts.metadataHash ?? '';
-  const clawback = opts.clawback ? protect(T_Address, opts.clawback) as string : undefined;
+  const clawback = opts.clawback ? cbr2algo_addr(protect(T_Address, opts.clawback) as string) : undefined;
   const params = await getTxnParams('launchToken');
 
   const txnResult = await sign_and_send_sync(

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -2142,7 +2142,66 @@ export function unsafeGetMnemonic(acc: NetworkAccount|Account): string {
   return algosdk.secretKeyToMnemonic(networkAccount.sk);
 }
 
-export async function launchToken (accCreator:Account, name:string, sym:string, opts:LaunchTokenOpts = {}) {
+const makeAssetCreateTxn = (
+  creator: Address,
+  supply: BigNumber,
+  decimals: number,
+  symbol: string,
+  name: string,
+  params: TxnParams,
+): Transaction => {
+  return algosdk.makeAssetCreateTxnWithSuggestedParamsFromObject({
+    from: creator,
+    // note: undefined,
+    total: bigNumberToBigInt(supply),
+    decimals: decimals,
+    defaultFrozen: false,
+    // manager: creator,
+    // reserve: creator,
+    // freeze: creator,
+    // clawback: creator,
+    unitName: symbol,
+    assetName: name,
+    // assetURL: '',
+    // assetMetadataHash: '',
+    suggestedParams: params,
+  });
+}
+
+export const launchToken = async (accCreator: Account, name: string, sym: string, opts: LaunchTokenOpts = {}) => {
+  const addrCreator = accCreator.networkAccount.addr;
+  const supply = opts.supply ? bigNumberify(opts.supply) : bigNumberify(2).pow(64).sub(1);
+  const decimals = opts.decimals !== undefined ? opts.decimals : 6;
+  const params = await getTxnParams('launchToken');
+  const assetCreateTxn = makeAssetCreateTxn(addrCreator, supply, decimals, sym, name, params);
+  const txnResult = await sign_and_send_sync(
+    `launchToken ${j2s(accCreator)} ${name} ${sym}`,
+    accCreator.networkAccount,
+    toWTxn(assetCreateTxn)
+  );
+
+  const assetIndex = txnResult['created-asset-index'];
+  if (!assetIndex) throw Error(`${sym} no asset-index!`);
+  const id = bigNumberify(assetIndex);
+
+  const mint = (accTo: Account, amt: unknown) => transfer(accCreator, accTo, amt, id);
+  const optOut = async (accFrom: Account, accTo: Account = accCreator) => {
+    // Opting out = sending all of your current balance to accTo
+    const addrFrom = accFrom.networkAccount.addr;
+    const addrTo = accTo.networkAccount.addr;
+    const params = await getTxnParams('token.optOut');
+    const optOutTxn = makeTransferTxn(addrFrom, addrTo, bigNumberify(0), id, params, addrTo);
+    await sign_and_send_sync(
+      `token.optOut ${j2s(accFrom)} ${name}`,
+      accFrom.networkAccount,
+      toWTxn(optOutTxn),
+    );
+  }
+
+  return { name, sym, id, mint, optOut };
+}
+
+void async function OLD_launchToken (accCreator:Account, name:string, sym:string, opts:LaunchTokenOpts = {}) {
   debug(`Launching token, ${name} (${sym})`);
   const addr = (acc:Account) => acc.networkAccount.addr;
   const caddr = addr(accCreator);

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -2173,7 +2173,7 @@ export const launchToken = async (accCreator: Account, name: string, sym: string
   const decimals = opts.decimals ?? 6;
   const url = opts.url ?? '';
   const metadataHash = opts.metadataHash ?? '';
-  const clawback = opts.clawback ? opts.clawback.networkAccount.addr : '';
+  const clawback = opts.clawback ? protect(T_Address, opts.clawback) as string : '';
   const params = await getTxnParams('launchToken');
 
   const txnResult = await sign_and_send_sync(

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -2149,21 +2149,18 @@ const makeAssetCreateTxn = (
   symbol: string,
   name: string,
   params: TxnParams,
+  url: string,
+  metadataHash: string,
 ): Transaction => {
   return algosdk.makeAssetCreateTxnWithSuggestedParamsFromObject({
     from: creator,
-    // note: undefined,
     total: bigNumberToBigInt(supply),
     decimals: decimals,
     defaultFrozen: false,
-    // manager: creator,
-    // reserve: creator,
-    // freeze: creator,
-    // clawback: creator,
     unitName: symbol,
     assetName: name,
-    // assetURL: '',
-    // assetMetadataHash: '',
+    assetURL: url,
+    assetMetadataHash: metadataHash,
     suggestedParams: params,
   });
 }
@@ -2171,13 +2168,15 @@ const makeAssetCreateTxn = (
 export const launchToken = async (accCreator: Account, name: string, sym: string, opts: LaunchTokenOpts = {}) => {
   const addrCreator = accCreator.networkAccount.addr;
   const supply = opts.supply ? bigNumberify(opts.supply) : bigNumberify(2).pow(64).sub(1);
-  const decimals = opts.decimals !== undefined ? opts.decimals : 6;
+  const decimals = opts.decimals ?? 6;
+  const url = opts.url ?? '';
+  const metadataHash = opts.metadataHash ?? '';
   const params = await getTxnParams('launchToken');
-  const assetCreateTxn = makeAssetCreateTxn(addrCreator, supply, decimals, sym, name, params);
+
   const txnResult = await sign_and_send_sync(
     `launchToken ${j2s(accCreator)} ${name} ${sym}`,
     accCreator.networkAccount,
-    toWTxn(assetCreateTxn)
+    toWTxn(makeAssetCreateTxn(addrCreator, supply, decimals, sym, name, params, url, metadataHash))
   );
 
   const assetIndex = txnResult['created-asset-index'];

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -1090,7 +1090,9 @@ async function launchToken (accCreator:Account, name:string, sym:string, opts:an
   debug(`${sym}: deploy`);
   const supply = (opts.supply && bigNumberify(opts.supply)) || bigNumberify(2).pow(256).sub(1);
   const decimals = opts.decimals !== undefined ? opts.decimals : standardDigits;
-  const contract = await factory.deploy(name, sym, '', '', supply, decimals);
+  const url = opts.url ?? '';
+  const metadataHash = opts.metadataHash ?? '';
+  const contract = await factory.deploy(name, sym, url, metadataHash, supply, decimals);
   debug(`${sym}: wait for deploy: ${contract.deployTransaction.hash}`);
   const deploy_r = await contract.deployTransaction.wait();
   debug(`${sym}: saw deploy: ${deploy_r.blockNumber}`);

--- a/js/stdlib/ts/interfaces.ts
+++ b/js/stdlib/ts/interfaces.ts
@@ -158,7 +158,7 @@ export interface Stdlib_User<Provider, ProviderEnv, ProviderName, Token, Contrac
   formatAddress: (acc: Account|string) => string
   formatWithDecimals: (amt: unknown, decimals: number) => string
   unsafeGetMnemonic: (acc: Account) => string
-  launchToken: (acc: Account, name: string, sym: string, opts?:LaunchTokenOpts) => any
+  launchToken: (acc: Account, name: string, sym: string, opts?: LaunchTokenOpts) => any
   reachStdlib: Stdlib_Backend<Ty>
   setMinMillisBetweenRequests: (n: number) => void
   setCustomHttpEventHandler: (h: (e: any) => Promise<void>) => void

--- a/js/stdlib/ts/shared_impl.ts
+++ b/js/stdlib/ts/shared_impl.ts
@@ -459,7 +459,7 @@ export type TokenMetadata = {
 export type LaunchTokenOpts = {
   'decimals'?: number,
   'supply'?: unknown,
-  'clawback'?: any
+  'clawback'?: any,
   'url'?: string,
   'metadataHash'?: string,
 };

--- a/js/stdlib/ts/shared_impl.ts
+++ b/js/stdlib/ts/shared_impl.ts
@@ -455,10 +455,13 @@ export type TokenMetadata = {
   supply: BigNumber,
   decimals: BigNumber,
 };
+
 export type LaunchTokenOpts = {
   'decimals'?: number,
   'supply'?: unknown,
   'clawback'?: any
+  'url'?: string,
+  'metadataHash'?: string,
 };
 
 export type IAccount<NetworkAccount, Backend, Contract, ContractInfo, Token> = {

--- a/test.sh
+++ b/test.sh
@@ -136,6 +136,13 @@ export REACH_BUILD_NO_CACHE=Y
 ci ALGO algo-time
 exit 0
 
+jb
+ci ALGO donation-balancesOf
+ci ALGO formatWithDecimals-demo
+ci ALGO nft-auction-api
+ci ALGO minBalance
+exit
+
 cdot users/algo-govt/index.rsh
 exit 0
 (cd users/algo-govt && ./test.sh)


### PR DESCRIPTION
More linear implementation of launchToken with more options on ALGO. Added launchToken to docs. Currently it's just at the end of the docs, lmk if it should go into a specific category of the docs.