### PR TITLE
DCT-309 

### DIFF
--- a/docs/src/rsh/errors/index.md
+++ b/docs/src/rsh/errors/index.md
@@ -1735,7 +1735,7 @@ const s = Struct([["x", UInt], ["y", UInt], ["x2", UInt]]);
 
 This error indicates that you are attempting to export a name that the
 Reach backend already produces. For example, the names provided in `{!rsh} Participant`,
-`{!rsh} ParticipantClass`, and `{!rsh} View` will be exported by the Reach backend.
+`{!rsh} API`, and `{!rsh} View` will be exported by the Reach backend.
 
 Reach exports a few names from the backend automatically, such as `{!rsh} getExports`.
 Therefore, you cannot export a `{!rsh} Participant` named `{!rsh} getExports` as such:

--- a/docs/src/rsh/errors/index.md
+++ b/docs/src/rsh/errors/index.md
@@ -1734,8 +1734,7 @@ const s = Struct([["x", UInt], ["y", UInt], ["x2", UInt]]);
 ## {#RE0098} RE0098
 
 This error indicates that you are attempting to export a name that the
-Reach backend already produces. For example, the names provided in `{!rsh} Participant`,
-`{!rsh} API`, and `{!rsh} View` will be exported by the Reach backend.
+Reach backend already produces. For example, the names provided in `{!rsh} Participant`, `{!rsh} ParticipantClass`, `{!rsh} API`, and `{!rsh} View` will be exported by the Reach backend.
 
 Reach exports a few names from the backend automatically, such as `{!rsh} getExports`.
 Therefore, you cannot export a `{!rsh} Participant` named `{!rsh} getExports` as such:


### PR DESCRIPTION
Error Message 98

Replaced `ParticipantClass` with `API`