### PR TITLE
WIP - first draft of array map/reduce with zipping

### DIFF
--- a/docs/src/rsh/compute/index.md
+++ b/docs/src/rsh/compute/index.md
@@ -997,6 +997,7 @@ x.zip(y)
 
  `{!rsh} Array.zip(x, y)` returns a new array the same size as `{!rsh} x` and `{!rsh} y` (which must be the same size) whose elements are tuples of the elements of `{!rsh} x` and `{!rsh} y`.
 This may be abbreviated as `{!rsh} x.zip(y)`.
+This function is generalized to an arbitrary number of arrays of the same size.
 
 #### `Array.map` && `.map`
 
@@ -1025,7 +1026,7 @@ arr.mapWithIndex(f)
 
  `{!rsh} Array.mapWithIndex(arr, f)` is similar to `{!rsh} Array.map`, except it
 provides `{!rsh} f` with an additional argument, which is the index of the current element in `{!rsh} arr`.
-Unlike `{!rsh} Array.map`, this function is not generalized to an arbitrary number of arrays; it only accepts one array.
+The index argument is the last argument of the given function `{!rsh} f`.
 
 #### `Array.forEachWithIndex` && `.forEachWithIndex`
 
@@ -1056,6 +1057,9 @@ This may be abbreviated as `{!rsh} arr.reduce(z, f)`.
 This function is generalized to an arbitrary number of arrays of the same size, which are provided before the `{!rsh} z` argument.
 For example, `{!rsh} Array.iota(4).reduce(Array.iota(4), 0, (x, y, z) => (z + x + y))` returns `{!rsh} ((((0 + 0 + 0) + 1 + 1) + 2 + 2) + 3 + 3)`.
 
+The supplied function `{!rsh} f` is in the form `{!rsh} (ACCUM, A0_i, A1_i, ...) => BODY`.
+In the example `{!rsh} a1.reduce(a2, a3, 0, (accum, v1, v2, v3) => 0)`, the `{!rsh} vN` values are drawn from the corresponding `{!rsh} aN` arrays.
+
 #### `Array.reduceWithIndex` && `.reduceWithIndex`
 
 @{ref("rsh", "Array.reduceWithIndex")}
@@ -1067,7 +1071,7 @@ arr.reduceWithIndex(z, f)
 
  `{!rsh} Array.reduceWithIndex(arr, z, f)` is similar to `{!rsh} Array.reduce`, except it
 provides `{!rsh} f` with an additional argument, which is the index of the current element in `{!rsh} arr`.
-Unlike `{!rsh} Array.reduce`, this function is not generalized to an arbitrary number of arrays; it only accepts one array.
+The index argument is the last argument of the given function `{!rsh} f`.
 
 #### `Array.indexOf` && `.indexOf`
 

--- a/examples/array-map-reduce-zip/.dockerignore
+++ b/examples/array-map-reduce-zip/.dockerignore
@@ -1,0 +1,4 @@
+node_modules/
+
+Dockerfile
+Makefile

--- a/examples/array-map-reduce-zip/.gitignore
+++ b/examples/array-map-reduce-zip/.gitignore
@@ -1,0 +1,3 @@
+build/
+node_modules/
+tls/

--- a/examples/array-map-reduce-zip/index.mjs
+++ b/examples/array-map-reduce-zip/index.mjs
@@ -1,0 +1,39 @@
+import { loadStdlib } from '@reach-sh/stdlib';
+import * as backend from './build/index.main.mjs';
+const stdlib = loadStdlib(process.env);
+
+const startingBalance = stdlib.parseCurrency(100);
+const accA = await stdlib.newTestAccount(startingBalance);
+const accB = await stdlib.newTestAccount(startingBalance);
+const ctcA = accA.contract(backend);
+const ctcB = accB.contract(backend, ctcA.getInfo());
+
+const expect = (expected, actual, m) => {
+  if (JSON.stringify(expected) != JSON.stringify(actual)) {
+    console.log(m + ": expected: " + expected + ", actual: " + actual);
+    throw m;
+  }
+  return;
+}
+
+const num = stdlib.bigNumberToNumber;
+
+const Player = {
+  ...stdlib.hasConsoleLogger,
+  getArray: () => {
+    return [0, 1, 2, 3, 4];
+  },
+  expectMapped: (arr) => expect([0,2,0,6,0], arr.map(num), "local mapped value"),
+  expectReduced: (v) => expect(260, num(v), "local reduced value"),
+  expectConsensusMapped: (arr) => expect([0,3,2,9,4], arr.map(num), "consensus mapped value"),
+  expectConsensusReduced: (v) => expect(28, num(v), "consensus mapped value"),
+  expectConsensusZipped: (arr) => expect([[0,0,1], [2,1,1], [0,2,1], [6,3,1], [0,4,1]],
+                                         arr.map((ia)=>ia.map(num)),
+                                         "consensus zipped value"),
+
+};
+
+await Promise.all([
+  ctcA.p.A({...Player,}),
+  ctcB.p.B({...Player,}),
+]);

--- a/examples/array-map-reduce-zip/index.rsh
+++ b/examples/array-map-reduce-zip/index.rsh
@@ -1,0 +1,46 @@
+'reach 0.1';
+
+const part = {
+  ...hasConsoleLogger,
+  getArray: Fun([], Array(UInt, 5)),
+  expectMapped: Fun([Array(UInt, 5)], Null),
+  expectReduced: Fun([UInt], Null),
+  expectConsensusMapped: Fun([Array(UInt, 5)], Null),
+  expectConsensusReduced: Fun([UInt], Null),
+  expectConsensusZipped: Fun([Array(Tuple(UInt, UInt, UInt), 5)], Null),
+}
+
+export const main = Reach.App(() => {
+  const A = Participant('A', {...part,});
+  const B = Participant('B', {...part,});
+  init();
+
+  A.only(() => {
+    const a1 = array(UInt, [0,1,2,3,4])
+    const a1_m = a1.mapWithIndex((x, i) => x + i)
+    const ia = declassify(interact.getArray())
+    const mapped = a1_m.mapWithIndex(ia, (x, y, i) => y % 2 == 0 ? 0 : x)
+    const reduced = mapped.reduce(ia, 256, (z, v1, v2) => z + (v1 < v2 ? v1 : v2))
+  })
+  A.publish(mapped, reduced);
+  commit();
+
+  B.only(() => {
+    const ba = declassify(interact.getArray())
+  })
+  B.publish(ba);
+
+  const consensusMapped = mapped.map(ba, (v1, v2) => v1 + v2);
+  const consensusReduced = mapped.reduceWithIndex(ba, 0, (acc, v1, v2, i) => acc + v1 + v2 + i);
+  const consensusZipped = mapped.zip(ba, array(UInt, [1,1,1,1,1]));
+  commit();
+
+  A.only(() => {
+    interact.expectMapped(mapped);
+    interact.expectReduced(reduced);
+    interact.expectConsensusMapped(consensusMapped);
+    interact.expectConsensusReduced(consensusReduced);
+    interact.expectConsensusZipped(consensusZipped);
+  })
+
+})

--- a/examples/array-map-reduce-zip/index.txt
+++ b/examples/array-map-reduce-zip/index.txt
@@ -1,0 +1,5 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 7 theorems; No failures!

--- a/hs/src/Reach/AST/DK.hs
+++ b/hs/src/Reach/AST/DK.hs
@@ -12,8 +12,8 @@ import Reach.Texty
 
 data DKCommon
   = DKC_Let SrcLoc DLLetVar DLExpr
-  | DKC_ArrayMap SrcLoc DLVar DLArg DLVar DLVar DKBlock
-  | DKC_ArrayReduce SrcLoc DLVar DLArg DLArg DLVar DLVar DLVar DKBlock
+  | DKC_ArrayMap SrcLoc DLVar [DLArg] [DLVar] DLVar DKBlock
+  | DKC_ArrayReduce SrcLoc DLVar [DLArg] DLArg DLVar [DLVar] DLVar DKBlock
   | DKC_Var SrcLoc DLVar
   | DKC_Set SrcLoc DLVar DLArg
   | DKC_LocalDo SrcLoc DKTail

--- a/hs/src/Reach/AST/DL.hs
+++ b/hs/src/Reach/AST/DL.hs
@@ -85,8 +85,8 @@ mkAnnot a = StmtAnnot {..}
 
 data DLSStmt
   = DLS_Let SrcLoc DLLetVar DLExpr
-  | DLS_ArrayMap SrcLoc DLVar DLArg DLVar DLVar DLSBlock
-  | DLS_ArrayReduce SrcLoc DLVar DLArg DLArg DLVar DLVar DLVar DLSBlock
+  | DLS_ArrayMap SrcLoc DLVar [DLArg] [DLVar] DLVar DLSBlock
+  | DLS_ArrayReduce SrcLoc DLVar [DLArg] DLArg DLVar [DLVar] DLVar DLSBlock
   | DLS_If SrcLoc DLArg StmtAnnot DLStmts DLStmts
   | DLS_Switch SrcLoc DLVar StmtAnnot (SwitchCases DLStmts)
   | DLS_Return SrcLoc Int DLArg

--- a/hs/src/Reach/AddCounts.hs
+++ b/hs/src/Reach/AddCounts.hs
@@ -91,16 +91,20 @@ instance AC DLStmt where
         _ -> do
           ac_visit $ de
           return $ DL_Let at x' de
-    DL_ArrayMap at ans x a i f -> do
-      -- XXX remove if ans not used
-      f' <- ac f
-      ac_visit $ x
-      return $ DL_ArrayMap at ans x a i f'
-    DL_ArrayReduce at ans x z b a i f -> do
-      -- XXX remove if ans not used
-      f' <- ac f
-      ac_visit $ [x, z]
-      return $ DL_ArrayReduce at ans x z b a i f'
+    DL_ArrayMap at ans xs as i f -> do
+      ac_getCount ans >>= \case
+        Nothing -> skip at
+        Just _ -> do
+          f' <- ac f
+          ac_visit $ xs
+          return $ DL_ArrayMap at ans xs as i f'
+    DL_ArrayReduce at ans xs z b as i f -> do
+      ac_getCount ans >>= \case
+        Nothing -> skip at
+        Just _ -> do
+          f' <- ac f
+          ac_visit $ xs <> [z]
+          return $ DL_ArrayReduce at ans xs z b as i f'
     DL_Var at dv ->
       ac_getCount dv >>= \case
         Nothing -> skip at

--- a/hs/src/Reach/AddCounts.hs
+++ b/hs/src/Reach/AddCounts.hs
@@ -92,16 +92,18 @@ instance AC DLStmt where
           ac_visit $ de
           return $ DL_Let at x' de
     DL_ArrayMap at ans xs as i f -> do
-      ac_getCount ans >>= \case
-        Nothing -> skip at
-        Just _ -> do
+      count <- ac_getCount ans
+      case (count, isPure f) of
+        (Nothing, True) -> skip at
+        _ -> do
           f' <- ac f
           ac_visit $ xs
           return $ DL_ArrayMap at ans xs as i f'
     DL_ArrayReduce at ans xs z b as i f -> do
-      ac_getCount ans >>= \case
-        Nothing -> skip at
-        Just _ -> do
+      count <- ac_getCount ans
+      case (count, isPure f) of
+        (Nothing, True) -> skip at
+        _ -> do
           f' <- ac f
           ac_visit $ xs <> [z]
           return $ DL_ArrayReduce at ans xs z b as i f'

--- a/hs/src/Reach/AnalyzeVars.hs
+++ b/hs/src/Reach/AnalyzeVars.hs
@@ -106,7 +106,6 @@ instance FreeVars DLExpr where
     DLE_ArrayRef _ a b -> freeVars [a, b]
     DLE_ArraySet _ a b c -> freeVars [a, b, c]
     DLE_ArrayConcat _ a b -> freeVars [a, b]
-    DLE_ArrayZip _ a b -> freeVars [a, b]
     DLE_TupleRef _ a _ -> freeVars a
     DLE_ObjectRef _ a _ -> freeVars a
     DLE_Interact _ _ _ _ _ a -> freeVars a
@@ -172,8 +171,8 @@ instance FreeVars DLStmt where
   freeVars = readMMap fvMap $ \case
     DL_Nop {} -> mempty
     DL_Let _ _ e -> freeVars e
-    DL_ArrayMap _ _ x a i f -> freeVars [x] <> bindsFor [a, i] f
-    DL_ArrayReduce _ _ x z a b i f -> freeVars [x, z] <> bindsFor [a, b, i] f
+    DL_ArrayMap _ _ xs as i f -> freeVars xs <> bindsFor (as <> [i]) f
+    DL_ArrayReduce _ _ xs z b as i f -> freeVars (xs <> [z]) <> bindsFor (as <> [b, i]) f
     DL_Var {} -> mempty
     DL_Set _ v a -> freeVars v <> freeVars a
     DL_LocalIf _ c t f -> freeVars c <> freeVars [t, f]
@@ -186,8 +185,8 @@ instance BoundVars DLStmt where
   boundVars = readMMap bvMap $ \case
     DL_Nop {} -> mempty
     DL_Let _ lv _ -> boundVars lv
-    DL_ArrayMap _ ans _ a i f -> boundVars [ans, a, i] <> boundVars f
-    DL_ArrayReduce _ ans _ _ a b i f -> boundVars [ans, a, b, i] <> boundVars f
+    DL_ArrayMap _ ans _ as i f -> boundVars (as <> [ans, i]) <> boundVars f
+    DL_ArrayReduce _ ans _ _ b as i f -> boundVars (as <> [ans, b, i]) <> boundVars f
     DL_Var _ v -> boundVars v
     DL_Set {} -> mempty
     DL_LocalIf _ _ t f -> boundVars [t, f]

--- a/hs/src/Reach/CollectCounts.hs
+++ b/hs/src/Reach/CollectCounts.hs
@@ -137,7 +137,6 @@ instance Countable DLExpr where
     DLE_ArrayRef _ aa ea -> counts [aa, ea]
     DLE_ArraySet _ aa ia va -> counts [aa, ia, va]
     DLE_ArrayConcat _ x y -> counts x <> counts y
-    DLE_ArrayZip _ x y -> counts x <> counts y
     DLE_TupleRef _ t _ -> counts t
     DLE_ObjectRef _ aa _ -> counts aa
     DLE_Interact _ _ _ _ _ as -> counts as
@@ -213,10 +212,10 @@ instance CountableK DLStmt where
   countsk kcs = \case
     DL_Nop {} -> kcs
     DL_Let _ lv e -> countsk (counts e <> kcs) lv
-    DL_ArrayMap _ ans x a i f ->
-      count_rms [ans, a, i] (counts f <> kcs) <> counts x
-    DL_ArrayReduce _ ans x z b a i f ->
-      count_rms [ans, b, a, i] (counts f <> kcs) <> counts [x, z]
+    DL_ArrayMap _ ans xs as i f ->
+      count_rms (as <> [ans, i]) (counts f <> kcs) <> counts xs
+    DL_ArrayReduce _ ans xs z b as i f ->
+      count_rms (as <> [ans, b, i]) (counts f <> kcs) <> counts (xs <> [z])
     DL_Var _ v -> count_rms [v] kcs
     DL_Set _ v a -> counts v <> counts a <> kcs
     DL_LocalIf _ c t f -> counts c <> counts [t, f] <> kcs

--- a/hs/src/Reach/CollectTypes.hs
+++ b/hs/src/Reach/CollectTypes.hs
@@ -116,7 +116,6 @@ instance CollectsTypes DLExpr where
     DLE_ArrayRef _ a i -> cts a <> cts i
     DLE_ArraySet _ a i v -> cts a <> cts i <> cts v
     DLE_ArrayConcat _ x y -> cts x <> cts y
-    DLE_ArrayZip _ x y -> cts x <> cts y
     DLE_TupleRef _ t _ -> cts t
     DLE_ObjectRef _ a _ -> cts a
     DLE_Interact _ _ _ _ t as -> cts t <> cts as

--- a/hs/src/Reach/EPP.hs
+++ b/hs/src/Reach/EPP.hs
@@ -359,20 +359,20 @@ be_m = \case
       _ -> return ()
     fg_edge mdv de
     retb0 $ const $ return $ DL_Let at mdv de
-  DL_ArrayMap at ans x a i f -> do
-    fg_defn $ [ans, a, i]
-    fg_use $ x
+  DL_ArrayMap at ans xs as i f -> do
+    fg_defn $ [ans] <> as <> [i]
+    fg_use xs
     be_bl f
       >>= retb
         (\f' ->
-           return $ DL_ArrayMap at ans x a i f')
-  DL_ArrayReduce at ans x z b a i f -> do
-    fg_defn $ [ans, b, a, i]
-    fg_use $ [x, z]
+           return $ DL_ArrayMap at ans xs as i f')
+  DL_ArrayReduce at ans xs z b as i f -> do
+    fg_defn $ [ans] <> as <> [b, i]
+    fg_use $ xs <> [z]
     be_bl f
       >>= retb
         (\f' ->
-           return $ DL_ArrayReduce at ans x z b a i f')
+           return $ DL_ArrayReduce at ans xs z b as i f')
   DL_Var at v -> do
     fg_defn $ v
     let mkt _ = return $ DL_Var at v

--- a/hs/src/Reach/Eval.hs
+++ b/hs/src/Reach/Eval.hs
@@ -109,7 +109,6 @@ instance Pandemic DLExpr where
     DLE_ArrayRef at a i -> DLE_ArrayRef at <$> pan a <*> pan i
     DLE_ArraySet at a i v -> DLE_ArraySet at <$> pan a <*> pan i <*> pan v
     DLE_ArrayConcat at x y -> DLE_ArrayConcat at <$> pan x <*> pan y
-    DLE_ArrayZip at x y -> DLE_ArrayZip at <$> pan x <*> pan y
     DLE_TupleRef at a i -> DLE_TupleRef at <$> pan a <*> pure i
     DLE_ObjectRef at a f -> DLE_ObjectRef at <$> pan a <*> pure f
     DLE_Interact at cxt slp s ty as -> DLE_Interact at cxt slp s ty <$> pan as

--- a/hs/src/Reach/Eval/Error.hs
+++ b/hs/src/Reach/Eval/Error.hs
@@ -434,7 +434,7 @@ instance ErrorSuggestions EvalError where
 instance Show EvalError where
   show = \case
     Err_Zip_ArraysNotEqualLength x y ->
-      "Zip requires arrays of equal length, but got " <> show x <> " and " <> show y
+      "Method requires arrays of equal length, but got " <> show x <> " and " <> show y
     Err_Apply_ArgCount cloAt nFormals nArgs ->
       "Invalid function application. Expected " <> show nFormals <> " args, got " <> show nArgs <> " for function defined at " <> show cloAt
     Err_Block_Assign _jsop _stmts ->

--- a/hs/src/Reach/Freshen.hs
+++ b/hs/src/Reach/Freshen.hs
@@ -130,7 +130,6 @@ instance Freshen DLExpr where
     DLE_ArrayRef at a b -> DLE_ArrayRef at <$> fu a <*> fu b
     DLE_ArraySet at a b c -> DLE_ArraySet at <$> fu a <*> fu b <*> fu c
     DLE_ArrayConcat at a b -> DLE_ArrayConcat at <$> fu a <*> fu b
-    DLE_ArrayZip at a b -> DLE_ArrayZip at <$> fu a <*> fu b
     DLE_TupleRef at x y -> DLE_TupleRef at <$> fu x <*> pure y
     DLE_ObjectRef at x y -> DLE_ObjectRef at <$> fu x <*> pure y
     DLE_Interact a b c d e f -> DLE_Interact a b c d e <$> fu f

--- a/hs/src/Reach/Linearize.hs
+++ b/hs/src/Reach/Linearize.hs
@@ -87,10 +87,10 @@ dk1 :: DKTail -> DLSStmt -> DKApp DKTail
 dk1 k s =
   case s of
     DLS_Let at mdv de -> com $ DKC_Let at mdv de
-    DLS_ArrayMap at ans x a i f ->
-      com' $ DKC_ArrayMap at ans x a i <$> dk_block at f
-    DLS_ArrayReduce at ans x z b a i f ->
-      com' $ DKC_ArrayReduce at ans x z b a i <$> dk_block at f
+    DLS_ArrayMap at ans xs as i f ->
+      com' $ DKC_ArrayMap at ans xs as i <$> dk_block at f
+    DLS_ArrayReduce at ans xs z b as i f ->
+      com' $ DKC_ArrayReduce at ans xs z b as i <$> dk_block at f
     DLS_If at c _ t f -> do
       let con = DK_If at c
       let loc t' f' = DK_Com (DKC_LocalIf at c t' f') k
@@ -446,7 +446,7 @@ lookupTokenIdx at tok toks = do
   let bl = DLBlock at [] block_tl $ DLA_Var bl_res
   let ss =
         [ asn init_acc_dv $ DLE_LArg at $ DLLA_Tuple [DLA_Literal $ DLL_Bool False, DLA_Literal $ DLL_Int at 0]
-        , DL_ArrayReduce at reduce_res toks (DLA_Var init_acc_dv) acc_dv elem_dv i_dv bl
+        , DL_ArrayReduce at reduce_res [toks] (DLA_Var init_acc_dv) acc_dv [elem_dv] i_dv bl
         , asn tok_idx $ DLE_TupleRef at (DLA_Var reduce_res) 1
         , asn found' $ DLE_TupleRef at (DLA_Var reduce_res) 0
         , DL_Let at DLV_Eff $ DLE_Claim at [] CT_Assert (DLA_Var found') $ Just "Token is tracked" ]

--- a/hs/src/Reach/Pretty.hs
+++ b/hs/src/Reach/Pretty.hs
@@ -2,6 +2,7 @@
 
 module Reach.Pretty where
 
+import qualified Data.List as L
 import qualified Data.Map.Strict as M
 import Reach.Texty
 
@@ -53,10 +54,11 @@ prettyContinue cont_da =
 prettyStop :: Doc
 prettyStop = "exit" <> parens (emptyDoc) <> semi
 
-prettyMap :: (Pretty a, Pretty b, Pretty c, Pretty d) => a -> b -> a -> c -> d -> Doc
-prettyMap ans x a i f =
-  "map" <+> pretty ans <+> "=" <+> "for" <+> parens (pretty a <> "," <> pretty i <+> "in" <+> pretty x)
-    <+> braces (nest $ hardline <> pretty f)
+prettyMap :: (Pretty a, Pretty b, Pretty c, Pretty d) => a -> [b] -> [a] -> c -> d -> Doc
+prettyMap ans xs as i f =
+  "map" <+> pretty ans <+> "=" <+> "for" <+>
+  parens (withCommas as <> pretty i <+> "in" <+> withCommas xs) <+> braces (nest $ hardline <> pretty f)
+    where withCommas vs = L.foldl' (\accum v -> accum <> pretty v <> ",") "" vs
 
 prettyReduce :: (Pretty a, Pretty b, Pretty c, Pretty d, Pretty e, Pretty f, Pretty g) => a -> b -> c -> d -> e -> f -> g -> Doc
 prettyReduce ans x z b a i f =

--- a/hs/src/Reach/Sanitize.hs
+++ b/hs/src/Reach/Sanitize.hs
@@ -64,7 +64,6 @@ instance Sanitize DLExpr where
     DLE_ArrayRef _ a i -> DLE_ArrayRef sb (sani a) (sani i)
     DLE_ArraySet _ a i v -> DLE_ArraySet sb (sani a) (sani i) (sani v)
     DLE_ArrayConcat _ x y -> DLE_ArrayConcat sb (sani x) (sani y)
-    DLE_ArrayZip _ x y -> DLE_ArrayZip sb (sani x) (sani y)
     DLE_TupleRef _ a i -> DLE_TupleRef sb (sani a) i
     DLE_ObjectRef _ a f -> DLE_ObjectRef sb (sani a) f
     DLE_Interact _ fs p m t as -> DLE_Interact sb fs p m t (sani as)

--- a/hs/src/Reach/Subst.hs
+++ b/hs/src/Reach/Subst.hs
@@ -82,7 +82,6 @@ instance Subst DLExpr where
     DLE_ArrayRef at a b -> DLE_ArrayRef at <$> subst a <*> subst b
     DLE_ArraySet at a b c -> DLE_ArraySet at <$> subst a <*> subst b <*> subst c
     DLE_ArrayConcat at a b -> DLE_ArrayConcat at <$> subst a <*> subst b
-    DLE_ArrayZip at a b -> DLE_ArrayZip at <$> subst a <*> subst b
     DLE_TupleRef at x y -> DLE_TupleRef at <$> subst x <*> pure y
     DLE_ObjectRef at x y -> DLE_ObjectRef at <$> subst x <*> pure y
     DLE_Interact a b c d e f -> DLE_Interact a b c d e <$> subst f

--- a/hs/src/Reach/Util.hs
+++ b/hs/src/Reach/Util.hs
@@ -27,6 +27,7 @@ module Reach.Util
   , leftPad
   , makeErrCode
   , arraySet
+  , allEqual
   )
 where
 
@@ -156,3 +157,10 @@ makeErrCode errType errIndex =
 
 arraySet :: Int -> a -> [a] -> [a]
 arraySet n a arr = take n arr <> [a] <> drop (n + 1) arr
+
+allEqual :: Eq a => [a] -> Either (Maybe (a,a)) a
+allEqual [] = Left Nothing
+allEqual [x] = Right x
+allEqual (x:xs) = case allEqual xs of
+  Right y -> if x == y then Right y else Left $ Just (x,y)
+  Left diff -> Left diff

--- a/hs/src/Reach/Verify/Knowledge.hs
+++ b/hs/src/Reach/Verify/Knowledge.hs
@@ -199,8 +199,6 @@ kgq_e ctxt mv = \case
   DLE_ArraySet _ a e n -> kgq_la ctxt mv (DLLA_Tuple [a, e, n])
   DLE_ArrayConcat _ x_da y_da ->
     kgq_a_onlym ctxt mv x_da >> kgq_a_onlym ctxt mv y_da
-  DLE_ArrayZip _ x_da y_da ->
-    kgq_a_onlym ctxt mv x_da >> kgq_a_onlym ctxt mv y_da
   DLE_TupleRef _ a _ -> kgq_a_onlym ctxt mv a
   DLE_ObjectRef _ a _ -> kgq_a_onlym ctxt mv a
   DLE_Interact _ _ who what t as ->
@@ -259,14 +257,14 @@ kgq_m :: KCtxt -> DLStmt -> IO ()
 kgq_m ctxt = \case
   DL_Nop _ -> mempty
   DL_Let _ lv de -> kgq_e ctxt (lv2mdv lv) de
-  DL_ArrayMap _ ans x a i (DLBlock _ _ f r) ->
-    kgq_a_only ctxt a x
+  DL_ArrayMap _ ans xs as i (DLBlock _ _ f r) ->
+    zipWithM (kgq_a_only ctxt) as xs
       >> kgq_a_all ctxt (DLA_Var i)
       >> kgq_a_only ctxt ans r
       >> kgq_l ctxt f
-  DL_ArrayReduce _ ans x z b a i (DLBlock _ _ f r) ->
+  DL_ArrayReduce _ ans xs z b as i (DLBlock _ _ f r) ->
     kgq_a_only ctxt b z
-      >> kgq_a_only ctxt a x
+      >> zipWithM (kgq_a_only ctxt) as xs
       >> kgq_a_all ctxt (DLA_Var i)
       >> kgq_a_only ctxt ans r
       >> kgq_l ctxt f

--- a/hs/src/Reach/Verify/SMT.hs
+++ b/hs/src/Reach/Verify/SMT.hs
@@ -1043,9 +1043,6 @@ smt_e at_dv mdv de = do
     DLE_ArrayConcat {} ->
       --- FIXME: This might be possible to do by generating a function
       impossible "array_concat"
-    DLE_ArrayZip {} ->
-      --- FIXME: This might be possible to do by using `map`
-      impossible "array_zip"
     DLE_TupleRef at arr_da i -> do
       let t = argTypeOf arr_da
       s <- smtTypeSort t

--- a/hs/t/n/Err_Zip_ArraysNotEqualLength.txt
+++ b/hs/t/n/Err_Zip_ArraysNotEqualLength.txt
@@ -1,4 +1,4 @@
-reachc: error[RE0071]: Zip requires arrays of equal length, but got 5 and 3
+reachc: error[RE0071]: Method requires arrays of equal length, but got 5 and 3
 
   ./Err_Zip_ArraysNotEqualLength.rsh:6:32:application
 

--- a/hs/t/n/array_map_length_mismatch.rsh
+++ b/hs/t/n/array_map_length_mismatch.rsh
@@ -1,0 +1,16 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const A = Participant('A', {
+    getA: Fun([], Array(UInt, 5)),
+  });
+  init();
+  A.only(() => {
+    const x = declassify(interact.getA());
+    const y = array(UInt, [0, 1, 2]);
+    const z = Array.map(x, y, (l, r) => l + r);
+  });
+  A.publish(z);
+  commit();
+  exit();
+});

--- a/hs/t/n/array_map_length_mismatch.txt
+++ b/hs/t/n/array_map_length_mismatch.txt
@@ -1,0 +1,11 @@
+reachc: error[RE0071]: Method requires arrays of equal length, but got 5 and 3
+
+  ./array_map_length_mismatch.rsh:11:24:application
+
+  11|     const z = Array.map(x, y, (l, r) => l + r);
+
+Trace:
+  in [unknown function] from (./array_map_length_mismatch.rsh:8:13:function exp) at (./array_map_length_mismatch.rsh:8:9:application)
+
+For further explanation of this error, see: https://docs.reach.sh/rsh/errors/#RE0071
+

--- a/hs/t/n/array_reduce_length_mismatch.rsh
+++ b/hs/t/n/array_reduce_length_mismatch.rsh
@@ -1,0 +1,16 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const A = Participant('A', {
+    getA: Fun([], Array(UInt, 5)),
+  });
+  init();
+  A.only(() => {
+    const xs = declassify(interact.getA());
+    const ys = array(UInt, [0, 1, 2]);
+    const z = Array.reduce(xs, ys, 0, (ac, x, y) => ac - x + y);
+  });
+  A.publish(z);
+  commit();
+  exit();
+});

--- a/hs/t/n/array_reduce_length_mismatch.txt
+++ b/hs/t/n/array_reduce_length_mismatch.txt
@@ -1,0 +1,11 @@
+reachc: error[RE0071]: Method requires arrays of equal length, but got 5 and 3
+
+  ./array_reduce_length_mismatch.rsh:11:27:application
+
+  11|     const z = Array.reduce(xs, ys, 0, (ac, x, y) => ac - x + y);
+
+Trace:
+  in [unknown function] from (./array_reduce_length_mismatch.rsh:8:13:function exp) at (./array_reduce_length_mismatch.rsh:8:9:application)
+
+For further explanation of this error, see: https://docs.reach.sh/rsh/errors/#RE0071
+

--- a/hs/t/y/array_groups.txt
+++ b/hs/t/y/array_groups.txt
@@ -4,4 +4,4 @@ Verifying for generic connector
   Verifying when NO participants are honest
 Checked 9 theorems; No failures!
 WARNING: Compiler instructed to emit for Algorand, but we can statically determine that this program will not work on Algorand, because:
- * Step 0 uses 34442 units of cost, but the limit is 700. Step 0 starts at ./array_groups.rsh:45:7:dot.
+ * Step 0 uses 2662 units of cost, but the limit is 700. Step 0 starts at ./array_groups.rsh:45:7:dot.

--- a/hs/t/y/array_map_reduce.rsh
+++ b/hs/t/y/array_map_reduce.rsh
@@ -1,0 +1,18 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const A = Participant('A', {
+    getA: Fun([], Array(UInt, 5)),
+  });
+  init();
+  A.only(() => {
+    const xs = declassify(interact.getA());
+    const ys = array(UInt, [0, 1, 2, 3, 4]);
+    const mapped = Array.map(xs, ys, (x, y) => x + y);
+    const z = Array.reduce(xs, ys, mapped, 0, (acc, x, y, m) => acc + m - x - y);
+    assert(z == 0);
+  });
+  A.publish(z);
+  commit();
+  exit();
+});

--- a/hs/t/y/array_map_reduce.txt
+++ b/hs/t/y/array_map_reduce.txt
@@ -1,0 +1,5 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 5 theorems; No failures!

--- a/hs/t/y/overflows.txt
+++ b/hs/t/y/overflows.txt
@@ -3,5 +3,3 @@ Verifying for generic connector
   Verifying when ALL participants are honest
   Verifying when NO participants are honest
 Checked 52 theorems; No failures!
-WARNING: Compiler instructed to emit for Algorand, but we can statically determine that this program will not work on Algorand, because:
- * Step 0 uses 844 units of cost, but the limit is 700. Step 0 starts at ./overflows.rsh:12:7:dot.

--- a/js/stdlib/ts/interfaces.ts
+++ b/js/stdlib/ts/interfaces.ts
@@ -41,9 +41,8 @@ export interface Stdlib_Backend_Shared_User<Ty> {
 export interface Stdlib_Backend_Shared<Ty> extends Stdlib_Backend_Shared_User<Ty> {
   checkedBigNumberify: (at: string, max: BigNumber, n: any) => BigNumber
   protect: (t: any, v: unknown, ai?: string) => unknown
-  Array_asyncMap: <A, B>(a: A[], f:((x:A, i:number) => Promise<B>)) => Promise<B[]>
-  Array_asyncReduce: <A, B>(a: A[], b:B, f:((y:B, x:A, i:number) => Promise<B>)) => Promise<B>
-  Array_zip: <A, B>(a1: A[], a2: B[]) => [A, B][]
+  Array_asyncMap: <B>(as:any[][], f:(x:any[], i:number) => Promise<B>) => Promise<B[]>
+  Array_asyncReduce: <B>(as:any[][], b: B, f:((xs:any[], y:B, i:number) => Promise<B>)) => Promise<B>
   newMap: <A>(opts: MapOpts<A>) => LinearMap<A>
   mapRef: <A>(m: LinearMap<A>, f: string) => Promise<MaybeRep<A>>
   mapSet: <A>(m: LinearMap<A>, f: string, v: A) => Promise<void>

--- a/js/stdlib/ts/shared_backend.ts
+++ b/js/stdlib/ts/shared_backend.ts
@@ -192,19 +192,20 @@ export const mapRef = async <A>(m: LinearMap<A>, f: string): Promise<MaybeRep<A>
   return await m.ref(f);
 };
 
-export const Array_asyncMap = <A, B>(a: A[], f:((x:A, i:number) => Promise<B>)): Promise<B[]> => Promise.all(a.map(f));
-
-export const Array_asyncReduce = async <A, B>(a: A[], b:B, f:((y:B, x:A, i:number) => Promise<B>)): Promise<B> => {
-  let y = b;
-  let i = 0;
-  for ( const x of a ) {
-    y = await f(y, x, i++);
-  }
-  return y;
+export const Array_asyncMap = async <B>(as:any[][], f:(x:any[], i:number) => Promise<B>): Promise<B[]> => {
+  const fWrap = (_a:any, i:number) => f(as.map((a) => a[i]), i);
+  return Promise.all(as[0].map(fWrap));
 };
 
-export const Array_zip = <X,Y>(x: Array<X>, y: Array<Y>): Array<[X, Y]> =>
-  x.map((e, i): [X, Y] => [e, y[i]]);
+export const Array_asyncReduce = async <B>(as:any[][], b: B, f:((xs:any[], y:B, i:number) => Promise<B>)): Promise<B> => {
+  let accum = b;
+  let i = 0;
+  for ( i = 0; i < as[0].length; i++) {
+    const as_i = as.map((a) => a[i]);
+    accum = await f(as_i, accum, i);
+  }
+  return accum;
+};
 
 export const simMapDupe = <A>(sim_r:any, mapi:number, mapo:LinearMap<A>): void => {
   sim_r.maps[mapi] = copyMap(mapo.ref);


### PR DESCRIPTION
Some questions:

* Right now I've left the code raising the same error as `array_zip` when the array lengths don't match.  Should we make different errors for each, or genericize the zip error?
* Is the ALGO connector code correct?  I did it certainly wrong a couple of times, and I hope this one is at least close.  Your colloquium probably would have been helpful earlier -- eg. explaining what all of the functions with two-letter names mean.  I feel like it always takes me a long time to try to decipher what the intended meanings of the short names are.  Often there's a domino effect where I want to figure out what one abbreviation means, so I go to its definition to find a short body itself only full of abbreviations.  Often I give up.  Ultimately my understanding of what is going on, especially in the ALGO connector, is pretty foggy.
* What are your feelings about how non-duplicated code should be?  There is a loop pattern in the two ALGO connector branches that is similar that could be captured.  I started doing it, but then got a weird parse error that I didn't understand and just backed out my changes and decided to push and get feedback before fussing with it anymore.  Personally, in my own code, that loop pattern is the sort of thing that I'll often leave duplicated if I only do it twice, especially if I can't capture it textually near its two use sites, judging that the extra indirection is not yet worth the benefits of deduplication.  But this is a judgment call that many people and organizations feel differently about, and my impression @jeapostrophe is that you're more of a stickler for deduplication than most.
* I added a couple test files that fail when array lengths aren't matched, and then one that compiles correctly that includes map and reduce.  But what is our general approach to testing that the functionality actually works as expected beyond just compiling correctly?