### PR TITLE
print-keyword-info: include stdenv exports

### DIFF
--- a/hs/src/Reach/EditorInfo.hs
+++ b/hs/src/Reach/EditorInfo.hs
@@ -1,4 +1,4 @@
-module Reach.EditorInfo (printKeywordInfo) where
+module Reach.EditorInfo (printBaseKeywordInfo) where
 
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Encode.Pretty as A
@@ -18,23 +18,15 @@ customConfig = A.Config {
   confTrailingNewline = True
 }
 
-printKeywordInfo :: IO ()
-printKeywordInfo =
+printBaseKeywordInfo :: (M.Map String SLVal) -> IO ()
+printBaseKeywordInfo stdlibExports =
   B.putStr $
-    A.encodePretty'
-      customConfig $ infoMap
+    A.encodePretty' customConfig $ A.toJSON $
+       M.map
+         (\v -> M.singleton ("CompletionItemKind" :: String) $ show v)
+         $ M.mapMaybe completionKind
+         $ M.union (M.fromList C.base_env_slvals) stdlibExports
 
-infoMap :: A.Value
-infoMap =
-  A.toJSON $
-    M.map
-      (\v -> M.singleton ("CompletionItemKind" :: String) $ show v)
-      completionTypeMap
-
-completionTypeMap :: M.Map String CompletionItemKind
-completionTypeMap =
-  M.mapMaybe completionKind
-  $ M.fromList C.base_env_slvals
 
 data CompletionItemKind
   = CK_Text
@@ -70,6 +62,22 @@ instance Show CompletionItemKind where
 completionKind :: SLVal -> Maybe CompletionItemKind
 completionKind v =
   case v of
+    SLV_Null _ _ -> Just CK_Constant
+    SLV_Bool _ _ -> Just CK_Constant
+    SLV_Int _ _ -> Just CK_Constant
+    SLV_Bytes _ _ -> Just CK_Constant
+    SLV_Array _ _ _ -> Just CK_Constant
+    SLV_Tuple _ _ -> Just CK_Constant
+    SLV_Object _ _ _ -> Just CK_Constant
+    SLV_Struct _ _ -> Just CK_Constant
+    SLV_Clo _ _ _ -> Just CK_Function
+    SLV_Data _ _ _ _ -> Just CK_Constructor -- ?
+    SLV_DLC _ -> Just CK_Constant
+    SLV_Connector _ -> Nothing
+    SLV_RaceParticipant _ _ -> Just CK_Constant -- ?
+    SLV_Participant _ _ _ _ -> Just CK_Constant -- ?
+    SLV_Map _ -> Just CK_Variable -- ?
+    SLV_Deprecated _ _ -> Nothing -- ?
     SLV_Type _ -> Just CK_TypeParameter
     SLV_Kwd _ -> Just CK_Keyword
     SLV_DLVar _ -> Just CK_Variable
@@ -180,4 +188,4 @@ completionKind v =
         SLForm_apiCall_partial _ -> Nothing
         SLForm_wait -> Just CK_Function
         SLForm_setApiDetails -> Nothing
-    _ -> Nothing
+    --_ -> Nothing

--- a/hs/src/Reach/Eval.hs
+++ b/hs/src/Reach/Eval.hs
@@ -302,7 +302,7 @@ checkUnusedVars m = do
       expect_throw Nothing at $ Err_Unused_Variables l
   return a
 
-evalBundle :: Connectors -> JSBundle -> IO (S.Set SLVar, (SLVar -> IO DLProg))
+evalBundle :: Connectors -> JSBundle -> IO (SLEnv, S.Set SLVar, (SLVar -> IO DLProg))
 evalBundle cns (JSBundle mods) = do
   evalEnv <- makeEnv cns
   let run = flip runReaderT evalEnv
@@ -325,7 +325,7 @@ evalBundle cns (JSBundle mods) = do
         compileDApp shared_lifts exports topv
   case S.null tops of
     True -> do
-      return (S.singleton "default", const $ go $ return defaultApp)
+      return (exe_ex, S.singleton "default", const $ go $ return defaultApp)
     False -> do
       let go' which = go $ env_lookup LC_CompilerRequired which exe_ex
-      return (tops, go')
+      return (exe_ex, tops, go')

--- a/hs/src/Reach/Parser.hs
+++ b/hs/src/Reach/Parser.hs
@@ -342,12 +342,16 @@ map_order dm = order
     edgeList = map (\(from, to) -> (from, from, to)) $ M.toList dm
     getNodePart (n, _, _) = n
 
-gatherDeps_top :: FilePath -> Bool -> FilePath -> IO JSBundle
+gatherDeps_top :: ReachSource -> Bool -> FilePath -> IO JSBundle
 gatherDeps_top src_p e_install e_dreachp = do
   let e_at = srcloc_top
   e_bm <- liftIO $ newIORef (mempty, mempty)
   flip runReaderT (Env {..}) $ do
-    _src_abs_p <- gatherDeps_file GatherTop src_p
+    unless (src_p == ReachStdLib) $ do
+      _src_abs_p <- case src_p of
+        ReachSourceFile f -> gatherDeps_file GatherTop f
+        ReachStdLib -> impossible "gatherDeps"
+      return ()
     gatherDeps_stdlib
     (dm, fm) <- liftIO $ readIORef e_bm
     return $ JSBundle $ map (\k -> (k, ensureJust (fm M.! k))) $ map_order dm


### PR DESCRIPTION
Note that this still doesn't quite bring the generated map to parity with the old JSON file.  The old file includes `Array.map`, while the stdlib has only `Array_map`, and other similar Array methods.