### PR TITLE
fix: update text

### DIFF
--- a/docs/src/workshop/hash-lock/index.md
+++ b/docs/src/workshop/hash-lock/index.md
@@ -233,11 +233,6 @@ load: /examples/workshop-hash-lock/index.rsh
 + Lines 11-14 have Alice declassify some of her values.
 + Line 21 has Bob provide his password.
 
-:::note
-Did you notice that we didn't mention what line 5 is for?
-We'll discuss that in the next section; don't worry!
-:::
-
 At this point, when we
 
 ```cmd


### PR DESCRIPTION
Removed note about discussing line 5, the empty object, in `index.rsh`.