### PR TITLE
CORE-1434 add compiler flag to quit after first verification fail

### DIFF
--- a/docs/src/changelog/index.md
+++ b/docs/src/changelog/index.md
@@ -7,6 +7,7 @@ Versions and changes-within-versions are listed in reverse-chronological order: 
 
 Version 0.1.10 is the current Reach release candidate version.
 
++ 2022/04/22: Added `--verify-fail-once` flag to @{seclink("ref-usage-compile")} to only print the first verification failure produced by a program.
 + 2022/04/19: Added `{!js} withDisconnect` and `{!js} disconnect` to help participant frontends disconnect early from a contract.
 + 2022/04/18: Added `{!rsh} Contract.addressEq`.
 + 2022/04/18: Added `{!rsh} remote.ALGO`.

--- a/docs/src/tool/index.md
+++ b/docs/src/tool/index.md
@@ -133,6 +133,9 @@ The output name of a library is the same as if it exported a `{!rsh} Reach.App` 
 + `--verify-timeout` `TIMEOUT-MS` --- Sets the timeout of individual verification theorems, in milliseconds.
   The default value is 2 minutes.
 
++ `--verify-fail-once` --- Stops the compilation process after printing a single verification failure.
+  This may help keep you organized while fixing verification failures in your program.
+
 + The environment variable `{!cmd} REACH_DEBUG`, if set to any non-empty value, enables debug messages from the Reach compiler, which will appear in the console.
   This debug information includes: the estimated cost of the contract on Algorand.
   This variable automatically enables `--intermediate-files`.

--- a/hs/src/Reach/CommandLine.hs
+++ b/hs/src/Reach/CommandLine.hs
@@ -79,8 +79,8 @@ compiler =
                   (long "sim"
                      <> help "Run Simulator"))
            <*> (switch
-                  (long "first-fail-quit"
-                     <> help "Quit after printing the first verification failure")))
+                  (long "verify-fail-once"
+                     <> help "Quit after a single verification failure")))
 
 getCompilerArgs :: String -> IO CompilerToolArgs
 getCompilerArgs versionCliDisp = do

--- a/hs/src/Reach/CommandLine.hs
+++ b/hs/src/Reach/CommandLine.hs
@@ -31,6 +31,7 @@ data CompilerOpts = CompilerOpts
   , co_printKeywordInfo :: Bool
   , co_verifyTimeout :: Integer
   , co_sim :: Bool
+  , co_verifyFirstFailQuit :: Bool
   }
 
 compiler :: Parser CompilerToolArgs
@@ -76,7 +77,10 @@ compiler =
                      <> showDefault))
            <*> (switch
                   (long "sim"
-                     <> help "Run Simulator")))
+                     <> help "Run Simulator"))
+           <*> (switch
+                  (long "first-fail-quit"
+                     <> help "Quit after printing the first verification failure")))
 
 getCompilerArgs :: String -> IO CompilerToolArgs
 getCompilerArgs versionCliDisp = do

--- a/hs/src/Reach/Compiler.hs
+++ b/hs/src/Reach/Compiler.hs
@@ -89,6 +89,7 @@ compile env (CompilerOpts {..}) = do
         let vo_mvcs = doIf connectors dlo_verifyPerConnector
         let vo_timeout = co_verifyTimeout
         let vo_dir = dirDotReach'
+        let vo_first_fail_quit = co_verifyFirstFailQuit
         verify (VerifyOpts {..}) ol >>= maybeDie
         el <- erase_logic ol
         showp "el" el

--- a/hs/src/Reach/Verify/SMT.hs
+++ b/hs/src/Reach/Verify/SMT.hs
@@ -646,6 +646,8 @@ display_fail tat f tk mmsg mrd mdv timeout = do
             []
             (M.toList pm_str_val)
       iputStrLn $ show $ showTrace pm_dv_val smtTrace
+  when vo_first_fail_quit $
+    liftIO $ exitWith $ ExitFailure 1
 
 dropConstants :: M.Map String SMTVal -> [SMTLet] -> [SMTLet]
 dropConstants pm = \case

--- a/hs/src/Reach/Verify/Shared.hs
+++ b/hs/src/Reach/Verify/Shared.hs
@@ -13,6 +13,7 @@ data VerifyOpts = VerifyOpts
   , vo_mvcs :: Maybe [Connector]
   , vo_timeout :: Integer
   , vo_dir :: FilePath
+  , vo_first_fail_quit :: Bool
   }
 
 data VerifySt = VerifySt


### PR DESCRIPTION
flag is `--first-fail-quit`. better name? should it also count knowledge verification fails?