### PR TITLE
CORE-1153 Print srclocs w/ remote object and step arg length warnings

### DIFF
--- a/.circleci/config.pre.yml
+++ b/.circleci/config.pre.yml
@@ -242,7 +242,7 @@ jobs:
     - run:
         command: |
           cd .circleci && ./example.sh <<parameters.connector>> "${CIRCLE_NODE_TOTAL}" "${CIRCLE_NODE_INDEX}"
-        no_output_timeout: 20m
+        no_output_timeout: 30m
     - store_artifacts:
         path: /tmp/artifacts
     - store_artifacts:

--- a/examples/algo-incompatible-warnings/index.mjs
+++ b/examples/algo-incompatible-warnings/index.mjs
@@ -1,0 +1,1 @@
+// index.mjs is not used in this example

--- a/examples/algo-incompatible-warnings/index.rsh
+++ b/examples/algo-incompatible-warnings/index.rsh
@@ -1,0 +1,54 @@
+'reach 0.1';
+// 'use strict';
+
+export const main = Reach.App(() => {
+  const A = Participant('Alice', {
+    ctc: Fun([], Contract),
+    addrs: Fun([], Tuple(
+                    Address,Address,Address,Address,Address,Address,Address,Address,Address,Address,
+                    Address,Address,Address,Address,Address,Address,Address,Address,Address,Address,
+                    Address,Address,Address,Address,Address,Address,Address,Address,Address,Address,
+                    Address,Address,Address,Address,Address,Address,Address,Address,Address,Address,
+                    Address,Address,Address,Address,Address,Address,Address,Address,Address,Address,
+                    Address,Address,Address,Address,Address,Address,Address,Address,Address,Address,
+                    Address,Address,Address,Address)),
+  });
+
+  init();
+  A.publish();
+
+  commit();
+  A.only(() => {
+    const [a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,
+           a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,
+           a46,a47,a48,a49,a50,a51,a52,a53,a54,a55,a56,a57,a58,a59,a60,a61,a62,a63]
+           = declassify(interact.addrs());
+  });
+  A.publish(a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12, a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,
+            a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,
+            a45,a46,a47,a48,a49,a50,a51,a52,a53,a54,a55,a56,a57,a58,a59,a60,a61,a62,a63);
+
+  commit();
+  A.only(() => {
+    const [a0_,a1_,a2_,a3_,a4_,a5_,a6_,a7_,a8_,a9_,a10_,a11_,a12_,a13_,a14_,a15_,a16_,a17_,a18_,
+           a19_,a20_,a21_,a22_,a23_,a24_,a25_,a26_,a27_,a28_,a29_,a30_,a31_,a32_,a33_,a34_,a35_,
+           a36_,a37_,a38_,a39_,a40_,a41_,a42_,a43_,a44_,a45_,a46_,a47_,a48_,a49_,a50_,a51_,a52_,
+           a53_,a54_,a55_,a56_,a57_,a58_,a59_,a60_,a61_,a62_,a63_] = declassify(interact.addrs());
+  });
+  A.publish(a0_,a1_,a2_,a3_,a4_,a5_,a6_,a7_,a8_,a9_,a10_,a11_,a12_, a13_,a14_,a15_,a16_,a17_,a18_,
+            a19_,a20_,a21_,a22_,a23_,a24_,a25_,a26_,a27_,a28_,a29_,a30_,a31_,a32_,a33_,a34_,a35_,
+            a36_,a37_,a38_,a39_,a40_,a41_,a42_,a43_,a44_,a45_,a46_,a47_,a48_,a49_,a50_,a51_,a52_,
+            a53_,a54_,a55_,a56_,a57_,a58_,a59_,a60_,a61_,a62_,a63_);
+
+  commit();
+  A.only(() => {
+    const ctc = declassify(interact.ctc());
+  })
+  A.publish(ctc);
+  const rctc = remote(ctc, { f: Fun([], Null) });
+  rctc.f();
+  rctc.f();
+
+  commit()
+  exit();
+});

--- a/examples/algo-incompatible-warnings/index.txt
+++ b/examples/algo-incompatible-warnings/index.txt
@@ -1,0 +1,14 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 18 theorems; No failures!
+WARNING: Compiler instructed to emit for Algorand, but the conservative analysis found these potential problems:
+ * This program could use 2056 bytes of logs, but the limit is 1024; longest path:
+     TOP --> preamble --> publish --> l1_publish_lt_3 --> publish2 --> updateState --> apiReturn --> checkSize --> done --> BOT
+
+WARNING: Compiler instructed to emit for Algorand, but we can statically determine that this program will not work on Algorand, because:
+ * Step 1's argument length is 2049, but the maximum is 2048. Step 1 begins at ./index.rsh:27:5:dot
+ * Step 2's argument length is 2049, but the maximum is 2048. Step 2 begins at ./index.rsh:38:5:dot
+ * This program uses a remote object at ./index.rsh:49:9:application
+ * This program uses a remote object at ./index.rsh:50:9:application

--- a/examples/log-attack1/index.txt
+++ b/examples/log-attack1/index.txt
@@ -4,4 +4,4 @@ Verifying for generic connector
   Verifying when NO participants are honest
 Checked 9 theorems; No failures!
 WARNING: Compiler instructed to emit for Algorand, but we can statically determine that this program will not work on Algorand, because:
- * This program uses remote objects
+ * This program uses a remote object at ./index.rsh:21:12:application

--- a/examples/log-attack1j/index.txt
+++ b/examples/log-attack1j/index.txt
@@ -4,4 +4,5 @@ Verifying for generic connector
   Verifying when NO participants are honest
 Checked 12 theorems; No failures!
 WARNING: Compiler instructed to emit for Algorand, but we can statically determine that this program will not work on Algorand, because:
- * This program uses remote objects
+ * This program uses a remote object at ./index.rsh:19:8:application
+ * This program uses a remote object at ./index.rsh:23:8:application

--- a/examples/log-attack2/index.txt
+++ b/examples/log-attack2/index.txt
@@ -4,4 +4,4 @@ Verifying for generic connector
   Verifying when NO participants are honest
 Checked 12 theorems; No failures!
 WARNING: Compiler instructed to emit for Algorand, but we can statically determine that this program will not work on Algorand, because:
- * This program uses remote objects
+ * This program uses a remote object at ./index.rsh:20:10:application

--- a/examples/remote-api/index.txt
+++ b/examples/remote-api/index.txt
@@ -4,4 +4,4 @@ Verifying for generic connector
   Verifying when NO participants are honest
 Checked 17 theorems; No failures!
 WARNING: Compiler instructed to emit for Algorand, but we can statically determine that this program will not work on Algorand, because:
- * This program uses remote objects
+ * This program uses a remote object at ./index.rsh:53:28:application

--- a/examples/remote-rsh/index.txt
+++ b/examples/remote-rsh/index.txt
@@ -9,4 +9,8 @@ Verifying for generic connector
   Verifying when NO participants are honest
 Checked 27 theorems; No failures!
 WARNING: Compiler instructed to emit for Algorand, but we can statically determine that this program will not work on Algorand, because:
- * This program uses remote objects
+ * This program uses a remote object at ./index.rsh:77:21:application
+ * This program uses a remote object at ./index.rsh:78:31:application
+ * This program uses a remote object at ./index.rsh:79:22:application
+ * This program uses a remote object at ./index.rsh:86:30:application
+ * This program uses a remote object at ./index.rsh:90:34:application

--- a/examples/remote/index.txt
+++ b/examples/remote/index.txt
@@ -4,4 +4,12 @@ Verifying for generic connector
   Verifying when NO participants are honest
 Checked 80 theorems; No failures!
 WARNING: Compiler instructed to emit for Algorand, but we can statically determine that this program will not work on Algorand, because:
- * This program uses remote objects
+ * This program uses a remote object at ./index.rsh:47:13:application
+ * This program uses a remote object at ./index.rsh:48:22:application
+ * This program uses a remote object at ./index.rsh:52:24:application
+ * This program uses a remote object at ./index.rsh:53:38:application
+ * This program uses a remote object at ./index.rsh:54:45:application
+ * This program uses a remote object at ./index.rsh:73:34:application
+ * This program uses a remote object at ./index.rsh:77:35:application
+ * This program uses a remote object at ./index.rsh:82:34:application
+ * This program uses a remote object at ./index.rsh:86:68:application

--- a/hs/src/Reach/Connector/ALGO.hs
+++ b/hs/src/Reach/Connector/ALGO.hs
@@ -798,8 +798,8 @@ bad lab = do
   liftIO $ bad_io sFailuresR lab
   mapM_ comment $ LT.lines $ "BAD " <> lab
 
-xxx :: LT.Text -> App ()
-xxx lab = bad $ "This program uses " <> lab
+xxx :: String -> App ()
+xxx = bad . LT.pack
 
 freshLabel :: String -> App LT.Text
 freshLabel d = do
@@ -1575,7 +1575,8 @@ ce = \case
         cla $ mdaToMaybeLA mt mva
         cTupleSet at mdt $ fromIntegral i
         cMapStore at
-  DLE_Remote {} -> xxx "remote objects"
+  DLE_Remote at _ _ _ _ _ _ ->
+    xxx $ "This program uses a remote object at " <> show at
   DLE_TokenNew at (DLTokenNew {..}) -> do
     block_ "TokenNew" $ do
       let ct_at = at
@@ -2231,7 +2232,9 @@ ch which (C_Handler at int from prev svsl msgl timev secsv body) = recordWhich w
   let isCtor = which == 0
   let argSize = 1 + (typeSizeOf $ T_Tuple $ map varType $ msg)
   when (argSize > algoMaxAppTotalArgLen) $
-    xxx $ texty $ "Step " <> show which <> "'s argument length is " <> show argSize <> ", but the maximum is " <> show algoMaxAppTotalArgLen
+    xxx $ "Step " <> show which <> "'s argument length is " <> show argSize
+                  <> ", but the maximum is " <> show algoMaxAppTotalArgLen 
+                  <> ". Step " <> show which <> " begins at " <> show at
   let bindFromMsg = bindFromGV GV_argMsg (return ()) at
   let bindFromSvs = bindFromSvs_ at svsl
   block (handlerLabel which) $ do


### PR DESCRIPTION
Adds SrcLoc printing to warnings about using remote objects on ALGO and about having steps that take too large of arguments. Let me know if you'd like it phrased differently.

Example of warning phrasing here:
![image](https://user-images.githubusercontent.com/1377477/156865082-53e51dcb-c828-4022-bfdc-2d03f92f637e.png)
