### PR TITLE
CORE-1145 | fetch balances with BigInt precision

### DIFF
--- a/examples/algo-try-csp/index.mjs
+++ b/examples/algo-try-csp/index.mjs
@@ -17,7 +17,7 @@ try {
         case 2:
           if ( stdlib.connector === 'ALGO' ) {
             console.log(`Trying to clear state...`);
-            const ctcInfo = await ctcA.getInfo();
+            const ctcInfo = stdlib.bigNumberToNumber(await ctcA.getInfo());
             const ALGO = stdlib;
             const { algosdk } = ALGO;
             const thisAcc = accA.networkAccount;

--- a/examples/api-raw/index.mjs
+++ b/examples/api-raw/index.mjs
@@ -53,7 +53,7 @@ const run = async ({fn, isRaw}) => {
       exp = [ x, ...args ];
       const fnM = `${isView ? 'V' : 'P'}_${fn}`;
 
-      const ctcInfo = await ctcA.getInfo();
+      const ctcInfo = stdlib.bigNumberToNumber(await ctcA.getInfo());
       const ctc = accB.contract(backend, ctcInfo);
       const ABI = ctc.getABI(true);
       console.log(ABI);

--- a/examples/api-raw/index.mjs
+++ b/examples/api-raw/index.mjs
@@ -53,7 +53,7 @@ const run = async ({fn, isRaw}) => {
       exp = [ x, ...args ];
       const fnM = `${isView ? 'V' : 'P'}_${fn}`;
 
-      const ctcInfo = stdlib.bigNumberToNumber(await ctcA.getInfo());
+      const ctcInfo = await ctcA.getInfo();
       const ctc = accB.contract(backend, ctcInfo);
       const ABI = ctc.getABI(true);
       console.log(ABI);
@@ -80,7 +80,8 @@ const run = async ({fn, isRaw}) => {
       } else if ( conn === 'ALGO' ) {
         const ALGO = stdlib;
         const { algosdk } = ALGO;
-        const ctcAddr = algosdk.getApplicationAddress(ctcInfo);
+        const ci = stdlib.bigNumberToNumber(ctcInfo)
+        const ctcAddr = algosdk.getApplicationAddress(ci);
         const thisAcc = accB.networkAccount;
         const from = thisAcc.addr;
         const params = await ALGO.getTxnParams('raw');
@@ -108,7 +109,7 @@ const run = async ({fn, isRaw}) => {
         const sel = meth.getSelector();
         const aargs = [ sel, ...eargs ];
         stuff = { ...stuff, eargs, sel, aargs };
-        const txnApp = algosdk.makeApplicationNoOpTxn(from, params, ctcInfo, aargs);
+        const txnApp = algosdk.makeApplicationNoOpTxn(from, params, ci, aargs);
         txnApp.fee = ALGO.MinTxnFee * 2;
         const txnPays = isView ? [] : [txnPay];
         const rtxns = [ ...txnPays, txnApp ];

--- a/examples/ctc-address/index.mjs
+++ b/examples/ctc-address/index.mjs
@@ -14,10 +14,10 @@ const stdlib = loadStdlib(process.env);
 
   const common = (ctcMe) => ({
     showCtcInfo: async (ctc) => {
-      const info = stdlib.bigNumberToNumber(await ctcMe.getInfo());
+      const info = await ctcMe.getInfo();
       console.log(`Contract Info From Reach      : ${ctc}`);
       console.log(`Contract Info From ctc.getInfo: ${info}`);
-      stdlib.assert(ctc == info);
+      stdlib.assert(JSON.stringify(ctc) === JSON.stringify(info));
     },
     showAddress: async (addr) => {
       const ctcAddress = await ctcMe.getContractAddress();

--- a/examples/ctc-address/index.mjs
+++ b/examples/ctc-address/index.mjs
@@ -14,7 +14,7 @@ const stdlib = loadStdlib(process.env);
 
   const common = (ctcMe) => ({
     showCtcInfo: async (ctc) => {
-      const info = await ctcMe.getInfo();
+      const info = stdlib.bigNumberToNumber(await ctcMe.getInfo());
       console.log(`Contract Info From Reach      : ${ctc}`);
       console.log(`Contract Info From ctc.getInfo: ${info}`);
       stdlib.assert(ctc == info);

--- a/examples/max-supply-precision/index.mjs
+++ b/examples/max-supply-precision/index.mjs
@@ -1,0 +1,21 @@
+import { loadStdlib } from "@reach-sh/stdlib";
+const stdlib = loadStdlib();
+
+const sbal = stdlib.parseCurrency(100);
+const acc = await stdlib.newTestAccount(sbal);
+
+const supply = '18446744073709551615';
+
+const tokA = await stdlib.launchToken(acc, "zorkmid", "ZMD", { supply });
+
+const assertEq = (a, e) => {
+  if (!a.eq(e)) {
+    throw Error(`Expected ${e}, got ${a}`);
+  }
+};
+
+const mdA = await acc.tokenMetadata(tokA.id);
+
+assertEq( mdA.supply, supply );
+
+assertEq( await stdlib.balanceOf(acc, tokA.id), supply );

--- a/examples/max-supply-precision/index.rsh
+++ b/examples/max-supply-precision/index.rsh
@@ -1,0 +1,3 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {});

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -6,7 +6,11 @@ import { ethers } from 'ethers';
 import Timeout from 'await-timeout';
 import buffer from 'buffer';
 import type MyAlgoConnect from '@randlabs/myalgo-connect';
-import type { Transaction, EncodedTransaction } from 'algosdk'; // =>
+import type {
+  Transaction,
+  EncodedTransaction,
+  SuggestedParams,
+} from 'algosdk'; // =>
 import type {
   ARC11_Wallet,
   WalletTransaction,
@@ -107,19 +111,21 @@ export type Address = string
 // type RawAddress = Uint8Array;
 type SecretKey = Uint8Array; // length 64
 
-type TxnParams = {
+type TxnParamsRaw = {
   flatFee?: boolean,
-  fee: number,
-  firstRound: number,
-  lastRound: number,
+  fee: bigint,
+  firstRound: bigint,
+  lastRound: bigint,
   genesisID: string,
   genesisHash: string,
 }
+// XXX Remove once algosdk support bigints
+type TxnParams = SuggestedParams;
 type RecvTxn = {
-  'confirmed-round': number,
-  'created-asset-index'?: number,
-  'created-application-index'?: number,
-  'application-index'?: number,
+  'confirmed-round': bigint,
+  'created-asset-index'?: bigint,
+  'created-application-index'?: bigint,
+  'application-index'?: bigint,
   'application-args': Array<string>,
   'sender': Address,
   'logs': Array<string>,
@@ -155,7 +161,7 @@ export type Backend = IBackend<AnyALGO_Ty> & {_Connectors: {ALGO: {
 type BackendViewsInfo = IBackendViewsInfo<AnyALGO_Ty>;
 type BackendViewInfo = IBackendViewInfo<AnyALGO_Ty>;
 
-export type ContractInfo = number;
+export type ContractInfo = BigNumber;
 type SendRecvArgs = ISendRecvArgs<Address, Token, AnyALGO_Ty>;
 type RecvArgs = IRecvArgs<AnyALGO_Ty>;
 type Recv = IRecv<Address>
@@ -168,8 +174,8 @@ type SetupEventArgs = ISetupEventArgs<ContractInfo, VerifyResult>;
 type SetupRes = ISetupRes<ContractInfo, Address, Token, AnyALGO_Ty>;
 
 type AccountAssetInfo = {
-  'asset-id': number,
-  'amount': number,
+  'asset-id': bigint,
+  'amount': bigint,
 };
 type AppStateVal = {
   'bytes'?: string,
@@ -180,54 +186,54 @@ type AppStateKV = {
 };
 type AppStateKVs = Array<AppStateKV>;
 type AppState = {
-  'id': number,
+  'id': bigint,
   'key-value': AppStateKVs,
 };
 type AppSchema = {
-  "num-byte-slice": number,
-  "num-uint": number
+  "num-byte-slice": bigint,
+  "num-uint": bigint
 }
 type AccountInfo = {
-  'amount': number,
+  'amount': bigint,
   'assets'?: Array<AccountAssetInfo>,
-  'apps-local-state'?: Array<AppState>
+  'apps-local-state'?: Array<AppState>,
   'apps-total-schema'?: AppSchema,
   'created-apps'?: Array<AppInfo>
 };
 type IndexerAccountInfoRes = {
-  'current-round': number,
+  'current-round': bigint,
   'account': AccountInfo,
 };
 
 type AppStateSchema = {
-  'num-uint': number,
-  'num-byte-slice': number,
+  'num-uint': bigint,
+  'num-byte-slice': bigint,
 };
 type AppInfo = {
-  'id': number,
-  'created-at-round': number,
+  'id': bigint,
+  'created-at-round': bigint,
   'deleted': boolean,
   'params': {
     'creator': string,
     'approval-program': string,
     'clear-state-program': string,
     'global-state': AppStateKVs,
-    'extra-program-pages': number,
+    'extra-program-pages': bigint,
     'local-state-schema': AppStateSchema,
     'global-state-schema': AppStateSchema,
   },
 };
 type IndexerAppInfoRes = {
-  'current-round': number,
+  'current-round': bigint,
   'application': AppInfo,
 };
 
 type AssetInfo = {
-  'index': number,
+  'index': bigint,
   'params': {
     'clawback': string,
     'creator': string,
-    'decimals': number,
+    'decimals': bigint,
     'default-frozen': boolean,
     'freeze': string,
     'manager': string,
@@ -235,7 +241,7 @@ type AssetInfo = {
     'name': string,
     'name-b64': string,
     'reserve': string,
-    'total': number,
+    'total': bigint,
     'unit-name': string,
     'unit-name-b64': string,
     'url': string,
@@ -243,7 +249,7 @@ type AssetInfo = {
   },
 };
 type IndexerAssetInfoRes = {
-  'current-round': number,
+  'current-round': bigint,
   'asset': AssetInfo,
 };
 
@@ -251,31 +257,31 @@ type OrExn<X> = { val: X } | {exn:any};
 type IndexerAppTxn = {
   'approval-program'?: string,
   'clear-state-program'?: string,
-  'application-id'?: number,
+  'application-id'?: bigint,
   'application-args'?: Array<string>,
   'on-completion'?: string,
 };
 type IndexerTxn = {
-  'confirmed-round': number,
+  'confirmed-round': bigint,
   'sender': Address,
-  'created-asset-index'?: number,
-  'created-application-index'?: number,
+  'created-asset-index'?: bigint,
+  'created-application-index'?: bigint,
   'application-transaction'?: IndexerAppTxn,
   'logs'?: Array<string>,
   'tx-type': string,
 };
 type IndexerQuery1Res = {
-  'current-round': number,
+  'current-round': bigint,
   'transaction': IndexerTxn,
 };
 type IndexerQueryMRes = {
-  'current-round': number,
+  'current-round': bigint,
   'transactions': Array<IndexerTxn>,
 };
 type AlgodTxn = {
-  'asset-index'?: number,
-  'application-index'?: number,
-  'confirmed-round'?: number,
+  'asset-index'?: bigint,
+  'application-index'?: bigint,
+  'confirmed-round'?: bigint,
   'logs'?: Array<string>,
   'txn': {
     'sig': Uint8Array,
@@ -351,11 +357,10 @@ function uint8ArrayToStr(a: Uint8Array, enc: 'utf8' | 'base64' = 'utf8') {
 const rawDefaultToken = 'c87f5580d7a866317b4bfe9e8b8d1dda955636ccebfa88c12b414db208dd9705';
 const rawDefaultItoken = 'reach-devnet';
 
-
 const indexerTxn2RecvTxn = (txn:IndexerTxn): RecvTxn => {
   const ait: IndexerAppTxn = txn['application-transaction'] || {};
   const aargs = ait['application-args'] || [];
-  const aidx = ait['application-id'] || 0;
+  const aidx = ait['application-id'];
   return {
     'confirmed-round': txn['confirmed-round'],
     'sender': txn['sender'],
@@ -503,7 +508,15 @@ export const getTxnParams = async (label: string): Promise<TxnParams> => {
   debug(dhead, `getting params`);
   const client = await getAlgodClient();
   while (true) {
-    const params = await client.getTransactionParams().do();
+    const params_r = (await client.getTransactionParams().do()) as unknown as TxnParamsRaw;
+    debug(dhead ,'got params:', params_r);
+    const bi2n = (x:bigint): number => bigNumberToNumber(bigNumberify(x));
+    const params: TxnParams = {
+      ...params_r,
+      fee: bi2n(params_r.fee),
+      firstRound: bi2n(params_r.firstRound),
+      lastRound: bi2n(params_r.lastRound),
+    };
     debug(dhead ,'got params:', params);
     if (params.firstRound !== 0) {
       return params;
@@ -617,7 +630,7 @@ export function setValidQueryWindow(n: number|true): void {
 
 const isCreateTxn = (txn:IndexerTxn): boolean => {
   const at = txn['application-transaction'];
-  return at ? at['application-id'] === 0 : false;
+  return at ? bigNumberify(at['application-id']).eq(0) : false;
 };
 const emptyOptIn = (txn:IndexerTxn) => {
   const at = txn['application-transaction'];
@@ -627,18 +640,18 @@ const emptyOptIn = (txn:IndexerTxn) => {
     : false;
 };
 type EQInitArgs = {
-  ApplicationID: number,
+  ApplicationID: BigNumber,
 };
 type EventQueue = IEventQueue<EQInitArgs, IndexerTxn, RecvTxn>;
 const newEventQueue = (): EventQueue => {
   const getTxns = async (dhead:string, initArgs:EQInitArgs, ctime: BigNumber, howMany: number): Promise<EQGetTxnsR<IndexerTxn>> => {
     const { ApplicationID } = initArgs;
     const indexer = await getIndexer();
-    const mtime = bigNumberToNumber(ctime) + 1;
+    const mtime = bigNumberToNumber(ctime.add(1));
     debug(dhead, { ctime, mtime });
     const query =
       indexer.searchForTransactions()
-        .applicationID(ApplicationID)
+        .applicationID(bigNumberToNumber(ApplicationID))
         //.txType('appl')
         .minRound(mtime);
     const q = query as unknown as ApiCall<IndexerQueryMRes>
@@ -865,8 +878,16 @@ export const [getProvider, setProvider] = replaceableThunk(async () => {
     return await makeProviderByEnv(process.env);
   }
 });
-const getAlgodClient = async () => (await getProvider()).algodClient;
-const getIndexer = async () => (await getProvider()).indexer;
+const getAlgodClient = async () => {
+  const c = (await getProvider()).algodClient;
+  c.setIntEncoding(algosdk.IntDecoding.BIGINT);
+  return c;
+};
+const getIndexer = async () => {
+  const p = (await getProvider()).indexer;
+  p.setIntEncoding(algosdk.IntDecoding.BIGINT);
+  return p;
+};
 const nodeCanRead = async () => ((await getProvider()).nodeWriteOnly === false);
 const ensureNodeCanRead = async () =>
   assert(await nodeCanRead(), "node can read" );
@@ -1070,7 +1091,9 @@ const getAccountInfo = async (a:Address): Promise<AccountInfo> => {
   try {
     await ensureNodeCanRead();
     const client = await getAlgodClient();
-    const res = (await client.accountInformation(a).do()) as AccountInfo;
+    const req = client.accountInformation(a);
+    debug(dhead, req);
+    const res = (await req.do()) as AccountInfo;
     debug(dhead, 'node', res);
     return res;
   } catch (e:any) {
@@ -1092,7 +1115,8 @@ const getAssetInfo = async (a:number): Promise<AssetInfo> => {
   return res.asset;
 };
 
-const getApplicationInfoM = async (id:number): Promise<OrExn<AppInfo>> => {
+const getApplicationInfoM = async (idn:BigNumber): Promise<OrExn<AppInfo>> => {
+  const id = bigNumberToNumber(idn);
   const dhead = 'getApplicationInfo';
   try {
     await ensureNodeCanRead();
@@ -1150,7 +1174,7 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
 
     type GlobalState = [BigNumber, BigNumber, Address];
     type ContractHandler = {
-      ApplicationID: number,
+      ApplicationID: BigNumber,
       Deployer: Address,
       viewMapRef: (mapi:number, a:Address) => Promise<any>,
       ensureOptIn: (() => Promise<void>),
@@ -1183,7 +1207,7 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
         }
         debug(label, 'getC', {ApplicationID} );
 
-        const ctcAddr = algosdk.getApplicationAddress(ApplicationID);
+        const ctcAddr = algosdk.getApplicationAddress(bigNumberToBigInt(ApplicationID));
         debug(label, 'getC', { ctcAddr });
 
         // Read map data
@@ -1191,7 +1215,8 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
           const ai = await getAccountInfo(a);
           debug(`getLocalState`, ai);
           const alss = ai['apps-local-state'] || [];
-          const als = alss.find((x) => (x.id === ApplicationID));
+          const fmtApplicationID = bigNumberToBigInt(ApplicationID);
+          const als = alss.find((x) => (x.id === fmtApplicationID));
           debug(`getLocalState`, als);
           return als ? als['key-value'] : undefined;
         };
@@ -1207,7 +1232,7 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
             thisAcc,
             toWTxn(algosdk.makeApplicationOptInTxn(
               thisAcc.addr, await getTxnParams(dhead),
-              ApplicationID,
+              bigNumberToNumber(ApplicationID),
               undefined, undefined, undefined, undefined,
               NOTE_Reach)));
           // We are commenting this out because the above ^ might not be
@@ -1366,10 +1391,11 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
                 undefined, undefined, undefined, undefined,
                 NOTE_Reach, undefined, undefined, extraPages)));
 
-          const ApplicationID = createRes['created-application-index'];
-          if ( ! ApplicationID ) {
+          const ai = createRes['created-application-index'];
+          if ( ! ai ) {
             throw Error(`No created-application-index in ${j2s(createRes)}`);
           }
+          const ApplicationID = bigNumberify(ai);
           debug(label, `created`, {ApplicationID});
           const ctcInfo = ApplicationID;
           setTrustedVerifyResult({ ApplicationID, Deployer });
@@ -1421,7 +1447,7 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
           // round, which we couldn't possibly be in, because it already
           // happened.
           debug(dhead, '--- TIMECHECK', { params, timeoutAt });
-          if ( await checkTimeout( isIsolatedNetwork, getTimeSecs, timeoutAt, params.firstRound + 1) ) {
+          if ( await checkTimeout( isIsolatedNetwork, getTimeSecs, timeoutAt, bigNumberify(params.firstRound).add(1) ) ) {
             return await doRecv(false, false, `timeout`);
           }
           if ( ! soloSend && ! await canIWin(lct) ) {
@@ -1557,7 +1583,7 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
             algosdk.makeApplicationNoOpTxn;
           const txnAppl =
             whichAppl(
-              thisAcc.addr, params, ApplicationID, safe_args,
+              thisAcc.addr, params, bigNumberToNumber(ApplicationID), safe_args,
               mapAcctsVal, undefined, assetsVal, NOTE_Reach);
           txnAppl.fee += extraFees;
           const rtxns = [ ...txnExtraTxns, txnAppl ];
@@ -1610,7 +1636,7 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
         // ^ The contract actually uses `global LatestTimestamp` which is the
         // time of the PREVIOUS round.
         // ^ Also, this field is only available from the indexer
-        const theSecs = await retryLoop([dhead, 'getTimeSecs'], () => getTimeSecs(bigNumberify(theRound - 0)));
+        const theSecs = await retryLoop([dhead, 'getTimeSecs'], () => getTimeSecs(bigNumberify(theRound)));
         // ^ XXX it would be nice if Reach could support variables bound to
         // promises and then we wouldn't need to wait here.
 
@@ -1660,13 +1686,12 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
         debug(dhead, 'start');
         const { isIsolatedNetwork } = await getC();
         const didTimeout = async (cr_bn: BigNumber): Promise<boolean> => {
-          const cr = bigNumberToNumber(cr_bn);
-          debug(dhead, 'TIMECHECK', {timeoutAt, cr_bn, cr});
-          const crp = cr + 1;
+          const crp = cr_bn.add(1);
+          debug(dhead, 'TIMECHECK', {timeoutAt, cr_bn, crp});
           const r = await checkTimeout( isIsolatedNetwork, getTimeSecs, timeoutAt, crp);
           debug(dhead, 'TIMECHECK', {r, waitIfNotPresent});
           if ( !r && waitIfNotPresent ) {
-            await waitUntilTime(bigNumberify(crp));
+            await waitUntilTime(crp);
           }
           return r;
         };
@@ -1849,7 +1874,7 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
 export const minimumBalanceOf = async (acc: Account): Promise<BigNumber> => {
   const addr = extractAddr(acc);
   const ai = await getAccountInfo(addr);
-  if ( ai.amount === 0 ) { return bigNumberify(0); }
+  if ( ai.amount === BigInt(0) ) { return bigNumberify(0); }
   const createdAppCount = bigNumberify((ai['created-apps']??[]).length);
   const optinAppCount = bigNumberify((ai['apps-local-state']??[]).length);
   const numByteSlice = bigNumberify((ai['apps-total-schema']??{})['num-byte-slice']??0);
@@ -2059,7 +2084,7 @@ const appGlobalStateNumUInt = 0;
 const appGlobalStateNumBytes = 1;
 
 type VerifyResult = {
-  ApplicationID: number,
+  ApplicationID: BigNumber,
   Deployer: Address,
 };
 
@@ -2070,8 +2095,7 @@ export const verifyContract = async (info: ContractInfo, bin: Backend): Promise<
 const verifyContract_ = async (label:string, info: ContractInfo, bin: Backend, eq: EventQueue): Promise<VerifyResult> => {
   must_be_supported(bin);
   // @ts-ignore
-  const ai_bn: BigNumber = protect(T_Contract, info);
-  const ApplicationID: number = bigNumberToNumber(ai_bn);
+  const ApplicationID: BigNumber = protect(T_Contract, info);
   const { appApproval, appClear, mapDataKeys, stateKeys } =
     bin._Connectors.ALGO;
 
@@ -2082,11 +2106,16 @@ const verifyContract_ = async (label:string, info: ContractInfo, bin: Backend, e
       throw Error(`${dhead} failed: ${msg}`);
     }
   };
-  const chkeq = (a: unknown, e:unknown, msg:string) => {
+  const chkeq_x = <X>(cmp:((a:X, b:X) => boolean)) => (a: X, e:X, msg:string) => {
     const as = j2sf(a);
     const es = j2sf(e);
-    chk(as === es, `${msg}: expected ${es}, got ${as}`);
+    chk(cmp(a, e), `${msg}: expected ${es}, got ${as}`);
   };
+  const chkeq_b = chkeq_x<boolean>((a:boolean, b:boolean) => a === b);
+  const chkeq_bn_ = chkeq_x<BigNumber>((a:BigNumber, b:BigNumber) => a.eq(b));
+  const chkeq_bn = (a:unknown, b:unknown, msg:string) => chkeq_bn_(bigNumberify(a), bigNumberify(b), msg);
+  type Program = string|undefined;
+  const chkeq_bs = chkeq_x<Program>((a:Program, b:Program) => j2sf(a) === j2sf(b));
 
   const appInfoM = await getApplicationInfoM(ApplicationID);
   if ( 'exn' in appInfoM ) {
@@ -2096,33 +2125,33 @@ const verifyContract_ = async (label:string, info: ContractInfo, bin: Backend, e
   const appInfo_p = appInfo['params'];
   debug(dhead, {appInfo_p});
   chk(appInfo_p !== undefined, `Cannot lookup ApplicationId`);
-  chkeq(appInfo_p['approval-program'], appApproval, `Approval program does not match Reach backend`);
-  chkeq(appInfo_p['clear-state-program'], appClear, `ClearState program does not match Reach backend`);
+  chkeq_bs(appInfo_p['approval-program'], appApproval, `Approval program does not match Reach backend`);
+  chkeq_bs(appInfo_p['clear-state-program'], appClear, `ClearState program does not match Reach backend`);
   const Deployer = appInfo_p['creator'];
 
   const appInfo_LocalState = appInfo_p['local-state-schema'];
-  chkeq(appInfo_LocalState['num-byte-slice'], appLocalStateNumBytes + mapDataKeys, `Num of byte-slices in local state schema does not match Reach backend`);
-  chkeq(appInfo_LocalState['num-uint'], appLocalStateNumUInt, `Num of uints in local state schema does not match Reach backend`);
+  chkeq_bn(appInfo_LocalState['num-byte-slice'], appLocalStateNumBytes + mapDataKeys, `Num of byte-slices in local state schema does not match Reach backend`);
+  chkeq_bn(appInfo_LocalState['num-uint'], appLocalStateNumUInt, `Num of uints in local state schema does not match Reach backend`);
 
   const appInfo_GlobalState = appInfo_p['global-state-schema'];
-  chkeq(appInfo_GlobalState['num-byte-slice'], appGlobalStateNumBytes + stateKeys, `Num of byte-slices in global state schema does not match Reach backend`);
-  chkeq(appInfo_GlobalState['num-uint'], appGlobalStateNumUInt, `Num of uints in global state schema does not match Reach backend`);
+  chkeq_bn(appInfo_GlobalState['num-byte-slice'], appGlobalStateNumBytes + stateKeys, `Num of byte-slices in global state schema does not match Reach backend`);
+  chkeq_bn(appInfo_GlobalState['num-uint'], appGlobalStateNumUInt, `Num of uints in global state schema does not match Reach backend`);
 
-  chkeq(appInfo['deleted'] === true, false, `Application must not be deleted`);
+  chkeq_b(appInfo['deleted'] === true, false, `Application must not be deleted`);
   eq.init({ ApplicationID });
 
   // Next, we check that it was created with this program and wasn't created
   // with a different program first (which could have modified the state)
   const iat = await eq.deq(dhead);
   debug({iat});
-  chkeq(iat['created-application-index'], ApplicationID, 'app created');
-  chkeq(iat['application-index'], 0, 'app created');
+  chkeq_bn(iat['created-application-index'], ApplicationID, 'app created');
+  chkeq_bn(iat['application-index'], 0, 'app created');
   const allocRound = appInfo['created-at-round'];
   if ( allocRound ) {
-    chkeq(iat['confirmed-round'], allocRound, 'created on correct round');
+    chkeq_bn(iat['confirmed-round'], allocRound, 'created on correct round');
   }
-  chkeq(iat['approval-program'], appInfo_p['approval-program'], `ApprovalProgram unchanged since creation`);
-  chkeq(iat['clear-state-program'], appInfo_p['clear-state-program'], `ClearStateProgram unchanged since creation`);
+  chkeq_bs(iat['approval-program'], appInfo_p['approval-program'], `ApprovalProgram unchanged since creation`);
+  chkeq_bs(iat['clear-state-program'], appInfo_p['clear-state-program'], `ClearStateProgram unchanged since creation`);
 
   return { ApplicationID, Deployer };
 };
@@ -2168,40 +2197,50 @@ const makeAssetCreateTxn = (
   });
 }
 
-export const launchToken = async (accCreator: Account, name: string, sym: string, opts: LaunchTokenOpts = {}) => {
-  const addrCreator = accCreator.networkAccount.addr;
+export async function launchToken (accCreator:Account, name:string, sym:string, opts:LaunchTokenOpts = {}) {
+  debug(`Launching token, ${name} (${sym})`);
+  const addr = (acc:Account) => acc.networkAccount.addr;
+  const caddr = addr(accCreator);
+  const zaddr = caddr;
+  // ^ XXX should be nothing; docs say can be "", but doesn't actually work
+  const client = await getAlgodClient();
+  const dotxn = async (mktxn:(params:TxnParams) => Transaction, acc:Account = accCreator) => {
+    const sk = acc.networkAccount.sk;
+    if ( ! sk ) {
+      throw new Error(`can only launchToken with account with secret key`);
+    }
+    const params = await getTxnParams('launchToken');
+    const t = mktxn(params);
+    const s = t.signTxn(sk);
+    const r = (await client.sendRawTransaction(s).do());
+    return await waitForConfirmation(r.txId);
+  };
   const supply = opts.supply ? bigNumberify(opts.supply) : bigNumberify(2).pow(64).sub(1);
-  const decimals = opts.decimals ?? 6;
-  const url = opts.url ?? '';
-  const metadataHash = opts.metadataHash ?? '';
-  const clawback = opts.clawback ? cbr2algo_addr(protect(T_Address, opts.clawback) as string) : undefined;
-  const params = await getTxnParams('launchToken');
-
-  const txnResult = await sign_and_send_sync(
-    `launchToken ${j2s(accCreator)} ${name} ${sym}`,
-    accCreator.networkAccount,
-    toWTxn(makeAssetCreateTxn(addrCreator, supply, decimals, sym,
-                              name, url, metadataHash, clawback, params))
-  );
-
-  const assetIndex = txnResult['created-asset-index'];
-  if (!assetIndex) throw Error(`${sym} no asset-index!`);
-  const id = bigNumberify(assetIndex);
-
-  const mint = (accTo: Account, amt: any) => transfer(accCreator, accTo, amt, id);
-  const optOut = async (accFrom: Account, accTo: Account = accCreator) => {
-    // Opting out = sending all of your current balance to accTo
-    const addrFrom = accFrom.networkAccount.addr;
-    const addrTo = accTo.networkAccount.addr;
-    const params = await getTxnParams('token.optOut');
-    const optOutTxn = makeTransferTxn(addrFrom, addrTo, bigNumberify(0), id, params, addrTo);
-    await sign_and_send_sync(
-      `token.optOut ${j2s(accFrom)} ${name}`,
-      accFrom.networkAccount,
-      toWTxn(optOutTxn),
-    );
-  }
-
+  const decimals = opts.decimals !== undefined ? opts.decimals : 6;
+  const ctxn_p = await dotxn(
+    (params:TxnParams) =>
+    algosdk.makeAssetCreateTxnWithSuggestedParams(
+      caddr, undefined, bigNumberToBigInt(supply), decimals,
+      false, zaddr, zaddr, zaddr, zaddr,
+      sym, name, '', '', params,
+    ));
+  const idn = ctxn_p['created-asset-index'];
+  if ( ! idn ) { throw Error(`${sym} no asset-index!`); }
+  const id = bigNumberify(idn);
+  debug(`${sym}: asset is ${id}`);
+  const mint = async (accTo:Account, amt:unknown) => {
+    debug(`${sym}: transferring ${amt} ${sym} for ${addr(accTo)}`);
+    await transfer(accCreator, accTo, amt, id);
+  };
+  const optOut = async (accFrom:Account, accTo:Account = accCreator) => {
+    await dotxn(
+      (params) =>
+      algosdk.makeAssetTransferTxnWithSuggestedParams(
+        addr(accFrom), addr(accTo), addr(accTo), undefined,
+        // XXX this should be a bigint, but the SDK doesn't allow it
+        0, undefined, bigNumberToNumber(id), params
+      ), accFrom);
+  };
   return { name, sym, id, mint, optOut };
 }
 

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -2197,50 +2197,40 @@ const makeAssetCreateTxn = (
   });
 }
 
-export async function launchToken (accCreator:Account, name:string, sym:string, opts:LaunchTokenOpts = {}) {
-  debug(`Launching token, ${name} (${sym})`);
-  const addr = (acc:Account) => acc.networkAccount.addr;
-  const caddr = addr(accCreator);
-  const zaddr = caddr;
-  // ^ XXX should be nothing; docs say can be "", but doesn't actually work
-  const client = await getAlgodClient();
-  const dotxn = async (mktxn:(params:TxnParams) => Transaction, acc:Account = accCreator) => {
-    const sk = acc.networkAccount.sk;
-    if ( ! sk ) {
-      throw new Error(`can only launchToken with account with secret key`);
-    }
-    const params = await getTxnParams('launchToken');
-    const t = mktxn(params);
-    const s = t.signTxn(sk);
-    const r = (await client.sendRawTransaction(s).do());
-    return await waitForConfirmation(r.txId);
-  };
+export const launchToken = async (accCreator: Account, name: string, sym: string, opts: LaunchTokenOpts = {}) => {
+  const addrCreator = accCreator.networkAccount.addr;
   const supply = opts.supply ? bigNumberify(opts.supply) : bigNumberify(2).pow(64).sub(1);
-  const decimals = opts.decimals !== undefined ? opts.decimals : 6;
-  const ctxn_p = await dotxn(
-    (params:TxnParams) =>
-    algosdk.makeAssetCreateTxnWithSuggestedParams(
-      caddr, undefined, bigNumberToBigInt(supply), decimals,
-      false, zaddr, zaddr, zaddr, zaddr,
-      sym, name, '', '', params,
-    ));
-  const idn = ctxn_p['created-asset-index'];
-  if ( ! idn ) { throw Error(`${sym} no asset-index!`); }
-  const id = bigNumberify(idn);
-  debug(`${sym}: asset is ${id}`);
-  const mint = async (accTo:Account, amt:unknown) => {
-    debug(`${sym}: transferring ${amt} ${sym} for ${addr(accTo)}`);
-    await transfer(accCreator, accTo, amt, id);
-  };
-  const optOut = async (accFrom:Account, accTo:Account = accCreator) => {
-    await dotxn(
-      (params) =>
-      algosdk.makeAssetTransferTxnWithSuggestedParams(
-        addr(accFrom), addr(accTo), addr(accTo), undefined,
-        // XXX this should be a bigint, but the SDK doesn't allow it
-        0, undefined, bigNumberToNumber(id), params
-      ), accFrom);
-  };
+  const decimals = opts.decimals ?? 6;
+  const url = opts.url ?? '';
+  const metadataHash = opts.metadataHash ?? '';
+  const clawback = opts.clawback ? cbr2algo_addr(protect(T_Address, opts.clawback) as string) : undefined;
+  const params = await getTxnParams('launchToken');
+
+  const txnResult = await sign_and_send_sync(
+    `launchToken ${j2s(accCreator)} ${name} ${sym}`,
+    accCreator.networkAccount,
+    toWTxn(makeAssetCreateTxn(addrCreator, supply, decimals, sym,
+                              name, url, metadataHash, clawback, params))
+  );
+
+  const assetIndex = txnResult['created-asset-index'];
+  if (!assetIndex) throw Error(`${sym} no asset-index!`);
+  const id = bigNumberify(assetIndex);
+
+  const mint = (accTo: Account, amt: any) => transfer(accCreator, accTo, amt, id);
+  const optOut = async (accFrom: Account, accTo: Account = accCreator) => {
+    // Opting out = sending all of your current balance to accTo
+    const addrFrom = accFrom.networkAccount.addr;
+    const addrTo = accTo.networkAccount.addr;
+    const params = await getTxnParams('token.optOut');
+    const optOutTxn = makeTransferTxn(addrFrom, addrTo, bigNumberify(0), id, params, addrTo);
+    await sign_and_send_sync(
+      `token.optOut ${j2s(accFrom)} ${name}`,
+      accFrom.networkAccount,
+      toWTxn(optOutTxn),
+    );
+  }
+
   return { name, sym, id, mint, optOut };
 }
 

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -648,7 +648,7 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
 
         while ( true ) {
           debug(dhead, 'TIMECHECK', { timeoutAt });
-          if ( await checkTimeout( isIsolatedNetwork, getTimeSecs, timeoutAt, await getNetworkTimeNumber() + 1) ) {
+          if ( await checkTimeout( isIsolatedNetwork, getTimeSecs, timeoutAt, (bigNumberify(await getNetworkTimeNumber())).add(1) ) ) {
             debug(dhead, 'FAIL/TIMEOUT');
             return await doRecv(false, false, `timeout`);
           }
@@ -733,13 +733,12 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
         debug(dhead, 'start');
         const ethersC = await getC();
         const didTimeout = async (cr_bn: BigNumber): Promise<boolean> => {
-          const cr = bigNumberToNumber(cr_bn);
-          debug(dhead, 'TIMECHECK', {timeoutAt, cr_bn, cr});
-          const crp = cr + 1;
+          const crp = cr_bn.add(1);
+          debug(dhead, 'TIMECHECK', {timeoutAt, cr_bn, crp});
           const r = await checkTimeout( isIsolatedNetwork, getTimeSecs, timeoutAt, crp);
           debug(dhead, 'TIMECHECK', {r, waitIfNotPresent});
           if ( !r && waitIfNotPresent ) {
-            await waitUntilTime(bigNumberify(crp));
+            await waitUntilTime(crp);
           }
           return r;
         };

--- a/js/stdlib/ts/shared_impl.ts
+++ b/js/stdlib/ts/shared_impl.ts
@@ -742,11 +742,10 @@ export const make_waitUntilX = (label: string, getCurrent: () => Promise<BigNumb
   return current;
 };
 
-export const checkTimeout = async (runningIsolated:(() => boolean), getTimeSecs: ((now:BigNumber) => Promise<BigNumber>), timeoutAt: TimeArg | undefined, nowTimeN: number): Promise<boolean> => {
-  debug('checkTimeout', { timeoutAt, nowTimeN });
+export const checkTimeout = async (runningIsolated:(() => boolean), getTimeSecs: ((now:BigNumber) => Promise<BigNumber>), timeoutAt: TimeArg | undefined, nowTime: BigNumber): Promise<boolean> => {
+  debug('checkTimeout', { timeoutAt, nowTime });
   if ( ! timeoutAt ) { return false; }
   const [ mode, val ] = timeoutAt;
-  const nowTime = bigNumberify(nowTimeN);
   if ( mode === 'time' ) {
     return val.lte(nowTime);
   } else if ( mode === 'secs' ) {


### PR DESCRIPTION
This is primarily composed of adjustment Jay has made to ALGO.ts to allow for BigInt precision on the results of balanceOf and other functions using setIntEncoding. 

Whereas before a token with the maximum supply would return 18446744073709552000 (since it could only get up to number precision) it will now return 18446744073709551615 (since it now has bigint precision). 

Jay also created an example to test and prove this functionality of the balanceOf function.