### PR TITLE
Core 1349 give more information about compilation status to developers

### DIFF
--- a/vsce/client/package-lock.json
+++ b/vsce/client/package-lock.json
@@ -12,17 +12,17 @@
 				"vscode-languageclient": "^7.0.0"
 			},
 			"devDependencies": {
-				"@types/vscode": "^1.52.0",
+				"@types/vscode": "^1.65.0",
 				"vscode-test": "^1.3.0"
 			},
 			"engines": {
-				"vscode": "^1.52.0"
+				"vscode": "^1.65.0"
 			}
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.62.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-			"integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
+			"version": "1.65.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
+			"integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
 			"dev": true
 		},
 		"node_modules/agent-base": {
@@ -256,9 +256,9 @@
 	},
 	"dependencies": {
 		"@types/vscode": {
-			"version": "1.62.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-			"integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
+			"version": "1.65.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
+			"integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
 			"dev": true
 		},
 		"agent-base": {

--- a/vsce/client/package.json
+++ b/vsce/client/package.json
@@ -10,13 +10,13 @@
 		"url": "https://github.com/reach-sh/reach-lang"
 	},
 	"engines": {
-		"vscode": "^1.52.0"
+		"vscode": "^1.65.0"
 	},
 	"dependencies": {
 		"vscode-languageclient": "^7.0.0"
 	},
 	"devDependencies": {
-		"@types/vscode": "^1.52.0",
+		"@types/vscode": "^1.65.0",
 		"vscode-test": "^1.3.0"
 	}
 }

--- a/vsce/client/src/constants.ts
+++ b/vsce/client/src/constants.ts
@@ -1,0 +1,9 @@
+// This should stay synchronized with server/src/constants.ts
+
+// e.g., sendNotification(For.commencedCompilation);
+export enum For {
+  commencedCompilation = 'comp_commenced',
+  completedCompilation = 'comp_completed',
+  errorDuringCompilation = 'error_during_compilation',
+  compilationCouldntCommence = 'comp_couldnt_commence',
+};

--- a/vsce/package.json
+++ b/vsce/package.json
@@ -25,7 +25,7 @@
         "conflux"
     ],
     "engines": {
-        "vscode": "^1.43.0"
+        "vscode": "^1.65.0"
     },
     "activationEvents": [
         "workspaceContains:**/*.rsh",

--- a/vsce/server/src/constants.ts
+++ b/vsce/server/src/constants.ts
@@ -1,0 +1,9 @@
+// This should stay synchronized with client/src/constants.ts
+
+// e.g., sendNotification(For.commencedCompilation);
+export enum For {
+  commencedCompilation = 'comp_commenced',
+  completedCompilation = 'comp_completed',
+  errorDuringCompilation = 'error_during_compilation',
+  compilationCouldntCommence = 'comp_couldnt_commence',
+};


### PR DESCRIPTION
This screen recording provides some context for why we want this change, up until around 2:05, after which it goes into what this change actually does.

It also has some audio if you want to hear additional information. You can watch it at 2x speed if your browser supports it.

The goal of this change is to provide a lot of useful information regarding compilation in a way that respects users' attention.

https://user-images.githubusercontent.com/43425812/163056056-7e022e41-f1a5-4923-ad1d-89f233588c16.mp4