### PR TITLE
Update rpc_server.ts

### DIFF
--- a/js/stdlib/ts/rpc_server.ts
+++ b/js/stdlib/ts/rpc_server.ts
@@ -135,8 +135,8 @@ export const mkStdlibProxy = async (lib: any, ks: any) => {
       return await lib.miniumBalanceOf(account.id(id));
     },
 
-    transfer: async (from: string, to: string, bal: any) =>
-      lib.transfer(account.id(from), account.id(to), bal),
+    transfer: async (from: string, to: string, bal: any, token?: any) =>
+      lib.transfer(account.id(from), account.id(to), bal, token),
 
     assert: (x: any) =>
       lib.assert(x),


### PR DESCRIPTION
<!--
Hey! Thanks so much!
-->

## Summary

<!-- Explain what you're trying to do in this pull request -->

The rpc server transfer function does not pass through the fourth argument (token: non-network token id) to the stdlib transfer function. This change adds the token argument for the non-token token id, which is needed to transfer non-network tokens.

<!-- DESIGN: Does this code have some deeper design concept that motivates it that is hard to understand just by reading the code? -->

No design changes

<!-- TESTING: How did you test this? Is there a new example? Do you have some test scenario you're using? -->

Untested

<!-- DOCS: Should there be a documentation or changelog update with this code? -->

No doc changes should be needed