### PR TITLE
js/cfx: walletFallback & mnem access

### DIFF
--- a/.circleci/config.pre.yml
+++ b/.circleci/config.pre.yml
@@ -371,6 +371,7 @@ workflows:
           - "build-sink"
           - "browser-tests.eth"
           - "browser-tests.algo"
+          - "browser-tests.cfx"
         filters:
           branches:
             only: master
@@ -389,6 +390,15 @@ workflows:
         devnet: "devnet-algo"
         requires:
           - "build-devnet-algo"
+          - "build-react-runner"
+          - "build-reach-cli"
+          - "build-reach"
+    - "browser-tests":
+        name: "browser-tests.cfx"
+        connector: "CFX"
+        devnet: "devnet-cfx"
+        requires:
+          - "build-devnet-cfx"
           - "build-react-runner"
           - "build-reach-cli"
           - "build-reach"

--- a/examples/rps-9-web/cypress.patch
+++ b/examples/rps-9-web/cypress.patch
@@ -1,5 +1,5 @@
 diff --git a/examples/rps-9-web/index.js b/examples/rps-9-web/index.js
-index 4b2705cea..72918d340 100644
+index 0d03c6139..c0a15576b 100644
 --- a/examples/rps-9-web/index.js
 +++ b/examples/rps-9-web/index.js
 @@ -7,6 +7,7 @@ import './index.css';
@@ -10,7 +10,15 @@ index 4b2705cea..72918d340 100644
  
  const handToInt = {'ROCK': 0, 'PAPER': 1, 'SCISSORS': 2};
  const intToOutcome = ['Bob wins!', 'Draw!', 'Alice wins!'];
-@@ -93,4 +94,19 @@ class Attacher extends Player {
+@@ -20,6 +21,7 @@ class App extends React.Component {
+   }
+   async componentDidMount() {
+     const acc = await reach.getDefaultAccount();
++    acc.setGasLimit(5000000);
+     const balAtomic = await reach.balanceOf(acc);
+     const bal = reach.formatCurrency(balAtomic, 4);
+     this.setState({acc, bal});
+@@ -93,4 +95,19 @@ class Attacher extends Player {
    render() { return renderView(this, AttacherViews); }
  }
  

--- a/hs/app/reach/Main.hs
+++ b/hs/app/reach/Main.hs
@@ -730,7 +730,7 @@ withCompose DockerMeta {..} wrapped = do
         (_, _, Live) -> []
         (WithProject Console _, ALGO, Devnet) -> ["9392"]
         (_, ALGO, _) -> ["4180:4180", "8980:8980", "9392:9392"]
-        (_, CFX, _) -> ["12537:12537"]
+        (_, CFX, _) -> ["12537:12537", "1337:1337"]
         (_, ETH, _) -> ["8545:8545"]
   let reachConnectorMode = packs cm
   let debug' = if debug then "1" else ""

--- a/scripts/devnet-cfx/faucet/index.mjs
+++ b/scripts/devnet-cfx/faucet/index.mjs
@@ -2,6 +2,7 @@ import Timeout from 'await-timeout';
 import cfxsdk from 'js-conflux-sdk';
 import { createServer } from 'http';
 import express from 'express';
+import cors from 'cors';
 import * as fs from 'fs';
 import toml from 'toml';
 import { Channel } from 'async-csp';
@@ -69,6 +70,7 @@ fund.consume(async ({to, value, res}) => {
 });
 
 const app = express();
+app.use(cors());
 app.use(express.json());
 app.get('*', (req, res, next) => {
   const { address: to, amount: value } = req.query;

--- a/scripts/devnet-cfx/faucet/package.json
+++ b/scripts/devnet-cfx/faucet/package.json
@@ -7,6 +7,7 @@
     "await-timeout": "^0.6.0",
     "toml": "^3.0.0",
     "express": "^4.17.1",
+    "cors": "^2.8.5",
     "async-csp": "^0.5.0",
     "js-conflux-sdk": "^1.7.3"
   },


### PR DESCRIPTION
* adds `walletFallback` for cfx
* fixes issues w/ accessing the faucet from a browser
* allows `unsafeGetMnemonic` to work for cfx wallets generated by the reach stdlib
* cypress tests now also run on cfx
