### PR TITLE
improve error handling when updating via extension

### DIFF
--- a/vsce/client/src/util/update.ts
+++ b/vsce/client/src/util/update.ts
@@ -105,21 +105,15 @@ const UPDATE_SCRIPT_AND_CLI_IMAGE_USING = (
 ) => {
   try {
     execSync('docker pull "reachsh/reach-cli:latest"');
-  } catch (error) {
-    return error;
-  }
 
-  try {
     execSync(`curl https://docs.reach.sh/reach -o "${
       pathToScript
     }"`);
-  } catch (error) {
-    return error;
-  }
 
-  try {
     execSync(`chmod +x "${pathToScript}"`);
+
   } catch (error) {
+
     return error;
   }
 

--- a/vsce/package-lock.json
+++ b/vsce/package-lock.json
@@ -22,7 +22,7 @@
                 "webpack-cli": "^4.9.1"
             },
             "engines": {
-                "vscode": "^1.43.0"
+                "vscode": "^1.65.0"
             }
         },
         "node_modules/@discoveryjs/json-ext": {


### PR DESCRIPTION
# Without this change

If something goes wrong during the

```ts
execSync(
  'docker pull "reachsh/reach-cli:latest" ' +
  `&& curl https://docs.reach.sh/reach -o "${
    pathToScript
  }" && chmod +x "${pathToScript}"`
);
```

step, the user interface just hangs.

https://user-images.githubusercontent.com/43425812/164503220-39f2ad99-9ece-4991-9ef2-81d5767523ba.mp4

# With this change

The user interface should update with an error notification if an error occurs, instead of just "hanging". I also split that big

```ts
execSync(
  'docker pull "reachsh/reach-cli:latest" ' +
  `&& curl https://docs.reach.sh/reach -o "${
    pathToScript
  }" && chmod +x "${pathToScript}"`
);
```

command into its three pieces for a more fine-grained approach, to hopefully help us troubleshoot things.

Both screen recordings should have audio, so feel free to unmute them for additional information.

https://user-images.githubusercontent.com/43425812/164503236-1f4a8e95-b23a-47fa-8dd2-444bd5de21f5.mp4