### PR TITLE
make goal-devnet script respect environment variable that goal uses

### DIFF
--- a/scripts/goal-devnet
+++ b/scripts/goal-devnet
@@ -1,9 +1,10 @@
 #!/bin/sh
+tmp="${TMPDIR:-/tmp}"
 exec docker run \
   --rm \
   -u "$(id -ru):$(id -rg)" \
-  --volume "$PWD:/app" \
-  --volume "/tmp:/tmp" \
+  --volume "${PWD}:/app" \
+  --volume "${tmp}:${tmp}" \
   --workdir /app \
   --entrypoint /bin/goal \
   reachsh/devnet-algo \


### PR DESCRIPTION
The `goal` program apparently checks the $TMPDIR environment variable,
defaulting to `/tmp` if it's unset.  This change makes our script do
the same instead of always mounting `/tmp` without checking.

This also switches the script to use bash instead of `/bin/sh`,
because I think the `:-` variable default operation is a bashism.
