### PR TITLE
don't create missing golden files

### DIFF
--- a/hs/Makefile.docker
+++ b/hs/Makefile.docker
@@ -33,7 +33,7 @@ src/Reach/Version.hs: src/Reach/Version.mo.hs $(ROOT)/VERSION $(ROOT)/DEPS
 
 .PHONY: docker-test-xml
 docker-test-xml:
-	stack test $(MAYBE_FAST) --test-arguments '--xml=test-reports/junit.xml'
+	stack test $(MAYBE_FAST) --test-arguments '--xml=test-reports/junit.xml --no-create'
 
 .PHONY: docker-check
 docker-check:


### PR DESCRIPTION
note hs-test will still generate them
this change only affects ci's makefile target, docker-test-xml
