### PR TITLE
add walletFallback opt for existing wc client

### DIFF
--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -939,9 +939,10 @@ const walletFallback_MyAlgoWallet = (MyAlgoConnect: unknown, opts: object) => ()
   };
   return doWalletFallback_signOnly(opts, getAddr, signTxns);
 };
-const walletFallback_WalletConnect = (WalletConnect:any, opts:object) => (): ARC11_Wallet => {
+const walletFallback_WalletConnect = (WalletConnect:any, opts:any) => (): ARC11_Wallet => {
   debug(`using WalletConnect wallet fallback`);
   const wc = new WalletConnect();
+  if (opts.connector) wc.wc = opts.connector;
   return doWalletFallback_signOnly(opts, (() => wc.getAddr()), ((ts) => wc.signTxns(ts)));
 };
 export const walletFallback = (opts:any) => {


### PR DESCRIPTION
This change allows a WalletConnectClient object, instantiated outside of the Reach stdlib, to be passed to the walletFallback() function as follows:

```
import WalletConnect from '@walletconnect/client';
import { ALGO_WalletConnect } from '@reach-sh/stdlib';
let wcClient = new WalletConnect();
stdlib.setWalletFallback(stdlib.walletFallback({ providerEnv: 'TestNet', WalletConnect: ALGO_WalletConnect, connector: wcClient }));
```

<!--
Hey! Thanks so much!
-->

## Summary

<!-- Explain what you're trying to do in this pull request -->

The intention is to be able to pass an existing walletConnect client session (i.e. if a walletconnect session was recreated from browser session storage, or passed to a backend nodejs function) in place of a newly instantiated client session. I may have missed it, but I could not find another way to make this work.

<!-- DESIGN: Does this code have some deeper design concept that motivates it that is hard to understand just by reading the code? -->

It's born from a desire to be able to take an existing walletConnect session object from local browser storage, pass it to a backend nodejs function, re-create the client session, and then use that session within the reach standard library.

<!-- TESTING: How did you test this? Is there a new example? Do you have some test scenario you're using? -->

Testing was performed on a transpiled version of the ALGO.ts (ALGO.js) file with a nodejs backend with Google Cloud Functions. However the direct modification of the TypeScript file is untested.

<!-- DOCS: Should there be a documentation or changelog update with this code? -->

Documentation for WalletConnect should be updated with an example like the one above.