### PR TITLE
improve documentation tooltips

### DIFF
--- a/docs/dev/generator.js
+++ b/docs/dev/generator.js
@@ -420,7 +420,7 @@ const processMd = async ({baseConfig, relDir, in_folder, iPath, oPath}) => {
   };
 
   const tooltip = (text, hoverText) => {
-    return `<a class="ui-tooltip" title="${hoverText}"><span style="cursor">${text}</span></a>`;
+    return `<a class="ui-tooltip" title="${hoverText}"><span style="cursor: help">${text}</span></a>`;
   };
 
   const makeDirectiveWithClass = (classString) => {

--- a/docs/dev/generator.js
+++ b/docs/dev/generator.js
@@ -420,7 +420,7 @@ const processMd = async ({baseConfig, relDir, in_folder, iPath, oPath}) => {
   };
 
   const tooltip = (text, hoverText) => {
-    return `<a class="ui-tooltip" title="${hoverText}"><span style="cursor: help">${text}</span></a>`;
+    return `<span class="ui-tooltip" title="${hoverText}"><span style="cursor: help">${text}</span></span>`;
   };
 
   const makeDirectiveWithClass = (classString) => {

--- a/docs/src/assets/styles.css
+++ b/docs/src/assets/styles.css
@@ -356,7 +356,7 @@ i.fas:hover {cursor: pointer;}
 #page-col a:hover:not(.btn) {color: var(--link-hover); text-decoration: none;}
 #page-col a:hover.ui-tooltip {color: var(--reach-red-hover);}
 #page-col a.ui-tooltip {color: var(--reach-red);}
-#page-col a.ui-tooltip::after {content: " \1F6C8";}
+#page-col a.ui-tooltip::after {content: " \1F6C8"; cursor: help;}
 
 #page-col div#hh-viewer ul:not(.nav) {list-style-type: square;}
 

--- a/docs/src/assets/styles.css
+++ b/docs/src/assets/styles.css
@@ -356,6 +356,7 @@ i.fas:hover {cursor: pointer;}
 #page-col a:hover:not(.btn) {color: var(--link-hover); text-decoration: none;}
 #page-col a:hover.ui-tooltip {color: var(--reach-red-hover);}
 #page-col a.ui-tooltip {color: var(--reach-red);}
+#page-col a.ui-tooltip::after {content: " \1F6C8";}
 
 #page-col div#hh-viewer ul:not(.nav) {list-style-type: square;}
 

--- a/docs/src/assets/styles.css
+++ b/docs/src/assets/styles.css
@@ -80,6 +80,8 @@ main {height: calc(100% - 56px);}
     --div-note-bg: #F5F5DC;
     --div-q-and-a-bg: #F5DCDC;
     --page-col-a-pid: #C8A8FF;
+    --reach-red: #F45747;
+    --reach-red-hover: #B62B1B;
 
     --shiki-color-text: #24292E;
     --shiki-color-background: var(--snippet);
@@ -131,6 +133,8 @@ main {height: calc(100% - 56px);}
     --div-note-bg: #201500;
     --div-q-and-a-bg: #210700;
     --page-col-a-pid: #38287F;
+    --reach-red: #F45747;
+    --reach-red-hover: #B62B1B;
 
     --shiki-color-text: #d0d0d0;
     --shiki-color-background: var(--snippet);
@@ -350,6 +354,8 @@ i.fas:hover {cursor: pointer;}
 
 #page-col a:not(.btn) {color: var(--link-no-hover); text-decoration: none;}
 #page-col a:hover:not(.btn) {color: var(--link-hover); text-decoration: none;}
+#page-col a:hover.ui-tooltip {color: var(--reach-red-hover);}
+#page-col a.ui-tooltip {color: var(--reach-red);}
 
 #page-col div#hh-viewer ul:not(.nav) {list-style-type: square;}
 

--- a/docs/src/assets/styles.css
+++ b/docs/src/assets/styles.css
@@ -354,9 +354,9 @@ i.fas:hover {cursor: pointer;}
 
 #page-col a:not(.btn) {color: var(--link-no-hover); text-decoration: none;}
 #page-col a:hover:not(.btn) {color: var(--link-hover); text-decoration: none;}
-#page-col a:hover.ui-tooltip {color: var(--reach-red-hover);}
-#page-col a.ui-tooltip {color: var(--reach-red);}
-#page-col a.ui-tooltip::after {content: " \1F6C8"; cursor: help;}
+#page-col span:hover.ui-tooltip {color: var(--reach-red-hover);}
+#page-col span.ui-tooltip {color: var(--reach-red);}
+#page-col span.ui-tooltip::after {content: " \1F6C8"; cursor: help;}
 
 #page-col div#hh-viewer ul:not(.nav) {list-style-type: square;}
 


### PR DESCRIPTION
We don't want readers to think tooltips are real links, and then click on them, and lose their place on the page.

Actually preventing clicking on the tooltips causing the page to jump to the top is something we will have to address later; straightforward fixes like doing `event.preventDefault()`, `event.stopPropagation()`, and overriding tooltips' `onclick` handlers with `return false;` don't appear to work.

This change just changes the tooltip color, hopefully discouraging users from clicking on them and losing their place on the page.

### Without this change

https://user-images.githubusercontent.com/43425812/166551666-6613b8f6-f949-45a1-a539-b60bb144cd0c.mp4

### With this change

https://user-images.githubusercontent.com/43425812/166538160-c5168571-d6b7-4f82-bada-be1897a7e5a2.mp4