### PR TITLE
CORE-1418 fix tokenMetadata example races

### DIFF
--- a/examples/max-supply-precision/index.mjs
+++ b/examples/max-supply-precision/index.mjs
@@ -1,4 +1,5 @@
 import { loadStdlib } from "@reach-sh/stdlib";
+import * as backend from './build/index.main.mjs';
 const stdlib = loadStdlib();
 
 const sbal = stdlib.parseCurrency(100);
@@ -13,6 +14,12 @@ const assertEq = (a, e) => {
     throw Error(`Expected ${e}, got ${a}`);
   }
 };
+
+{ // sync indexer latest blocks token launch
+  const ctc = acc.contract(backend);
+  await ctc.p.Alice({});
+  await ctc.e.sync.next();
+}
 
 const mdA = await acc.tokenMetadata(tokA.id);
 

--- a/examples/max-supply-precision/index.mjs
+++ b/examples/max-supply-precision/index.mjs
@@ -15,7 +15,7 @@ const assertEq = (a, e) => {
   }
 };
 
-{ // sync indexer latest blocks token launch
+{ // sync indexer with latest blocks, so it can observe token metadata
   const ctc = acc.contract(backend);
   await ctc.p.Alice({});
   await ctc.e.sync.next();

--- a/examples/max-supply-precision/index.rsh
+++ b/examples/max-supply-precision/index.rsh
@@ -1,3 +1,10 @@
 'reach 0.1';
 
-export const main = Reach.App(() => {});
+export const main = Reach.App(() => {
+    const A = Participant('Alice', {});
+    const E = Events({ sync: [] });
+    init();
+    A.publish();
+    E.sync();
+    commit();
+});

--- a/examples/max-supply-precision/index.txt
+++ b/examples/max-supply-precision/index.txt
@@ -2,4 +2,4 @@ Verifying knowledge assertions
 Verifying for generic connector
   Verifying when ALL participants are honest
   Verifying when NO participants are honest
-Checked 0 theorems; No failures!
+Checked 4 theorems; No failures!

--- a/examples/mint-basic/index.mjs
+++ b/examples/mint-basic/index.mjs
@@ -30,6 +30,7 @@ import * as backend from './build/index.main.mjs';
       console.log(`${me}: ${tok} balance: ${fmt(await stdlib.balanceOf(acc, tok))}`);
     };
     const showToken = async (_tok, cmd) => {
+      await ctc.e.tokenLaunch.next();
       tok = _tok;
       console.log(`${me}: The token is: ${tok}`);
       await showBalance();

--- a/examples/mint-basic/index.rsh
+++ b/examples/mint-basic/index.rsh
@@ -17,6 +17,7 @@ export const main = Reach.App(() => {
   const B = Participant('Bob', {
     ...shared,
   });
+  const TLE = Events({ tokenLaunch: [] });
   init();
 
   A.only(() => {
@@ -30,6 +31,7 @@ export const main = Reach.App(() => {
 
   const md1 = {name, symbol, url, metadata, supply};
   const tok1 = new Token(md1);
+  TLE.tokenLaunch();
   A.interact.showToken(tok1, md1);
   commit();
 
@@ -56,6 +58,7 @@ export const main = Reach.App(() => {
 
   const md2 = {name, symbol};
   const tok2 = new Token(md2);
+  TLE.tokenLaunch();
   A.interact.showToken(tok2, md2);
   B.interact.showToken(tok2, md2);
   commit();

--- a/examples/rpc-mint-basic/index.mjs
+++ b/examples/rpc-mint-basic/index.mjs
@@ -32,6 +32,7 @@ const go = async ({ role, ctc, acc }) => {
   };
 
   const showToken = async (_tok, cmd) => {
+    await rpc('/ctc/events/tokenLaunch/next', ctc);
     tok = _tok;
     console.log(`${r}: The token is: ${JSON.stringify(tok)}.`);
     await showBalance();

--- a/examples/rpc-token-decimals/index.mjs
+++ b/examples/rpc-token-decimals/index.mjs
@@ -11,6 +11,7 @@ const decimals              = 5;
 await rpcCallbacks('/backend/Alice', ctcAlice, {
   decimals,
   checkDecimals: async (tokId) => {
+    await rpc('/ctc/e/tokenLaunch/next', ctcAlice);
     const m = await rpc('/acc/tokenMetadata', accAlice, tokId);
     const d = a => rpc('/stdlib/bigNumberToNumber', a);
     assertEq('Metadata decimals should match', await d(m.decimals), await d(decimals));

--- a/examples/token-decimals/index.mjs
+++ b/examples/token-decimals/index.mjs
@@ -2,22 +2,23 @@ import {loadStdlib} from '@reach-sh/stdlib';
 import * as backend from './build/index.main.mjs';
 const stdlib = loadStdlib(process.env);
 
-  const startingBalance = stdlib.parseCurrency(100);
+const startingBalance = stdlib.parseCurrency(100);
 
-  const [ accAlice ] =
-    await stdlib.newTestAccounts(1, startingBalance);
+const [ accAlice ] =
+  await stdlib.newTestAccounts(1, startingBalance);
 
-  const ctcAlice = accAlice.contract(backend);
+const ctcAlice = accAlice.contract(backend);
 
-  const decimals = 5;
+const decimals = 5;
 
-  await Promise.all([
-    backend.Alice(ctcAlice, {
-      decimals,
-      checkDecimals: async (tokId) => {
-        const meta = await accAlice.tokenMetadata(tokId);
-        console.assert(meta.decimals.toNumber() === decimals);
-        console.log(`Token has ${decimals} decimals.`);
-      }
-    }),
-  ]);
+await Promise.all([
+  backend.Alice(ctcAlice, {
+    decimals,
+    checkDecimals: async (tokId) => {
+      await ctcAlice.e.tokenLaunch.next();
+      const meta = await accAlice.tokenMetadata(tokId);
+      console.assert(meta.decimals.toNumber() === decimals);
+      console.log(`Token has ${decimals} decimals.`);
+    }
+  }),
+]);

--- a/examples/token-decimals/index.rsh
+++ b/examples/token-decimals/index.rsh
@@ -5,6 +5,7 @@ export const main = Reach.App(() => {
     checkDecimals: Fun(true, Null),
     decimals: UInt,
   });
+  const TLE = Events({ tokenLaunch: [] });
   init();
 
   A.only(() => {
@@ -14,6 +15,7 @@ export const main = Reach.App(() => {
 
   const supply = UInt.max;
   const t = new Token({ supply, decimals });
+  TLE.tokenLaunch();
 
   commit();
   A.interact.checkDecimals(t);

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -638,7 +638,7 @@ const doQueryM_ = async <T>(dhead:string, query: ApiCall<T>): Promise<OrExn<T>> 
   }
 };
 
-const doQuery_ = async <T>(dhead:string, query: ApiCall<T>, howMany: number = 0, failOk:((e:any, howMany:number) => OrExn<T>) = ((exn:any, howMany:number) => { void howMany; return { exn }; })): Promise<T> => {
+const doQuery_ = async <T>(dhead:string, query: ApiCall<T>, howMany: number = 0, failOk:((e:any) => OrExn<T>) = ((exn:any) => { return { exn }; })): Promise<T> => {
   debug(dhead, query.query);
   while ( true ) {
     if ( howMany > 0 ) {
@@ -653,7 +653,7 @@ const doQuery_ = async <T>(dhead:string, query: ApiCall<T>, howMany: number = 0,
         debug(dhead, 'ACCOUNTING NOT INITIALIZED');
       }
       if ( e?.response?.text ) { e = e.response.text; }
-      const fr = failOk(e, howMany);
+      const fr = failOk(e);
       if ( 'exn' in fr ) {
         debug(dhead, 'RETRYING', {e});
         howMany++;
@@ -1205,8 +1205,7 @@ const getAccountInfo = async (a:Address): Promise<AccountInfo> => {
   }
   const indexer = await getIndexer();
   const q = indexer.lookupAccountByID(a) as unknown as ApiCall<IndexerAccountInfoRes>;
-  const failOk = (x:any, howMany:number): OrExn<IndexerAccountInfoRes> => {
-    void howMany;
+  const failOk = (x:any): OrExn<IndexerAccountInfoRes> => {
     if ( typeof x === 'string' && x.includes('no accounts found for address') ) {
       return { val: {
         'current-round': BigInt(0),
@@ -1227,11 +1226,8 @@ const getAssetInfo = async (a:number): Promise<AssetInfo> => {
   const dhead = 'getAssetInfo';
   const indexer = await getIndexer();
   const q = indexer.lookupAssetByID(a) as unknown as ApiCall<IndexerAssetInfoRes>;
-  const failOk = (x:any, howMany:number): OrExn<IndexerAssetInfoRes> => {
-    // XXX This howMany > 10 is for tests. Maybe it would be better to
-    // synchronize in the test with the indexer observing an event or use a
-    // network wait.
-    if ( howMany > 10 && typeof x === 'string' && x.includes('no assets found for asset-id') ) {
+  const failOk = (x:any): OrExn<IndexerAssetInfoRes> => {
+    if (typeof x === 'string' && x.includes('no assets found for asset-id') ) {
       throw Error(`Asset ${a} does not exist`);
     } else {
       return { exn: x };

--- a/js/stdlib/ts/rpc_server.ts
+++ b/js/stdlib/ts/rpc_server.ts
@@ -478,6 +478,9 @@ export const serveRpc = async (backend: any) => {
   app.use(`/ctc/apis`,        mkUserDefined('/ctc/apis',        'apis',        contract, true));
   app.use(`/ctc/safeApis`,    mkUserDefined('/ctc/safeApis',    'safeApis',    contract, false));
 
+  app.use(`/ctc/e`,           mkUserDefined('/ctc/e',           'e',           contract, true));
+  app.use(`/ctc/events`,      mkUserDefined('/ctc/events',      'events',      contract, true));
+
   // NOTE: it's important these are deferred in order to preserve middleware precedence
   for (const p in ctcPs) { app.use(p, ctcPs[p]); }
 


### PR DESCRIPTION
Added events to each racey example contract to sync the indexer. As a bonus, threw events into the rpc server. Inferred from surrounding code how to do it; maybe it's not a good implementation. If so I will redo the rpc examples and remove that change. 

I feel the fact that the stdlib can fall out of sync with itself, like in `max-supply-precision`, would be surprising from a user's perspective. It bubbles up the implementation details to viable race conditions in algo frontends. Strikes me as bad form.