### PR TITLE
js/browser-tests: try snapping screenshots

### DIFF
--- a/.circleci/config.pre.yml
+++ b/.circleci/config.pre.yml
@@ -310,6 +310,8 @@ jobs:
         (cd js/browser-tests && make run)
     - store_artifacts:
         path: js/browser-tests/cypress/videos
+    - store_artifacts:
+        path: js/browser-tests/cypress/screenshots
     - slack_fail
 
 workflows:

--- a/js/browser-tests/.gitignore
+++ b/js/browser-tests/.gitignore
@@ -1,4 +1,4 @@
 /node_modules
 /cypress/videos
-/cypress/snapshots
+/cypress/screenshots
 

--- a/js/browser-tests/cypress.json
+++ b/js/browser-tests/cypress.json
@@ -1,1 +1,3 @@
-{}
+{
+  "trashAssetsBeforeRuns": true
+}

--- a/js/browser-tests/cypress/integration/spec.js
+++ b/js/browser-tests/cypress/integration/spec.js
@@ -63,19 +63,23 @@ const rps = (choice, outcome) => {
   cy.then(() => setupAliceP).log('Alice acc is set up');
   cy.then(() => setupBobP).log('Bob acc is set up');
 
+  // screenshot opts helper fn for conciseness
+  let n = 1;
+  const s = (label) => [`${choice}_${n++}_${label}`, {overwrite: true}];
+
   cy.contains('button', 'Go').click();
-  cy.contains('button', 'Fund Account').click();
+  cy.contains('button', 'Fund Account').screenshot(...s('fund')).click();
   cy.contains('button', 'Deployer').click();
   cy.contains('button', 'Set wager').click();
-  cy.contains('button', 'Deploy').click();
+  cy.contains('button', 'Deploy').screenshot(...s('deploy')).click();
 
-  cy.get('.ContractInfo').then(async (el) => {
+  cy.get('.ContractInfo').screenshot(...s('info')).then(async (el) => {
     const ctcInfoStr = el.text();
     const ctcInfo = JSON.parse(ctcInfoStr);
     launchBob(ctcInfo);
   });
-  cy.contains('button', choice).click();
-  cy.contains(outcome);
+  cy.contains('button', choice).screenshot(...s('choose')).click();
+  cy.contains(outcome).screenshot(...s('outcome'));
 }
 
 describe('rps-9-web', () => {


### PR DESCRIPTION
Good news! By adding screenshots, we can see that Circle is, in fact, running through the whole testing process successfully. I'm not sure what's up with the video, but I'm satisfied by the screenshots.

https://app.circleci.com/pipelines/github/reach-sh/reach-lang/5684/workflows/a6168dda-4783-45e8-9547-a4ea0c0b51fd/jobs/106891/artifacts