### PR TITLE
prevent unhelpful auto-completion like `init`'s

### DIFF
--- a/vsce/client/src/extension.ts
+++ b/vsce/client/src/extension.ts
@@ -12,242 +12,203 @@
 
 import * as path from 'path';
 import {
-	commands,
-	env,
-	ExtensionContext,
-	Terminal,
-	Uri,
-	window,
-	workspace,
+  commands,
+  env,
+  ExtensionContext,
+  Terminal,
+  Uri,
+  window,
+  workspace,
 } from 'vscode';
 import { exec } from 'child_process';
 import { initButtons } from './buttons';
-
 import {
-	LanguageClient,
-	LanguageClientOptions,
-	ServerOptions,
-	TransportKind,
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+  TransportKind,
 } from 'vscode-languageclient/node';
 import CHECK_FOR_UPDATES_USING from './util/checkForUpdates';
 import { CommandsTreeDataProvider, DocumentationTreeDataProvider, HelpTreeDataProvider } from './CommandsTreeDataProvider';
 import { terminalOptions } from "./terminalOptions";
+import * as fs from 'fs';
+import * as url from 'url';
 
 const COMMANDS = require('../../data/commands.json');
 
 let client: LanguageClient;
-
-var terminal: Terminal;
-
-const fs = require('fs');
-import * as url from 'url';
-
-var rootFolder: string;
+let terminal: Terminal;
+let rootFolder: string;
 
 export function activate(context: ExtensionContext) {
-	// The server is implemented in node
-	let serverModule = context.asAbsolutePath(
-		path.join('server', 'out', 'server.js')
-	);
-	// The debug options for the server
-	// --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
-	let debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
+  // The server is implemented in node
+  let serverModule = context.asAbsolutePath(path.join('server', 'out', 'server.js'));
+  // The debug options for the server
+  // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
+  let debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
 
-	// If the extension is launched in debug mode then the debug server options are used
-	// Otherwise the run options are used
-	let serverOptions: ServerOptions = {
-		run: { module: serverModule, transport: TransportKind.ipc },
-		debug: {
-			module: serverModule,
-			transport: TransportKind.ipc,
-			options: debugOptions
-		}
-	};
+  // If the extension is launched in debug mode then the debug server options are used
+  // Otherwise the run options are used
+  let serverOptions: ServerOptions = {
+    run: { module: serverModule, transport: TransportKind.ipc },
+    debug: {
+      module: serverModule,
+      transport: TransportKind.ipc,
+      options: debugOptions
+    }
+  };
 
-	terminal = window.createTerminal(terminalOptions);
-	const reachExecutablePath = workspace.getConfiguration().get('reachide.executableLocation') as string;
-	const wf = workspace.workspaceFolders[0].uri.path || '.';
-	const reachPath = path.join(wf, reachExecutablePath);
-	registerCommands(context, reachPath);
+  terminal = window.createTerminal(terminalOptions);
+  const reachExecutablePath = workspace.getConfiguration().get('reachide.executableLocation') as string;
+  const wf = workspace.workspaceFolders[0].uri.path || '.';
+  const reachPath = path.join(wf, reachExecutablePath);
+  registerCommands(context, reachPath);
 
+  // Options to control the language client
+  let clientOptions: LanguageClientOptions = {
+    // Register the server for Reach .rsh documents
+    documentSelector: [
+      {
+        pattern: '**/*.rsh',
+        scheme: 'file'
+      }
+    ],
+    synchronize: {
+      // Notify the server about file changes to '.clientrc files contained in the workspace
+      fileEvents: workspace.createFileSystemWatcher('**/*.rsh')
+    }
+  };
 
-	// Options to control the language client
-	let clientOptions: LanguageClientOptions = {
-		// Register the server for Reach .rsh documents
-		documentSelector: [
-			{
-			  pattern: '**/*.rsh',
-			  scheme: 'file'
-			}
-		],
-		synchronize: {
-			// Notify the server about file changes to '.clientrc files contained in the workspace
-			fileEvents: workspace.createFileSystemWatcher('**/*.rsh')
-		}
-	};
+  // Create the language client and start the client.
+  client = new LanguageClient(
+    'reachide',
+    'Reach IDE',
+    serverOptions,
+    clientOptions
+  );
 
-	// Create the language client and start the client.
-	client = new LanguageClient(
-		'reachide',
-		'Reach IDE',
-		serverOptions,
-		clientOptions
-	);
+  // Start the client. This will also launch the server
+  client.start();
 
-	// Start the client. This will also launch the server
-	client.start();
+  initButtons(context);
 
-	initButtons(context);
+  // Checking for updates should be
+  // asynchronous and non-blocking.
+  client.onReady().then(() => CHECK_FOR_UPDATES_USING(reachPath));
 
-	// Checking for updates should be
-	// asynchronous and non-blocking.
-	client.onReady().then(() => CHECK_FOR_UPDATES_USING(
-		reachPath
-	));
+  // Inject association for .rsh file type
+  if (workspace.workspaceFolders !== undefined) {
+    rootFolder = url.fileURLToPath( workspace.workspaceFolders[0].uri.toString() );
+  }
+  associateRshFiles();
 
-	// Inject association for .rsh file type
-	if (workspace.workspaceFolders !== undefined) {
-		rootFolder = url.fileURLToPath( workspace.workspaceFolders[0].uri.toString() );
-	}
-	associateRshFiles();
-
-	window.registerTreeDataProvider('reach-commands', new CommandsTreeDataProvider());
-	window.registerTreeDataProvider('reach-help', new HelpTreeDataProvider());
-	window.registerTreeDataProvider('reach-docs', new DocumentationTreeDataProvider());
-}
+  window.registerTreeDataProvider('reach-commands', new CommandsTreeDataProvider());
+  window.registerTreeDataProvider('reach-help', new HelpTreeDataProvider());
+  window.registerTreeDataProvider('reach-docs', new DocumentationTreeDataProvider());
+};
 
 const commandHelper = (
-	context: ExtensionContext,
-	reachPath: string
+  context: ExtensionContext,
+  reachPath: string
 ) => (label: string) => {
-	const disposable = commands.registerCommand(`reach.${label}`, () => {
-		terminal.show();
-		if (label === 'download Reach shell script') {
-			terminal.sendText(
-				'curl https://docs.reach.sh/reach -o ' +
-				reachPath + ' ; chmod +x ' + reachPath
-			);
-		} else {
-			terminal.sendText(`${reachPath} ${label}`);
-		}
-	});
-	context.subscriptions.push(disposable);
+  const disposable = commands.registerCommand(`reach.${label}`, () => {
+    terminal.show();
+    if (label === 'download Reach shell script') {
+      terminal.sendText(`curl https://docs.reach.sh/reach -o ${reachPath} ; chmod +x ${reachPath}`);
+    } else {
+      terminal.sendText(`${reachPath} ${label}`);
+    }
+  });
+  context.subscriptions.push(disposable);
 };
 
 const urlHelper = (
-	context: ExtensionContext,
-	label: string,
-	url: string
+  context: ExtensionContext,
+  label: string,
+  url: string
 ) => {
-	const disposable = commands.registerCommand(`reach.${label}`, () => {
-		env.openExternal(Uri.parse(url));
-	});
-	context.subscriptions.push(disposable);
+  const disposable = commands.registerCommand(`reach.${label}`, () => {
+    env.openExternal(Uri.parse(url));
+  });
+  context.subscriptions.push(disposable);
 };
 
 function registerCommands(context: ExtensionContext, reachPath: string) {
-	const cmdHelper = commandHelper(context, reachPath);
+  const cmdHelper = commandHelper(context, reachPath);
 
-	// If a command has a url, we should call
-	// something like
-	// urlHelper(context, 'docs', 'https://link');
-	// Otherwise, call something like
-	// cmdHelper('compile');
-	COMMANDS.forEach((commandObject: {
-		label: string; url?: string;
-	}) => {
-		// Extract all the properties we might need
-		// from the parameter.
-		const { label, url } = commandObject;
-		commandObject.url ?
-			urlHelper(context, label, url) :
-			cmdHelper(label);
-	});
-}
+  // If a command has a url, we should call
+  // something like
+  // urlHelper(context, 'docs', 'https://link');
+  // Otherwise, call something like
+  // cmdHelper('compile');
+  COMMANDS.forEach((commandObject: {
+    label: string; url?: string;
+  }) => {
+    // Extract all the properties we might need
+    // from the parameter.
+    const { label, url } = commandObject;
+    commandObject.url ?
+      urlHelper(context, label, url) :
+      cmdHelper(label);
+  });
+};
 
 function associateRshFiles() {
-	exec(`mkdir -p ${rootFolder}${path.sep}.vscode`, (error: { message: any; }, stdout: any, stderr: any) => {
-		if (error) {
-			console.error(`Could not create .vscode directory: ${error.message}`);
-			return;
-		}
-		if (stderr) {
-			console.error(`Could not create .vscode directory: ${stderr}`);
-			return;
-		}
-		injectRshFileAssocation();
-	});
-}
+  exec(`mkdir -p ${rootFolder}${path.sep}.vscode`, (error: { message: any; }, stdout: any, stderr: any) => {
+    if (error || stderr) {
+      console.error(`Could not create .vscode directory: ${error?.message || stderr}`);
+      return;
+    }
+    injectRshFileAssocation();
+  });
+};
 
 function injectRshFileAssocation() {
-	const pathToSettingsFile: string = `${
-		rootFolder
-	}${path.sep}.vscode/settings.json`;
+  const pathToSettingsFile: string = `${rootFolder}${path.sep}.vscode/settings.json`;
 
-	console.info('The path to the settings file is');
-	console.info(pathToSettingsFile);
+  console.info('The path to the settings file is');
+  console.info(pathToSettingsFile);
 
-	fs.readFile(pathToSettingsFile, function (
-		err: any, content: string
-	) {
-		let parseJson: {
-			[x: string]: boolean | {
-				[x: string]: string;
-			};
-		};
+  fs.readFile(pathToSettingsFile, (err: any, data: Buffer) => {
+    let parseJson: {
+      [x: string]: boolean | {
+        [x: string]: string;
+      };
+    };
 
-		try {
-			parseJson = JSON.parse(content);
-		} catch {
-			parseJson = {};
-		}
-		console.info('parseJson', parseJson);
+    try {
+      parseJson = JSON.parse(data.toString());
+    } catch {
+      parseJson = {};
+    }
 
-		let fileAssoc = parseJson['files.associations'];
-		if (fileAssoc === undefined) {
-			parseJson['files.associations'] = {
-				'*.rsh': 'javascript'
-			};
-		} else {
-			parseJson['files.associations']['*.rsh'] =
-				'javascript';
-		}
+    if (parseJson['files.associations'] === undefined) {
+      parseJson['files.associations'] = {}
+    }
+    parseJson['files.associations']['*.rsh'] = 'javascript';
 
-		let completeFunctionCalls = parseJson[
-			'javascript.suggest.completeFunctionCalls'
-		];
-		if (completeFunctionCalls !== undefined) {
-			// Respect users' preferences.
-			// If they already have this setting,
-			// don't modify it.
-		} else {
-			parseJson[
-				'javascript.suggest.completeFunctionCalls'
-			] = true;
-		}
+    // Don't modify this setting if users already have it.
+    if (parseJson['javascript.suggest.completeFunctionCalls'] === undefined) {
+      parseJson['javascript.suggest.completeFunctionCalls'] = true;
+    }
 
-		fs.writeFile(pathToSettingsFile, JSON.stringify(
-			parseJson, null, 4
-		), function (err: any) {
-			if (err) {
-				console.error(
-					'Could not create ' +
-					'.vscode/settings.json' +
-					`: ${err}`
-				);
-				return;
-			} else {
-				console.info('Wrote to');
-				console.info(pathToSettingsFile);
-				console.info('successfully!');
-			}
-		});
-	});
-}
+    fs.writeFile(pathToSettingsFile, JSON.stringify(
+      parseJson, null, 4
+    ), (err: any) => {
+      if (err) {
+        console.error(`Could not create .vscode/settings.json: ${err}`);
+        return;
+      } else {
+        console.info('Wrote to');
+        console.info(pathToSettingsFile);
+        console.info('successfully!');
+      }
+    });
+  });
+};
 
 export function deactivate(): Thenable<void> | undefined {
-	if (!client) {
-		return undefined;
-	}
-	return client.stop();
-}
+  if (client) {
+    return client.stop();
+  }
+};

--- a/vsce/client/src/extension.ts
+++ b/vsce/client/src/extension.ts
@@ -180,25 +180,66 @@ function associateRshFiles() {
 }
 
 function injectRshFileAssocation() {
-	const settingsFile:string = `${rootFolder}${path.sep}.vscode/settings.json`;
+	const pathToSettingsFile: string = `${
+		rootFolder
+	}${path.sep}.vscode/settings.json`;
 
-	fs.readFile(settingsFile, function (err: any, content: string) {
-		let parseJson: { [x: string]: { [x: string]: string; }; };
+	console.info('The path to the settings file is');
+	console.info(pathToSettingsFile);
+
+	fs.readFile(pathToSettingsFile, function (
+		err: any, content: string
+	) {
+		let parseJson: {
+			[x: string]: boolean | {
+				[x: string]: string;
+			};
+		};
+
 		try {
 			parseJson = JSON.parse(content);
 		} catch {
 			parseJson = {};
 		}
+		console.info('parseJson', parseJson);
+
 		let fileAssoc = parseJson['files.associations'];
 		if (fileAssoc === undefined) {
-			parseJson['files.associations'] = { '*.rsh': 'javascript' };
+			parseJson['files.associations'] = {
+				'*.rsh': 'javascript'
+			};
 		} else {
-			parseJson['files.associations']['*.rsh'] = 'javascript';
+			parseJson['files.associations']['*.rsh'] =
+				'javascript';
 		}
-		fs.writeFile(settingsFile, JSON.stringify(parseJson), function (err: any) {
+
+		let completeFunctionCalls = parseJson[
+			'javascript.suggest.completeFunctionCalls'
+		];
+		if (completeFunctionCalls !== undefined) {
+			// Respect users' preferences.
+			// If they already have this setting,
+			// don't modify it.
+		} else {
+			parseJson[
+				'javascript.suggest.completeFunctionCalls'
+			] = true;
+		}
+
+		fs.writeFile(pathToSettingsFile, JSON.stringify(
+			parseJson, null, 4
+		), function (err: any) {
 			if (err) {
-				console.error(`Could not create .vscode/settings.json: ${err}`);
+				console.error(
+					'Could not create ' +
+					'.vscode/settings.json' +
+					`: ${err}`
+				);
 				return;
+			} else {
+				console.info('Wrote to');
+				console.info(pathToSettingsFile);
+				console.info('successfully!');
 			}
 		});
 	});


### PR DESCRIPTION
The goal of this change is to prevent unhelpful auto-completion like `init(` automatically changing to `Infinity()`, `rsvp(` automatically changing to `PaymentRequestUpdateEvent()`, and `progress(` automatically changing to `ProgressEvent()`.

This change should also respect users' preferences if they want to change the default setting, i.e., it shouldn't "undo" changes they make in `.vscode/settings.json`.