### PR TITLE
CORE-1172|1173: `reach compile` optimizations

### DIFF
--- a/hs/app/reach/Main.hs
+++ b/hs/app/reach/Main.hs
@@ -1012,7 +1012,7 @@ compile = command "compile" $ info f d
       let CompilerOpts {..} = cta_co
       let v = versionBy majMinPat version''
       let ci' = if ci then "true" else ""
-      let ports = if (elem "--sim" rawArgs || co_sim) then "-p 3001:3001" else ""
+      let ports = if co_sim then "-p 3001:3001" else ""
       liftIO $ do
         diePathContainsParentDir co_source
         maybe (pure ()) diePathContainsParentDir co_mdirDotReach
@@ -1070,6 +1070,7 @@ compile = command "compile" $ info f d
               -u "$(id -ru):$(id -rg)" \
               --name "reachc_$$$$" \
               --entrypoint tail \
+              $ports \
               reachsh/reach:$v -f /dev/null)"
           fi
 
@@ -1079,7 +1080,6 @@ compile = command "compile" $ info f d
             -e REACH_IDE \
             -e "REACHC_ID=$${ID}" \
             -e "CI=$ci'" \
-            $ports \
             "$$cid" reachc $args
         fi
       |]

--- a/hs/app/reach/Main.hs
+++ b/hs/app/reach/Main.hs
@@ -1011,6 +1011,7 @@ compile = command "compile" $ info f d
       let args = argsl <> recursiveDisableReporting e_disableReporting
       let CompilerOpts {..} = cta_co
       let v = versionBy majMinPat version''
+      let cn = flip T.map v $ \c -> if (isAlphaNum c && isAscii c) || c == '_' then c else '_'
       let ci' = if ci then "true" else ""
       let ports = if co_sim then "-p 3001:3001" else ""
       liftIO $ do
@@ -1068,7 +1069,7 @@ compile = command "compile" $ info f d
               --volume "$$PWD:/app" \
               -l "sh.reach.dir-project=$$PWD" \
               -u "$(id -ru):$(id -rg)" \
-              --name "reachc_$$$$" \
+              --name "reachc_${cn}_$$$$" \
               --entrypoint tail \
               $ports \
               reachsh/reach:$v -f /dev/null)"

--- a/hs/src/Reach/AST/Base.hs
+++ b/hs/src/Reach/AST/Base.hs
@@ -162,7 +162,7 @@ data CompilationError = CompilationError
   , ce_offendingToken :: Maybe String
   , ce_errorCode :: String
   }
-  deriving (Show, Generic, ToJSON)
+  deriving (Show, Generic, ToJSON, FromJSON)
 
 makeCompilationError :: (ErrorSuggestions a, ErrorMessageForJson a, Show a, HasErrorCode a) => SrcLoc -> a -> CompilationError
 makeCompilationError src err =
@@ -195,6 +195,11 @@ instance Exception CompileErrorException
 
 instance ToJSON CompileErrorException where
   toJSON = toJSON . cee_error
+
+instance FromJSON CompileErrorException where
+  parseJSON = withObject "CompileErrorException" $ \v -> CompileErrorException
+    <$> parseJSON (Object v)
+    <*> pure ""
 
 expect_throw :: (HasErrorCode a, Show a, ErrorMessageForJson a, ErrorSuggestions a) => HasCallStack => Maybe ([SLCtxtFrame]) -> SrcLoc -> a -> b
 expect_throw mCtx src err = throw CompileErrorException {..}


### PR DESCRIPTION
My observation while testing was that this PR shaves anywhere from 0.6 - 2.0+ seconds off `reach compile` times - it does so by forking logs to another UNIX process in a re-used Docker container. The mean seems to be around 1.1 seconds saved.

`reach down` has also been modified to clear out the new background `reachc` containers.

Running `docker container stats`, even with many concurrent instances of `reachsh/reach` launched from different project directories and with different `REACH_VERSION` targets, indicates the containers use almost no system resources at all.