### PR TITLE
Better Error Location For `evalApply`

### DIFF
--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -3792,12 +3792,7 @@ evalApply rator rands =
     SLV_Prim _ -> vals
     SLV_Clo {} -> vals
     SLV_Form f -> evalForm f rands
-    v -> do
-      fs <- e_stack <$> ask
-      let modAt = case fs of
-            [] -> id
-            h : _ -> locAt (srclocOf h)
-      modAt $ expect_t v $ Err_Eval_NotApplicable
+    v -> expect_t v $ Err_Eval_NotApplicable
   where
     vals = evalApplyVals' rator =<< evalExprs rands
 

--- a/hs/t/n/not_applicable_inside_only.rsh
+++ b/hs/t/n/not_applicable_inside_only.rsh
@@ -1,0 +1,11 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const A = Participant('A', { x: Bool });
+  init();
+  A.only(() => {
+    const x = declassify(interact.x);
+    const y = UInt(x);
+  });
+  A.publish(y);
+});

--- a/hs/t/n/not_applicable_inside_only.txt
+++ b/hs/t/n/not_applicable_inside_only.txt
@@ -1,0 +1,11 @@
+reachc: error[RE0035]: Invalid function application. Cannot apply: <SLV_Type>
+
+  ./not_applicable_inside_only.rsh:8:19:application
+
+  8|     const y = UInt(x);
+
+Trace:
+  in [unknown function] from (./not_applicable_inside_only.rsh:6:13:function exp) at (./not_applicable_inside_only.rsh:6:9:application)
+
+For further explanation of this error, see: https://docs.reach.sh/rsh/errors/#RE0035
+


### PR DESCRIPTION
Using the stack frame location gives weird positions. The stack frame will be traced anyway