### PR TITLE
CORE-996 underscore numeric separator

### DIFF
--- a/docs/src/rsh/compute/index.md
+++ b/docs/src/rsh/compute/index.md
@@ -502,6 +502,8 @@ These applications are considered negative positions for `{!rsh} Refine`.
 007
 -10
 34.5432
+123_456_789
+0x12_34_56
 true
 false
 null
@@ -520,6 +522,7 @@ Numeric literals must obey the @{defn("bit width")} of `{!rsh} UInt` if they are
 Reach provides abstractions for working with `{!rsh} Int`s and signed `{!rsh} FixedPoint` numbers.
 `{!rsh} Int`s may be defined by applying the unary `{!rsh} +` and `{!rsh} -` operators to values of type `{!rsh} UInt`.
 Reach provides syntactic sugar for defining signed `{!rsh} FixedPoint` numbers, in base 10, with decimal syntax.
+Numeric literals may contain underscore separators as a visual aid (e.g. `{!rsh} 123_456` is the same as `{!rsh} 123456`).
 
 @{defn("Boolean literal")}s may be written as `{!rsh} true` or `{!rsh} false`.
 

--- a/examples/numeric-underscores/index.mjs
+++ b/examples/numeric-underscores/index.mjs
@@ -8,8 +8,8 @@ const ctcAlice = accAlice.contract(backend);
 
 await Promise.all([
   backend.Alice(ctcAlice, {
-    verifyNumbers: (nDec) => {
-      if (nDec != 123_456_789) {
+    verifyNumber: (n) => {
+      if (n != 123_456_789) {
         throw Error("didn't get the right number");
       }
     }

--- a/examples/numeric-underscores/index.mjs
+++ b/examples/numeric-underscores/index.mjs
@@ -10,7 +10,7 @@ await Promise.all([
   backend.Alice(ctcAlice, {
     verifyNumber: (n) => {
       if (n != 123_456_789) {
-        throw Error("didn't get the right number");
+        throw Error(`didn't get the right number: ${n}`);
       }
     }
   }),

--- a/examples/numeric-underscores/index.mjs
+++ b/examples/numeric-underscores/index.mjs
@@ -1,0 +1,18 @@
+import {loadStdlib} from '@reach-sh/stdlib';
+import * as backend from './build/index.main.mjs';
+const stdlib = loadStdlib(process.env);
+
+const startingBalance = stdlib.parseCurrency(100);
+const [ accAlice ] = await stdlib.newTestAccounts(1, startingBalance);
+const ctcAlice = accAlice.contract(backend);
+
+await Promise.all([
+  backend.Alice(ctcAlice, {
+    verifyNumbers: (nDec) => {
+      if (nDec != 123_456_789) {
+        throw Error("didn't get the right number");
+      }
+    }
+  }),
+]);
+

--- a/examples/numeric-underscores/index.rsh
+++ b/examples/numeric-underscores/index.rsh
@@ -1,14 +1,14 @@
 'reach 0.1';
 
-const nDec = 123_456_789;
-
 export const main = Reach.App(() => {
-  const A = Participant('Alice', {
-    // Specify Alice's interact interface here
-    verifyNumbers: Fun([UInt], Null),
-  });
+  const A = Participant('Alice', { verifyNumber: Fun([UInt], Null) });
   init();
   A.publish();
-  A.interact.verifyNumbers(nDec);
+  A.interact.verifyNumber(123456789);
+  A.interact.verifyNumber(123_456_789);
+    A.only(() => {
+    // Starting with an underscore makes an identifier
+    const _123 = interact.verifyNumber(1_2_3_4_5_6_7_8_9);
+  })
   commit();
 });

--- a/examples/numeric-underscores/index.rsh
+++ b/examples/numeric-underscores/index.rsh
@@ -4,9 +4,11 @@ export const main = Reach.App(() => {
   const A = Participant('Alice', { verifyNumber: Fun([UInt], Null) });
   init();
   A.publish();
-  A.interact.verifyNumber(123456789);
-  A.interact.verifyNumber(123_456_789);
-    A.only(() => {
+  A.interact.verifyNumber(123456789);     // decimal without _'s
+  A.interact.verifyNumber(123_456_789);   // decimal with _'s
+  A.interact.verifyNumber(0x07_5B_CD_15); // hex
+  A.interact.verifyNumber(0726_746_425);  // octal
+  A.only(() => {
     // Starting with an underscore makes an identifier
     const _123 = interact.verifyNumber(1_2_3_4_5_6_7_8_9);
   })

--- a/examples/numeric-underscores/index.rsh
+++ b/examples/numeric-underscores/index.rsh
@@ -1,0 +1,14 @@
+'reach 0.1';
+
+const nDec = 123_456_789;
+
+export const main = Reach.App(() => {
+  const A = Participant('Alice', {
+    // Specify Alice's interact interface here
+    verifyNumbers: Fun([UInt], Null),
+  });
+  init();
+  A.publish();
+  A.interact.verifyNumbers(nDec);
+  commit();
+});

--- a/examples/numeric-underscores/index.txt
+++ b/examples/numeric-underscores/index.txt
@@ -1,0 +1,5 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 4 theorems; No failures!

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -3893,7 +3893,7 @@ evalExpr e = case e of
       "this" -> evalExpr $ JSIdentifier a l
       _ -> expect_ $ Err_Parse_IllegalLiteral l
   JSHexInteger a ns -> locAtf (srcloc_jsa "hex" a) $
-    withAt $ \at -> public $ SLV_Int at $ numberValue 16 ns
+    withAt $ \at -> public $ SLV_Int at $ numberValue 16 (drop 2 ns {- trim '0x' prefix -})
   JSOctal a ns -> locAtf (srcloc_jsa "octal" a) $
     withAt $ \at -> public $ SLV_Int at $ numberValue 8 ns
   JSStringLiteral a s -> locAtf (srcloc_jsa "string" a) $

--- a/hs/stack.yaml
+++ b/hs/stack.yaml
@@ -32,7 +32,7 @@ extra-deps:
     commit: ca66b8dcfe22d1c1afbe81c83274dbc27115bf68
     # ^ from branch "reach-fork-2"
   - git: https://github.com/reach-sh/language-javascript.git
-    commit: c1c9899708859e969c73343cf2691231a1ca7b03
+    commit: f1b4cd7d4a6502c385c64a5d0c80ce325202a48d
     # ^ from branch "reach-1"
   - git: https://github.com/google/ormolu.git
     commit: ffdf145bbdf917d54a3ef4951fc2655e35847ff0

--- a/hs/stack.yaml
+++ b/hs/stack.yaml
@@ -31,10 +31,9 @@ extra-deps:
   - git: https://github.com/reach-sh/stan.git
     commit: ca66b8dcfe22d1c1afbe81c83274dbc27115bf68
     # ^ from branch "reach-fork-2"
-  # - git: https://github.com/reach-sh/language-javascript.git
-  #   commit: bb807bd75fd45a8cce355f4be4bc413f9541e276
+  - git: https://github.com/reach-sh/language-javascript.git
+    commit: c1c9899708859e969c73343cf2691231a1ca7b03
     # ^ from branch "reach-1"
-  - ../../language-javascript/
   - git: https://github.com/google/ormolu.git
     commit: ffdf145bbdf917d54a3ef4951fc2655e35847ff0
     # ^ from branch "gfork"

--- a/hs/stack.yaml
+++ b/hs/stack.yaml
@@ -31,9 +31,10 @@ extra-deps:
   - git: https://github.com/reach-sh/stan.git
     commit: ca66b8dcfe22d1c1afbe81c83274dbc27115bf68
     # ^ from branch "reach-fork-2"
-  - git: https://github.com/reach-sh/language-javascript.git
-    commit: bb807bd75fd45a8cce355f4be4bc413f9541e276
+  # - git: https://github.com/reach-sh/language-javascript.git
+  #   commit: bb807bd75fd45a8cce355f4be4bc413f9541e276
     # ^ from branch "reach-1"
+  - ../../language-javascript/
   - git: https://github.com/google/ormolu.git
     commit: ffdf145bbdf917d54a3ef4951fc2655e35847ff0
     # ^ from branch "gfork"

--- a/hs/stack.yaml.lock
+++ b/hs/stack.yaml.lock
@@ -109,11 +109,11 @@ packages:
     git: https://github.com/reach-sh/language-javascript.git
     pantry-tree:
       size: 3233
-      sha256: 009bac12f48b261aabdbfc9559a8f00fa556e2065df1f379080dfa31470a3075
-    commit: c1c9899708859e969c73343cf2691231a1ca7b03
+      sha256: 90e2a4e8f79e764418c6735d02ff1239c71060ac682d646e676f7c54ed650efa
+    commit: f1b4cd7d4a6502c385c64a5d0c80ce325202a48d
   original:
     git: https://github.com/reach-sh/language-javascript.git
-    commit: c1c9899708859e969c73343cf2691231a1ca7b03
+    commit: f1b4cd7d4a6502c385c64a5d0c80ce325202a48d
 - completed:
     name: ormolu
     version: 0.1.4.1

--- a/hs/stack.yaml.lock
+++ b/hs/stack.yaml.lock
@@ -104,6 +104,17 @@ packages:
     git: https://github.com/reach-sh/stan.git
     commit: ca66b8dcfe22d1c1afbe81c83274dbc27115bf68
 - completed:
+    name: language-javascript
+    version: 0.7.1.1
+    git: https://github.com/reach-sh/language-javascript.git
+    pantry-tree:
+      size: 3233
+      sha256: 009bac12f48b261aabdbfc9559a8f00fa556e2065df1f379080dfa31470a3075
+    commit: c1c9899708859e969c73343cf2691231a1ca7b03
+  original:
+    git: https://github.com/reach-sh/language-javascript.git
+    commit: c1c9899708859e969c73343cf2691231a1ca7b03
+- completed:
     name: ormolu
     version: 0.1.4.1
     git: https://github.com/google/ormolu.git

--- a/hs/stack.yaml.lock
+++ b/hs/stack.yaml.lock
@@ -104,17 +104,6 @@ packages:
     git: https://github.com/reach-sh/stan.git
     commit: ca66b8dcfe22d1c1afbe81c83274dbc27115bf68
 - completed:
-    name: language-javascript
-    version: 0.7.1.1
-    git: https://github.com/reach-sh/language-javascript.git
-    pantry-tree:
-      size: 3233
-      sha256: b54361ae29e0f32abb0286cbf3efbd5b97a0a3ff264713b8affa9e389aa45041
-    commit: bb807bd75fd45a8cce355f4be4bc413f9541e276
-  original:
-    git: https://github.com/reach-sh/language-javascript.git
-    commit: bb807bd75fd45a8cce355f4be4bc413f9541e276
-- completed:
     name: ormolu
     version: 0.1.4.1
     git: https://github.com/google/ormolu.git


### PR DESCRIPTION
Update stack.yaml to use new language-javascript hash, and also add a small example to show it working.