### PR TITLE
Fix Opt for `.map/.reduce` Blocks

### DIFF
--- a/hs/src/Reach/Optimize.hs
+++ b/hs/src/Reach/Optimize.hs
@@ -600,13 +600,13 @@ instance Optimize DLStmt where
     DL_LocalSwitch at ov csm ->
       optSwitch (DL_LocalDo at) DT_Com DL_LocalSwitch at ov csm
     DL_ArrayMap at ans x a i f -> do
-      s' <- DL_ArrayMap at ans <$> opt x <*> pure a <*> pure i <*> opt f
+      s' <- DL_ArrayMap at ans <$> opt x <*> pure a <*> pure i <*> newScope (opt f)
       maybeUnroll s' x $ return s'
     DL_ArrayReduce at ans x z b a i f -> do
-      s' <- DL_ArrayReduce at ans <$> opt x <*> opt z <*> (opt b) <*> (pure a) <*> pure i <*> opt f
+      s' <- DL_ArrayReduce at ans <$> opt x <*> opt z <*> (opt b) <*> (pure a) <*> pure i <*> newScope (opt f)
       maybeUnroll s' x $ return s'
     DL_MapReduce at mri ans x z b a f -> do
-      DL_MapReduce at mri ans x <$> opt z <*> (pure b) <*> (pure a) <*> opt f
+      DL_MapReduce at mri ans x <$> opt z <*> (pure b) <*> (pure a) <*> newScope (opt f)
     DL_Only at ep l -> do
       let w = case ep of
             Left p -> focus_one p

--- a/hs/t/y/map_block_opt.rsh
+++ b/hs/t/y/map_block_opt.rsh
@@ -1,0 +1,21 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const A = Participant('A', {
+    mx: Maybe(UInt),
+    ma: Array(Digest, 10),
+  });
+  init();
+
+  A.only(() => {
+    const mx = declassify(interact.mx);
+    const ma = declassify(interact.ma);
+  });
+  A.publish(mx, ma);
+
+  const any = ma.any(m => m == digest(mx));
+  const all = ma.all(m => m == digest(mx));
+
+  commit();
+
+});

--- a/hs/t/y/map_block_opt.txt
+++ b/hs/t/y/map_block_opt.txt
@@ -1,0 +1,5 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 4 theorems; No failures!


### PR DESCRIPTION
Variable assignments inside of `.map/.reduce` blocks should only be remembered within the blocks scope