### PR TITLE
CORE-1183: fix `sed` portability issue for older Macs

### DIFF
--- a/hs/app/reach/Main.hs
+++ b/hs/app/reach/Main.hs
@@ -1971,7 +1971,8 @@ versionCompare' i' j' u' = scriptWithConnectorModeOptional $ do
 
     mkdir -p "$$(dirname $confH)"
     echo '['  > $confH
-    f | paste -s -d ' ' - | sed 's/} {/},\n{/g' >> $confH
+    f | paste -s -d ' ' - | sed 's/} {/},\
+    {/g' >> $confH
     echo ']' >> $confH
 
     $reachEx version-compare2$i$j$u --rm-ils --ils="$confC"


### PR DESCRIPTION
`sed` on macOS Catalina doesn't react to `\n` like newer versions do. The Jira ticket + its linked Discord discussion go into more detail.