### PR TITLE
examples/react-build fix

### DIFF
--- a/.circleci/config.pre.yml
+++ b/.circleci/config.pre.yml
@@ -81,11 +81,11 @@ jobs:
     - attach_workspace:
         at: /tmp/workspace
     - and_restore_docker:
-        deps: "stdlib runner rpc-server reach reach-cli devnet-eth devnet-cfx devnet-algo"
+        deps: "stdlib runner react-runner rpc-server reach reach-cli devnet-eth devnet-cfx devnet-algo"
     # Publish images
     - run: |
         docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-        for IMG in stdlib runner rpc-server reach reach-cli devnet-algo devnet-eth devnet-cfx; do
+        for IMG in stdlib runner react-runner rpc-server reach reach-cli devnet-algo devnet-eth devnet-cfx; do
           ./scripts/docker-push.sh reachsh/${IMG}
         done
     # Publish stdlib

--- a/.circleci/make.sh
+++ b/.circleci/make.sh
@@ -79,7 +79,7 @@ conn () {
         connector: "${CONN}"
         size: ${SIZE}
 END
-  deps "reach" "reach-cli" "runner" "rpc-server" "${IMAGE}"
+  deps "reach" "reach-cli" "runner" "react-runner" "rpc-server" "${IMAGE}"
   cat >>"${END}" <<END
           - "${NAME}"
 END

--- a/examples/react-build/package.json
+++ b/examples/react-build/package.json
@@ -21,11 +21,6 @@
     "eject": "react-scripts eject",
     "serve": "serve -s build"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
(Also include `react-runner` in automated release script.)

I suspect that the odd timing of the `react-build` failure was because it wasn't using the `react-runner` image that CI built (otherwise this would have been caught sooner, maybe), and was pulling the deployed `react-runner` instead; I believe this fixes that as well.