### PR TITLE
docs: re-add anchors for Foldable.imin and friends

### DIFF
--- a/docs/src/rsh/compute/index.md
+++ b/docs/src/rsh/compute/index.md
@@ -972,6 +972,12 @@ c.average()
 
 #### `Foldable.imin` && `Foldable.imax`
 
+@{ref("rsh", "Foldable.imin")}
+@{ref("rsh", "Foldable.imax")}
+@{ref("rsh", "Array.imin")}
+@{ref("rsh", "Array.imax")}
+@{ref("rsh", "Map.imin")}
+@{ref("rsh", "Map.imax")}
 ```reach
 Foldable.imin(c)
 Foldable.imax(c)


### PR DESCRIPTION
Oops, I guess I removed the anchors for these with those fixes earlier when I tried to clarify things.