### PR TITLE
change logic for finding reach binary

### DIFF
--- a/reach
+++ b/reach
@@ -57,8 +57,9 @@ run_d () {
    && [ -d "$REACH_DIR_EMBED"  ] \
    && [ -f "$REACH_STACK_YAML" ] \
    && which stack >/dev/null 2>&1; then
-    export STACK_YAML="$REACH_STACK_YAML"
-    REACH_EX="$0" $(cd "${REACH_HS}" && make hs-build 1>&2 && stack exec -- which reach 2>/dev/null) \
+    make --silent --directory "$REACH_HS" hs-build 1>&2
+    REACH_BINARY="$(stack --stack-yaml "$REACH_STACK_YAML" exec -- which reach 2>/dev/null)"
+    REACH_EX="$0" "$REACH_BINARY" \
       --dir-embed="$REACH_DIR_EMBED" \
       --dir-project-container="$(pwd)" \
       --dir-project-host="$(pwd)" \


### PR DESCRIPTION
small improvement to reach script. removes the printing of a couple annoying lines when REACH_DOCKER=0