### PR TITLE
alphabetize output of `reach help` for ease of use

### DIFF
--- a/hs/app/reach/Main.hs
+++ b/hs/app/reach/Main.hs
@@ -2469,23 +2469,23 @@ main = do
     _ -> pure []
   let header' = "reach " <> versionHashStr <> " - Reach command-line tool"
   let cs =
-        config
+        clean
           <> compile
-          <> clean
-          <> init' its
-          <> run'
-          <> down
-          <> scaffold
-          <> react
-          <> rpcServer
-          <> rpcRun
+          <> config
           <> devnet
-          <> info'
-          <> update
           <> dockerReset
-          <> version'
+          <> down
           <> hashes
           <> help'
+          <> info'
+          <> init' its
+          <> react
+          <> rpcRun
+          <> rpcServer
+          <> run'
+          <> scaffold
+          <> update
+          <> version'
   let hs =
         internal
           <> commandGroup "hidden subcommands"


### PR DESCRIPTION
<details>
<summary>Output without this change</summary>
<br>

```
hamir@WSL2:~/Reach-Rock-Paper-Scissors$ ./reach help
reach 0.1.9 (29d5aff2*) - Reach command-line tool

Usage: reach COMMAND

Available options:
  -h,--help                Show this help text

Available commands:
  config                   Configure default Reach settings
  compile                  Compile an app
  clean                    Delete 'build/$MODULE.$IDENT.mjs'
  init                     Set up source files for a simple app in the current
                           directory
  run                      Run a simple app
  down                     Halt all Dockerized Reach services and devnets
  scaffold                 Set up Docker scaffolding for a simple app in the
                           current directory
  react                    Run a simple React app
  rpc-server               Run a simple Reach RPC server
  rpc-run                  Run an RPC server + frontend with development
                           configuration
  devnet                   Run only the devnet
  info                     List available updates
  update                   Perform available updates
  docker-reset             Kill and remove all Docker containers
  version                  Display version
  hashes                   Display git hashes used to build each Docker image
  help                     Show usage
```
</details>
<details>
<summary>Screenshot without this change</summary>
<br>

![image](https://user-images.githubusercontent.com/43425812/161438931-4313453a-9495-46e4-ac59-2c10517cc2b5.png)
</details>
<br>
<details>
<summary>Output with this change</summary>
<br>

```
reach 0.1.9 - Reach command-line tool

Usage: reach COMMAND

Available options:
  -h,--help                Show this help text

Available commands:
  clean                    Delete 'build/$MODULE.$IDENT.mjs'
  compile                  Compile an app
  config                   Configure default Reach settings
  devnet                   Run only the devnet
  docker-reset             Kill and remove all Docker containers
  down                     Halt all Dockerized Reach services and devnets
  hashes                   Display git hashes used to build each Docker image
  help                     Show usage
  info                     List available updates
  init                     Set up source files for a simple app in the current
                           directory
  react                    Run a simple React app
  rpc-run                  Run an RPC server + frontend with development
                           configuration
  rpc-server               Run a simple Reach RPC server
  run                      Run a simple app
  scaffold                 Set up Docker scaffolding for a simple app in the
                           current directory
  update                   Perform available updates
  version                  Display version
```
</details>
<details>
<summary>Screenshot with this change</summary>
<br>

![image](https://user-images.githubusercontent.com/43425812/161439075-9734f1b1-2dd9-4e91-8e3a-31b269b88ef0.png)
</details>