### PR TITLE
DCT-335

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -8,6 +8,7 @@ ADD docs/dev ./docs/dev
 RUN (cd docs/dev && make installed)
 
 COPY VERSION .
+ADD hs/t ./hs/t
 ADD examples ./examples
 ADD rpc-client/py ./rpc-client/py
 ADD docs/src ./docs/src

--- a/docs/src/rsh/errors/index.md
+++ b/docs/src/rsh/errors/index.md
@@ -2185,6 +2185,29 @@ no `{!rsh} Participant`s or `{!rsh} ParticipantClass`es declared.
 This issue can arise when you use `{!rsh} Anybody.publish()`. To fix this issue, ensure you declare
 a `{!rsh} Participant` or `{!rsh} ParticipantClass`.
 
+For example, the program below erroneously uses `{!rsh} Anybody.publish()` without declaring any `{!rsh} Participant` or `{!rsh} ParticipantClass`:
+
+```reach
+load: ./hs/t/n/Err_No_Participants.rsh
+range: 3 - 9
+```
+
+However, the correct thing to do is to declare at least one `{!rsh} Participant` or `{!rsh} ParticipantClass` before using `{!rsh} Anybody.publish()` like in the program below:
+
+```reach
+load: ./examples/api-call/index.rsh
+range: 4 - 7
+```
+
+```reach
+load: ./examples/api-call/index.rsh
+range: 47 - 49
+```
+
+:::note 
+Since `{!rsh} ParticipantClass` is being deprecated, it is preferable to use `{!rsh} API`.
+:::
+
 ## {#RE0125} RE0125
 
 This error indicates that an `{!rsh} API` is explicitly attempting to make a publication, e.g. `{!rsh} api.publish()`.


### PR DESCRIPTION
### Error Message 124

- Added code samples
- Added a note saying that it's preferable to use `API` over `ParticipantClass`