### PR TITLE
correct syntax error for reach command

### DIFF
--- a/docs/src/rpc/index.md
+++ b/docs/src/rpc/index.md
@@ -12,7 +12,7 @@ An example frontend written using the Reach RPC Server is shown in the [tutorial
 
 The command
 ```cmd
-$ reach rpc-server
+$ ./reach rpc-server
 ```
 starts an instance of the Reach RPC Server.
 


### PR DESCRIPTION
``./reach rpc-server`` instead of ``reach rpc-server``

<!--
Hey! Thanks so much!
-->

## Summary

<!-- Explain what you're trying to do in this pull request -->

<!-- DESIGN: Does this code have some deeper design concept that motivates it that is hard to understand just by reading the code? -->

<!-- TESTING: How did you test this? Is there a new example? Do you have some test scenario you're using? -->

<!-- DOCS: Should there be a documentation or changelog update with this code? -->
