### PR TITLE
adhere more closely to arc-6 updates

### DIFF
--- a/docs/src/frontend/index.md
+++ b/docs/src/frontend/index.md
@@ -128,7 +128,13 @@ const reach = await loadStdlib(process.env);
 
 Or construct a custom object that has all of the environment keys and fields you need.
 
-As a special case, you may instead pass in the string `'ETH'` or the string `'ALGO'`
+On Algorand, this object may include the keys `ALGO_GENESIS_ID` or `ALGO_GENESIS_HASH` (or both),
+which allows you to request that the user's [arc-6 compliant wallet](https://github.com/algorandfoundation/ARCs/blob/main/ARCs/arc-0006.md) connect to a specific network.
+When left unspecified, it allows the user to select one of their wallet's supported networks.
+This object may also include the key `ALGO_ACCOUNT`,
+which allows you to request the use of a specific account from the user's arc-6 compliant wallet by address. This should usually be left unspecified, which allows the user to instead select their preferred account.
+
+As a special case, you may instead pass in the string `'ETH'`, `'ALGO'`, or `'CFX'`,
 to select the desired connector directly.
 
 ---

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -12,6 +12,9 @@ import type {
   WalletTransaction,
   EnableNetworkResult,
   EnableAccountsResult,
+  EnableOpts,
+  EnableResult,
+  EnableAccountsOpts,
 } from './ALGO_ARC11'; // =>
 import type { BaseHTTPClient } from 'algosdk';
 import * as RHC from './ALGO_ReachHTTPClient';
@@ -692,7 +695,14 @@ export interface Provider {
 
 const makeProviderByWallet = async (wallet:ARC11_Wallet): Promise<Provider> => {
   debug(`making provider with wallet`);
-  const walletOpts = {'network': process.env['ALGO_NETWORK']};
+  const { ALGO_GENESIS_ID, ALGO_GENESIS_HASH, ALGO_ACCOUNT, REACH_ISOLATED_NETWORK, ALGO_NODE_WRITE_ONLY } = process.env;
+  const walletOpts: EnableOpts = {
+    genesisID: ALGO_GENESIS_ID || undefined,
+    genesisHash: ALGO_GENESIS_HASH || undefined,
+    accounts: ALGO_ACCOUNT ? [ ALGO_ACCOUNT ] : undefined,
+  };
+  const isIsolatedNetwork = truthyEnv(REACH_ISOLATED_NETWORK);
+  const nodeWriteOnly = truthyEnv(ALGO_NODE_WRITE_ONLY);
   let enabledNetwork: EnableNetworkResult|undefined;
   let enabledAccounts: EnableAccountsResult|undefined;
   if ( wallet.enableNetwork === undefined && wallet.enableAccounts === undefined ) {
@@ -722,18 +732,38 @@ const makeProviderByWallet = async (wallet:ARC11_Wallet): Promise<Provider> => {
     return enabledAccounts.accounts[0];
   };
   const signAndPostTxns = wallet.signAndPostTxns;
-  const isIsolatedNetwork = truthyEnv(process.env['REACH_ISOLATED_NETWORK']);
-  const nodeWriteOnly = truthyEnv(process.env.ALGO_NODE_WRITE_ONLY);
   return { algod_bc, indexer_bc, indexer, algodClient, nodeWriteOnly, getDefaultAddress, isIsolatedNetwork, signAndPostTxns };
 };
 
 export const setWalletFallback = (wf:() => unknown) => {
   if ( ! window.algorand ) { window.algorand = wf(); }
 };
+
+const checkNetwork = (ret: EnableNetworkResult, eopts?: EnableOpts): void => {
+  const { genesisID:  id, genesisHash:  h } = ret;
+  const { genesisID: eid, genesisHash: eh } = eopts || {};
+  if ( ( eid && eid !== id) || ( eh && eh !== h ) ) {
+    throw Error(
+      `Requested genesis ID or hash not supported by this wallet.\n`
+      + `Expected: '${id}' '${h}'\n`
+      + `Got: '${eid}' '${eh}'`
+    );
+  }
+}
+
+const checkAccounts = (addr: string, got?: string[]): void => {
+  if ( got && ( got[0] !== addr || got.length > 1 ) ) {
+    throw Error(
+      `One or more requested accounts not supported by this wallet.\n`
+      + `Expected: ${JSON.stringify([addr])}\n`
+      + `Got: ${JSON.stringify(got)}`
+    );
+  }
+}
+
 const doWalletFallback_signOnly = (opts:any, getAddr:() => Promise<string>, signTxns:(txns:string[]) => Promise<string[]>): ARC11_Wallet => {
   let p: Provider|undefined = undefined;
-  const enableNetwork = async (eopts?:object) => {
-    void(eopts);
+  const enableNetwork = async (eopts?: EnableOpts): Promise<EnableNetworkResult> => {
     const base = opts['providerEnv'];
     if ( base ) {
       // XXX Is it a bad idea to update the process.env? This is to get
@@ -746,16 +776,20 @@ const doWalletFallback_signOnly = (opts:any, getAddr:() => Promise<string>, sign
       }
     }
     p = await makeProviderByEnv(process.env);
-    return {};
+    const { genesisID, genesisHash } = await p.algodClient.getTransactionParams().do();
+    const ret = { genesisID, genesisHash };
+    checkNetwork(ret, eopts);
+    return ret;
   };
-  const enableAccounts = async (eopts?:object) => {
-    void(eopts);
+  const enableAccounts = async (eopts?: EnableAccountsOpts): Promise<EnableAccountsResult> => {
     const addr = await getAddr();
+    checkAccounts(addr, eopts?.accounts);
     return { accounts: [ addr ] };
   };
-  const enable = async (eopts?:object) => {
-    await enableNetwork(eopts);
-    return await enableAccounts(eopts);
+  const enable = async (eopts?:object): Promise<EnableResult> => {
+    const nres = await enableNetwork(eopts);
+    const ares = await enableAccounts(eopts);
+    return { ...nres, ...ares };
   };
   const getAlgodv2Client = async () => {
     if ( !p ) { throw new Error(`must call enable`) };

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -766,7 +766,7 @@ const checkAccounts = (addr: string, got?: string[]): void => {
 
 const doWalletFallback_signOnly = (opts:any, getAddr:() => Promise<string>, signTxns:(txns:string[]) => Promise<string[]>): ARC11_Wallet => {
   let p: Provider|undefined = undefined;
-  const base = opts['providerEnv'];
+  const base = opts['providerEnv'] || 'LocalHost';
   const _env = typeof base === 'string' ? providerEnvByName(base) : base;
   const enableNetwork = async (eopts?: EnableOpts): Promise<EnableNetworkResult> => {
     p = await makeProviderByEnv(_env);

--- a/js/stdlib/ts/ALGO_ARC11.ts
+++ b/js/stdlib/ts/ALGO_ARC11.ts
@@ -5,11 +5,13 @@ export type EnableNetworkFunction = (
 ) => Promise<EnableNetworkResult>;
 
 export interface EnableNetworkOpts {
-  network?: string,    // NetworkIdentifier
+  genesisID?: string,   // ascii string
+  genesisHash?: string, // base64 string representing a 32-byte genesis hash.
 };
 
 export interface EnableNetworkResult {
-  network?: string,   // NetworkIdentifier
+  genesisID: string,   // ascii string
+  genesisHash: string, // base64 string representing a 32-byte genesis hash.
 };
 
 export type EnableAccountsFunction = (

--- a/js/stdlib/ts/ALGO_ARC11.ts
+++ b/js/stdlib/ts/ALGO_ARC11.ts
@@ -71,4 +71,6 @@ export interface WindowAlgorand {
   getIndexerClient: GetIndexerClientFunction;
 };
 
-export type ARC11_Wallet = WindowAlgorand;
+export type ARC11_Wallet = WindowAlgorand & {
+  _env?: any;
+};


### PR DESCRIPTION
Added the ability to do stuff like this:

```js
loadStdlib({
  REACH_CONNECTOR_MODE: 'ALGO',
  ALGO_GENESIS_ID: 'testnet-v1.0',
  ALGO_GENESIS_HASH: 'asdf',
  ALGO_ACCOUNT: 'deadbeef',
});
```

The spirit of [arc-6](https://github.com/algorandfoundation/ARCs/blob/main/ARCs/arc-0006.md) is for these to guide the wallet in prompting the user to accept a connection to that specific network (if specified) with that specific account (if specified). While our wallet doesn't do that, it at least conforms to the part of the spec that says if the wallet doesn't support that specific thing then it should throw an Error.

The ability to ask for a specific account is usually not what people will want to do, so the docs say it "should usually be left unspecified."

`ALGO_GENESIS_ID` correlates to what the `network` option used to be, but they changed arc-6 to name it genesisID, and they added genesisHash, so I updated our stuff accordingly. Apparently genesisID does not uniquely identify the network but genesisHash does.

I also rearranged `process.env`-related stuff in a way that I think is better. No more `updateProcessEnv` on the fly. `walletFallback` and `setWalletFallback` now rely only on their arguments, but the created wallet exposes `_env` (undocumented) so that `makeProviderByWallet` can extract useful info about it.