### PR TITLE
Remove index.mjs outdated indentation

### DIFF
--- a/hs/app/reach/embed/init/_default/index.mjs
+++ b/hs/app/reach/embed/init/_default/index.mjs
@@ -2,26 +2,26 @@ import {loadStdlib} from '@reach-sh/stdlib';
 import * as backend from './build/${APP}.main.mjs';
 const stdlib = loadStdlib(process.env);
 
-  const startingBalance = stdlib.parseCurrency(100);
+const startingBalance = stdlib.parseCurrency(100);
 
-  const [ accAlice, accBob ] =
-    await stdlib.newTestAccounts(2, startingBalance);
-  console.log('Hello, Alice and Bob!');
+const [ accAlice, accBob ] =
+  await stdlib.newTestAccounts(2, startingBalance);
+console.log('Hello, Alice and Bob!');
 
-  console.log('Launching...');
-  const ctcAlice = accAlice.contract(backend);
-  const ctcBob = accBob.contract(backend, ctcAlice.getInfo());
+console.log('Launching...');
+const ctcAlice = accAlice.contract(backend);
+const ctcBob = accBob.contract(backend, ctcAlice.getInfo());
 
-  console.log('Starting backends...');
-  await Promise.all([
-    backend.Alice(ctcAlice, {
-      ...stdlib.hasRandom,
-      // implement Alice's interact object here
-    }),
-    backend.Bob(ctcBob, {
-      ...stdlib.hasRandom,
-      // implement Bob's interact object here
-    }),
-  ]);
+console.log('Starting backends...');
+await Promise.all([
+  backend.Alice(ctcAlice, {
+    ...stdlib.hasRandom,
+    // implement Alice's interact object here
+  }),
+  backend.Bob(ctcBob, {
+    ...stdlib.hasRandom,
+    // implement Bob's interact object here
+  }),
+]);
 
-  console.log('Goodbye, Alice and Bob!');
+console.log('Goodbye, Alice and Bob!');


### PR DESCRIPTION
After recently removing the 'main' closure from the index.mjs template, the 2-space indentation for the body code was still there. This is just a little thing that bugged me :^)