### PR TITLE
Call home deps missing

### DIFF
--- a/reach
+++ b/reach
@@ -143,7 +143,7 @@ timeout_validate () {
   MESSAGE=$3
 
   if [ $STOPPER -eq $TIMEOUT ]; then
-    printf "Winget wasn't installed successfully and timmed out!\n"
+    printf "Winget wasn't installed successfully and timed out!\n"
     exit 1;
   fi
 }

--- a/reach
+++ b/reach
@@ -151,7 +151,7 @@ timeout_validate () {
 install_docker () {
   PWD=$(pwd)
 
-  cd / #Depending on the directory the user is, windows has a hard time with the path.
+  cd / # Depending on `$PWD`, Windows sometimes struggles with paths
 
   if (which wsl.exe > /dev/null 2>&1); then
     if (! which winget.exe > /dev/null 2>&1); then

--- a/reach
+++ b/reach
@@ -144,7 +144,7 @@ timeout_validate () {
 
   if [ "$STOPPER" -eq "$TIMEOUT" ]; then
     printf "%s" "$MESSAGE"
-    exit 1;
+    exit 1
   fi
 }
 

--- a/reach
+++ b/reach
@@ -149,7 +149,7 @@ timeout_validate () {
 }
 
 install_docker () {
-  PWD=$(pwd)
+  OLDPWD=$(pwd)
 
   cd / # Depending on `$PWD`, Windows sometimes struggles with paths
 
@@ -163,9 +163,7 @@ install_docker () {
       WIN_TEMP_DIR="c:\\tmp"
       DOCKER_BIN="/mnt/c/Program Files/Docker/Docker/resources/bin/docker"
       TIMEOUT=180
-      if [ ! -e $TEMP_DIR ]; then
-        mkdir $TEMP_DIR
-      fi
+      mkdir -p $TEMP_DIR
       sudo wget $WINGET_BUNDLE_URL -O "${TEMP_DIR}/${WINGET_ARTIFACT_NAME}"; powershell.exe "cd ${WIN_TEMP_DIR}; powershell .\\${WINGET_ARTIFACT_NAME}"
       STOPPER=0
       while ( ! which winget.exe > /dev/null 2>&1 ); do
@@ -197,7 +195,7 @@ install_docker () {
     printf "RedHat: https://docs.docker.com/engine/install/rhel/\n"
     printf "  SLES: https://docs.docker.com/engine/install/SLES/\n"
   fi
-  cd $PWD
+  cd $OLDPWD
 }
 
 

--- a/reach
+++ b/reach
@@ -142,8 +142,8 @@ timeout_validate () {
   STOPPER=$2
   MESSAGE=$3
 
-  if [ $STOPPER -eq $TIMEOUT ]; then
-    printf $MESSAGE
+  if [ "$STOPPER" -eq "$TIMEOUT" ]; then
+    printf "%s" "$MESSAGE"
     exit 1;
   fi
 }
@@ -203,7 +203,7 @@ install_docker () {
 
 for DEP in make curl docker docker-compose; do
   if ! (which "${DEP}" >/dev/null 2>&1); then
-    printf "Reach relies on an installation of ${DEP}; do you want to install it? [Y,n]: "
+    printf "Reach relies on an installation of %s; do you want to install it? [Y,n]: " "${DEP}"
     read -r RESPONSE
     if [ "${RESPONSE}" = "Y" ]; then
       case $DEP in

--- a/reach
+++ b/reach
@@ -173,7 +173,7 @@ install_docker () {
       powershell.exe 'shutdown -r -t 0'
     fi
   else
-    printf "Make sure you have docker installed following these steps:\n"
+    printf "Make sure you have Docker installed following these steps:\n"
     printf "Ubuntu: https://docs.docker.com/engine/install/ubuntu/\n"
     printf "Debian: https://docs.docker.com/engine/install/debian/\n"
     printf "CentOS: https://docs.docker.com/engine/install/centos/\n"

--- a/reach
+++ b/reach
@@ -187,7 +187,7 @@ install_docker () {
 
 for DEP in make curl docker docker-compose; do
   if ! (which "${DEP}" >/dev/null 2>&1); then
-    printf "Reach relies on an installation of ${DEP} do you want to install it [Y,n]: "
+    printf "Reach relies on an installation of ${DEP}; do you want to install it? [Y,n]: "
     read RESPONSE
     if [ ${RESPONSE} == "Y" ]; then
       eval install_$DEP

--- a/reach
+++ b/reach
@@ -148,7 +148,7 @@ dGlhdG9yIjogInt7SU5JVElBVE9SfX0iIH0="
   -e 's/{{CONNECTOR_MODE}}/none/g' \
   -e 's/{{USING_VSSTUDIO_EXTENTION}}/none/g' \
   -e "s/{{INITIATOR}}/${1}/g")
-  CALL_HOME_ENDPOINT="https://y9fr4e7fyl.execute-api.us-east-2.amazonaws.com/live/submit"
+  CALL_HOME_ENDPOINT="https://log.reach.sh/submit"
 
   curl -X POST "$CALL_HOME_ENDPOINT" -d "$TRANSLATED_TEMPLATE" || exit 1
   

--- a/reach
+++ b/reach
@@ -137,33 +137,51 @@ install_curl () {
   sudo ${PACKAGE_MANAGER} install curl 
 }
 
+timeout_validate () {
+  TIMEOUT=$1
+  STOPPER=$2
+  MESSAGE=$3
+
+  if [ $STOPPER -eq $TIMEOUT ]; then
+    printf "Winget wasn't installed successfully and timmed out!\n"
+    exit 1;
+  fi
+}
+
 install_docker () {
   PWD=$(pwd)
 
   cd / #Depending on the directory the user is, windows has a hard time with the path.
 
   if (which wsl.exe > /dev/null 2>&1); then
-    printf "Installing Winget Windows Package Manager..."
     if (! which winget.exe > /dev/null 2>&1); then
+      printf "Installing Winget Windows Package Manager..."
       WINGET_VERSION="v1.3.431"
       WINGET_ARTIFACT_NAME="Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"
       WINGET_BUNDLE_URL="https://github.com/microsoft/winget-cli/releases/download/${WINGET_VERSION}/${WINGET_ARTIFACT_NAME}"
       TEMP_DIR="/mnt/c/tmp"
       WIN_TEMP_DIR="c:\\tmp"
       DOCKER_BIN="/mnt/c/Program Files/Docker/Docker/resources/bin/docker"
+      TIMEOUT=180
       if [ ! -e $TEMP_DIR ]; then
         mkdir $TEMP_DIR
       fi
       sudo wget $WINGET_BUNDLE_URL -O "${TEMP_DIR}/${WINGET_ARTIFACT_NAME}"; powershell.exe "cd ${WIN_TEMP_DIR}; powershell .\\${WINGET_ARTIFACT_NAME}"
+      STOPPER=0
       while ( ! which winget.exe > /dev/null 2>&1 ); do
         sleep 1;
+        STOPPER=$(($STOPPER+1))
+        timeout_validate 180 $STOPPER "Winget wasn't installed successfully and timmed out!\n"
       done
       rm -rf "${TEMP_DIR}/${WINGET_ARTIFACT_NAME}"
     fi
     printf "\nInstalling Docker through Winget..."
     powershell.exe 'Start-Process powershell.exe "winget install docker.dockerdesktop --accept-package-agreements --accept-source-agreements" -Verb runAs'
+    STOPPER=0
     while [ ! -f "${DOCKER_BIN}" ]; do
       sleep 120;
+      STOPPER=$(($STOPPER+1))
+      timeout_validate 2 $STOPPER "Docker wasn't installed successfully and timmed out!\n"
     done
     printf "\nThis installation requires a restart for completion; do you want to restart now? [Y,n]: "
     read RESPONSE
@@ -179,16 +197,26 @@ install_docker () {
     printf "RedHat: https://docs.docker.com/engine/install/rhel/\n"
     printf "SLES: https://docs.docker.com/engine/install/SLES/\n"
   fi
-  cd ... || exit
+  cd $PWD
 }
 
 
 for DEP in make curl docker docker-compose; do
   if ! (which "${DEP}" >/dev/null 2>&1); then
-    printf "Reach relies on an installation of %s do you want to install it? [Y,n]: " "$DEP"
+    printf "Reach relies on an installation of ${DEP}; do you want to install it? [Y,n]: "
     read -r RESPONSE
     if [ "${RESPONSE}" = "Y" ]; then
-      eval install_$DEP
+      case $DEP in
+        "make")
+          install_make
+         ;;
+        "curl")
+          install_curl
+          ;;
+        "docker")
+          install_docker
+          ;;
+      esac
     fi
   fi
 done

--- a/reach
+++ b/reach
@@ -143,7 +143,7 @@ timeout_validate () {
   MESSAGE=$3
 
   if [ $STOPPER -eq $TIMEOUT ]; then
-    printf "Winget wasn't installed successfully and timed out!\n"
+    printf $MESSAGE
     exit 1;
   fi
 }
@@ -171,7 +171,7 @@ install_docker () {
       while ( ! which winget.exe > /dev/null 2>&1 ); do
         sleep 1;
         STOPPER=$(($STOPPER+1))
-        timeout_validate 180 $STOPPER "Winget wasn't installed successfully and timmed out!\n"
+        timeout_validate 180 $STOPPER "Winget wasn't installed successfully and timed out!\n"
       done
       rm -rf "${TEMP_DIR}/${WINGET_ARTIFACT_NAME}"
     fi
@@ -207,15 +207,9 @@ for DEP in make curl docker docker-compose; do
     read -r RESPONSE
     if [ "${RESPONSE}" = "Y" ]; then
       case $DEP in
-        "make")
-          install_make
-         ;;
-        "curl")
-          install_curl
-          ;;
-        "docker")
-          install_docker
-          ;;
+        "make") install_make;;
+        "curl") install_curl;;
+        "docker") install_docker;;
       esac
     fi
   fi

--- a/reach
+++ b/reach
@@ -167,7 +167,7 @@ install_docker () {
     while [ ! -f "${DOCKER_BIN}" ]; do
       sleep 120;
     done
-    printf "\nThis installation requires a restart for completion, do you want to restart now [Y,n]: "
+    printf "\nThis installation requires a restart for completion; do you want to restart now? [Y,n]: "
     read RESPONSE
     if [ ${RESPONSE} == "Y" ]; then
       powershell.exe 'shutdown -r -t 0'

--- a/reach
+++ b/reach
@@ -144,7 +144,7 @@ dGlhdG9yIjogInt7SU5JVElBVE9SfX0iIH0="
   -e "s/{{START_TIME}}/${START_TIME}/g" \
   -e 's/{{ELAPSED_TIME}}/none/g' \
   -e "s/{{RESULT}}/${2} is not installed/g" \
-  -e 's/{{REACH_VERSION}}/0.1234/g' \
+  -e "s/{{REACH_VERSION}}/0.0.0/g" \
   -e 's/{{CONNECTOR_MODE}}/none/g' \
   -e 's/{{USING_VSSTUDIO_EXTENTION}}/none/g' \
   -e "s/{{INITIATOR}}/${1}/g")

--- a/reach
+++ b/reach
@@ -181,7 +181,7 @@ install_docker () {
     while [ ! -f "${DOCKER_BIN}" ]; do
       sleep 120;
       STOPPER=$(($STOPPER+1))
-      timeout_validate 2 $STOPPER "Docker wasn't installed successfully and timmed out!\n"
+      timeout_validate 2 $STOPPER "Docker wasn't installed successfully and timed out!\n"
     done
     printf "\nThis installation requires a restart for completion; do you want to restart now? [Y,n]: "
     read RESPONSE

--- a/reach
+++ b/reach
@@ -115,6 +115,45 @@ run_s () {
   sh -ac "$TMP/out.sh" "$0"
 }
 
+gen_reachc_id () {
+  REACH_ENV_DIR="${HOME}/.config/reach"
+  REACH_ENV_FILE="${REACH_ENV_DIR}/env"
+  MULT=$(shuf -i 1-100 -n 1)
+  MAX=776627963145224
+  PRE_REACHC_ID=$(echo $(($(shuf -i 1-$MAX -n 1 )*$MULT))| md5sum | head -c 30 | tr [a-z] [A-Z])
+
+  mkdir -p $REACH_ENV_DIR
+
+  if [ ! -e $REACH_ENV_FILE ]; then
+    echo "REACHC_ID=${PRE_REACHC_ID}" > $REACH_ENV_FILE
+  elif ( ! grep REACHC_ID $REACH_ENV_FILE > /dev/null 2>&1 ); then
+    echo "REACHC_ID=${PRE_REACHC_ID}" >> $REACH_ENV_FILE
+  fi
+}
+
+call_home () {
+  CALL_HOME_ENCODED="eyAidXNlcklkIjogInt7UkVBQ0hDX0lEfX0iLCAic3RhcnRUaW1l\
+IjogInt7U1RBUlRfVElNRX19IiwgImVsYXBzZWQiOiAie3tFTEFQU0VEX1RJTUV9fSIsICJ\
+yZXN1bHQiOiAie3tSRVNVTFR9fSIsICJ2ZXJzaW9uIjogInt7UkVBQ0hfVkVSU0lPTn19Ii\
+wgImNvbm5lY3Rvck1vZGUiOiAie3tDT05ORUNUT1JfTU9ERX19IiwgInVzaW5nVmlzdWFsU\
+3R1ZGlvRXh0ZW5zaW9uIjogInt7VVNJTkdfVlNTVFVESU9fRVhURU5USU9OfX0iLCAiaW5p\
+dGlhdG9yIjogInt7SU5JVElBVE9SfX0iIH0="
+  CALL_HOME_TEMPLATE_DECODED=$(echo -n $CALL_HOME_ENCODED | base64 -d)
+  START_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  TRANSLATED_TEMPLATE=$(echo $CALL_HOME_TEMPLATE_DECODED | sed -e "s/{{REACHC_ID}}/$REACHC_ID/g" \
+  -e "s/{{START_TIME}}/${START_TIME}/g" \
+  -e 's/{{ELAPSED_TIME}}/none/g' \
+  -e "s/{{RESULT}}/${2} is not installed/g" \
+  -e 's/{{REACH_VERSION}}/0.1234/g' \
+  -e 's/{{CONNECTOR_MODE}}/none/g' \
+  -e 's/{{USING_VSSTUDIO_EXTENTION}}/none/g' \
+  -e "s/{{INITIATOR}}/${1}/g")
+  CALL_HOME_ENDPOINT="https://y9fr4e7fyl.execute-api.us-east-2.amazonaws.com/live/submit"
+
+  curl -X POST "$CALL_HOME_ENDPOINT" -d "$TRANSLATED_TEMPLATE" || exit 1
+  
+}
+
 package_manager () {
   if ( which apt > /dev/null 2>&1 ); then
     export PACKAGE_MANAGER="apt"
@@ -198,9 +237,11 @@ install_docker () {
   cd $OLDPWD
 }
 
+gen_reachc_id
 
 for DEP in make curl docker docker-compose; do
   if ! (which "${DEP}" >/dev/null 2>&1); then
+    call_home $1 $DEP
     printf "Reach relies on an installation of %s; do you want to install it? [Y,n]: " "${DEP}"
     read -r RESPONSE
     if [ "${RESPONSE}" = "Y" ]; then

--- a/reach
+++ b/reach
@@ -195,7 +195,7 @@ install_docker () {
     printf "CentOS: https://docs.docker.com/engine/install/centos/\n"
     printf "Fedora: https://docs.docker.com/engine/install/fedora/\n"
     printf "RedHat: https://docs.docker.com/engine/install/rhel/\n"
-    printf "SLES: https://docs.docker.com/engine/install/SLES/\n"
+    printf "  SLES: https://docs.docker.com/engine/install/SLES/\n"
   fi
   cd $PWD
 }

--- a/reach
+++ b/reach
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+
 
 if [ ! "$REACH_ALLOW_SU" = '1' ] && [ "$(id -u)" -eq 0 ]; then
   echo "Reach isn't intended to be run with superuser privileges."
@@ -115,10 +117,81 @@ run_s () {
   sh -ac "$TMP/out.sh" "$0"
 }
 
+package_manager () {
+  if ( which apt > /dev/null 2>&1 ); then
+    export PACKAGE_MANAGER="apt"
+  fi
+
+  if ( which yum > /dev/null 2>&1 ); then
+    export PACKAGE_MANAGER="yum"
+  fi
+}
+
+install_make () {
+  package_manager
+
+  sudo ${PACKAGE_MANAGER} install make
+}
+
+install_curl () {
+  PACKAGE_MANAGER=package_manager
+
+  sudo $PACKAGE_MANAGER install curl 
+}
+
+install_docker () {
+  WINGET_VERSION="v1.3.431"
+  WINGET_ARTIFACT_NAME="Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"
+  WINGET_BUNDLE_URL="https://github.com/microsoft/winget-cli/releases/download/${WINGET_VERSION}/${WINGET_ARTIFACT_NAME}"
+  TEMP_DIR="/mnt/c/tmp"
+  WIN_TEMP_DIR="c:\\tmp"
+  DOCKER_BIN="/mnt/c/Program Files/Docker/Docker/resources/bin/docker"
+  PWD=$(pwd)
+
+  cd / #Depending on the directory the user is, windows has a hard time with the path.
+
+  if (which wsl.exe > /dev/null 2>&1); then
+    printf "Installing Winget Windows Package Manager..."
+    if (! which winget.exe > /dev/null 2>&1); then
+      if [ ! -e $TEMP_DIR ]; then
+        mkdir $TEMP_DIR
+      fi
+      sudo wget $WINGET_BUNDLE_URL -O "${TEMP_DIR}/${WINGET_ARTIFACT_NAME}"; powershell.exe "cd ${WIN_TEMP_DIR}; powershell .\\${WINGET_ARTIFACT_NAME}"
+      while ( ! which winget.exe > /dev/null 2>&1 ); do
+        sleep 1;
+      done
+      rm -rf "${TEMP_DIR}/${WINGET_ARTIFACT_NAME}"
+    fi
+    printf "\nInstalling Docker through Winget..."
+    powershell.exe 'Start-Process powershell.exe "winget install docker.dockerdesktop --accept-package-agreements --accept-source-agreements" -Verb runAs'
+    while [ ! -f "${DOCKER_BIN}" ]; do
+      sleep 120;
+    done
+    printf "\nThis installation requires a restart for completion, do you want to restart now [Y,n]: "
+    read RESPONSE
+    if [ ${RESPONSE} == "Y" ]; then
+      powershell.exe 'shutdown -r -t 0'
+    fi
+  else
+    printf "Make sure you have docker installed following these steps:\n"
+    printf "Ubuntu: https://docs.docker.com/engine/install/ubuntu/\n"
+    printf "Debian: https://docs.docker.com/engine/install/debian/\n"
+    printf "CentOS: https://docs.docker.com/engine/install/centos/\n"
+    printf "Fedora: https://docs.docker.com/engine/install/fedora/\n"
+    printf "RedHat: https://docs.docker.com/engine/install/rhel/\n"
+    printf "SLES: https://docs.docker.com/engine/install/SLES/\n"
+  fi
+  cd $PWD
+}
+
+
 for DEP in make curl docker docker-compose; do
   if ! (which "${DEP}" >/dev/null 2>&1); then
-    echo "Reach relies on an installation of ${DEP}"
-    exit 1
+    printf "Reach relies on an installation of ${DEP} do you want to install it [Y,n]: "
+    read RESPONSE
+    if [ ${RESPONSE} == "Y" ]; then
+      eval install_$DEP
+    fi
   fi
 done
 

--- a/reach
+++ b/reach
@@ -132,6 +132,15 @@ gen_reachc_id () {
 }
 
 call_home () {
+
+  START_TIME=$1
+  ELAPSED_TIME=$2
+  RESULT=$3
+  REACH_VERSION=$4
+  CONNECTOR_MODE=$5
+  USING_VSSTUDIO_EXTENTION=$6
+  INITIATOR=$7
+
   CALL_HOME_ENCODED="eyAidXNlcklkIjogInt7UkVBQ0hDX0lEfX0iLCAic3RhcnRUaW1l\
 IjogInt7U1RBUlRfVElNRX19IiwgImVsYXBzZWQiOiAie3tFTEFQU0VEX1RJTUV9fSIsICJ\
 yZXN1bHQiOiAie3tSRVNVTFR9fSIsICJ2ZXJzaW9uIjogInt7UkVBQ0hfVkVSU0lPTn19Ii\
@@ -142,12 +151,12 @@ dGlhdG9yIjogInt7SU5JVElBVE9SfX0iIH0="
   START_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   TRANSLATED_TEMPLATE=$(echo $CALL_HOME_TEMPLATE_DECODED | sed -e "s/{{REACHC_ID}}/$REACHC_ID/g" \
   -e "s/{{START_TIME}}/${START_TIME}/g" \
-  -e 's/{{ELAPSED_TIME}}/none/g' \
-  -e "s/{{RESULT}}/${2} is not installed/g" \
-  -e "s/{{REACH_VERSION}}/0.0.0/g" \
-  -e 's/{{CONNECTOR_MODE}}/none/g' \
-  -e 's/{{USING_VSSTUDIO_EXTENTION}}/none/g' \
-  -e "s/{{INITIATOR}}/${1}/g")
+  -e "s/{{ELAPSED_TIME}}/${ELAPSED_TIME}/g" \
+  -e "s/{{RESULT}}/${RESULT}/g" \
+  -e "s/{{REACH_VERSION}}/${REACH_VERSION}/g" \
+  -e "s/{{CONNECTOR_MODE}}/${CONNECTOR_MODE}/g" \
+  -e "s/{{USING_VSSTUDIO_EXTENTION}}/${USING_VSSTUDIO_EXTENTION}/g" \
+  -e "s/{{INITIATOR}}/${INITIATOR}/g")
   CALL_HOME_ENDPOINT="https://log.reach.sh/submit"
 
   curl -X POST "$CALL_HOME_ENDPOINT" -d "$TRANSLATED_TEMPLATE" || exit 1
@@ -223,6 +232,8 @@ install_docker () {
     printf "\nThis installation requires a restart for completion; do you want to restart now? [Y,n]: "
     read RESPONSE
     if [ "${RESPONSE}" = "Y" ]; then
+      CALL_HOME_START_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+      call_home $CALL_HOME_START_TIME "none" "Docker Installed by Reach" "0.0.0" "none" "none" $1
       powershell.exe 'shutdown -r -t 0'
     fi
   else
@@ -241,7 +252,8 @@ gen_reachc_id
 
 for DEP in make curl docker docker-compose; do
   if ! (which "${DEP}" >/dev/null 2>&1); then
-    call_home $1 $DEP
+    CALL_HOME_START_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    call_home $CALL_HOME_START_TIME "none" "${DEP} is not installed" "0.0.0" "none" "none" $1
     printf "Reach relies on an installation of %s; do you want to install it? [Y,n]: " "${DEP}"
     read -r RESPONSE
     if [ "${RESPONSE}" = "Y" ]; then

--- a/reach
+++ b/reach
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-
+#!/bin/sh
 
 if [ ! "$REACH_ALLOW_SU" = '1' ] && [ "$(id -u)" -eq 0 ]; then
   echo "Reach isn't intended to be run with superuser privileges."
@@ -134,18 +132,12 @@ install_make () {
 }
 
 install_curl () {
-  PACKAGE_MANAGER=package_manager
+  package_manager
 
-  sudo $PACKAGE_MANAGER install curl 
+  sudo ${PACKAGE_MANAGER} install curl 
 }
 
 install_docker () {
-  WINGET_VERSION="v1.3.431"
-  WINGET_ARTIFACT_NAME="Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"
-  WINGET_BUNDLE_URL="https://github.com/microsoft/winget-cli/releases/download/${WINGET_VERSION}/${WINGET_ARTIFACT_NAME}"
-  TEMP_DIR="/mnt/c/tmp"
-  WIN_TEMP_DIR="c:\\tmp"
-  DOCKER_BIN="/mnt/c/Program Files/Docker/Docker/resources/bin/docker"
   PWD=$(pwd)
 
   cd / #Depending on the directory the user is, windows has a hard time with the path.
@@ -153,6 +145,12 @@ install_docker () {
   if (which wsl.exe > /dev/null 2>&1); then
     printf "Installing Winget Windows Package Manager..."
     if (! which winget.exe > /dev/null 2>&1); then
+      WINGET_VERSION="v1.3.431"
+      WINGET_ARTIFACT_NAME="Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"
+      WINGET_BUNDLE_URL="https://github.com/microsoft/winget-cli/releases/download/${WINGET_VERSION}/${WINGET_ARTIFACT_NAME}"
+      TEMP_DIR="/mnt/c/tmp"
+      WIN_TEMP_DIR="c:\\tmp"
+      DOCKER_BIN="/mnt/c/Program Files/Docker/Docker/resources/bin/docker"
       if [ ! -e $TEMP_DIR ]; then
         mkdir $TEMP_DIR
       fi
@@ -169,7 +167,7 @@ install_docker () {
     done
     printf "\nThis installation requires a restart for completion; do you want to restart now? [Y,n]: "
     read RESPONSE
-    if [ ${RESPONSE} == "Y" ]; then
+    if [ "${RESPONSE}" = "Y" ]; then
       powershell.exe 'shutdown -r -t 0'
     fi
   else
@@ -181,15 +179,15 @@ install_docker () {
     printf "RedHat: https://docs.docker.com/engine/install/rhel/\n"
     printf "SLES: https://docs.docker.com/engine/install/SLES/\n"
   fi
-  cd $PWD
+  cd ... || exit
 }
 
 
 for DEP in make curl docker docker-compose; do
   if ! (which "${DEP}" >/dev/null 2>&1); then
-    printf "Reach relies on an installation of ${DEP}; do you want to install it? [Y,n]: "
-    read RESPONSE
-    if [ ${RESPONSE} == "Y" ]; then
+    printf "Reach relies on an installation of %s do you want to install it? [Y,n]: " "$DEP"
+    read -r RESPONSE
+    if [ "${RESPONSE}" = "Y" ]; then
       eval install_$DEP
     fi
   fi


### PR DESCRIPTION
## Summary
This PR is based off of the install_docker branch.

This code introduces the creation of the REACHC_ID and the compileLog call when some of the dependencies are not installed.
![callhome](https://user-images.githubusercontent.com/8799720/165953325-a7948aca-88e8-42ff-ac42-b574b87b98ba.png)
