### PR TITLE
docs: add tooltip function

### DIFF
--- a/docs/dev/generator.js
+++ b/docs/dev/generator.js
@@ -419,6 +419,10 @@ const processMd = async ({baseConfig, relDir, in_folder, iPath, oPath}) => {
     return "";
   };
 
+  const tooltip = (text, hoverText) => {
+    return `<a class="ui-tooltip" title="${hoverText}"><span style="cursor">${text}</span></a>`;
+  };
+
   const directive_note = (node) => {
     const data = node.data;
     data.hName = "div";
@@ -463,7 +467,7 @@ const processMd = async ({baseConfig, relDir, in_folder, iPath, oPath}) => {
     return r.join(`\n`);
   };
 
-  const expanderEnv = { seclink, defn, workshopDeps, workshopInit, workshopWIP, errver, externalRef, ref, directive_note, directive_testQ, directive_testA, generateIndex };
+  const expanderEnv = { seclink, defn, workshopDeps, workshopInit, workshopWIP, errver, externalRef, ref, tooltip, directive_note, directive_testQ, directive_testA, generateIndex };
 
   const expanderDirective = () => (tree) => {
     visit(tree, (node) => {


### PR DESCRIPTION
Adds a form `@{tooltip(TEXT, HOVERTEXT)}`.

I tested that it works, but I'm not sure what good example to add with it actually showcasing its use.  (I made a test example with doofy hover text, but don't want to actually add that.)