### PR TITLE
delete unnecessary `await`s before non-`async` fns

### DIFF
--- a/vsce/server/src/server.ts
+++ b/vsce/server/src/server.ts
@@ -877,14 +877,14 @@ connection.onHover(
 
       var word = getWord(text, index, true);
       if (isReachKeyword(word)) {
-        let buf = await getReachKeywordMarkdown(word);
+        let buf = getReachKeywordMarkdown(word);
         hover.contents = buf;
         return hover;
       }
 
       var word = getWord(text, index, false);
       if (isReachKeyword(word)) {
-        let buf = await getReachKeywordMarkdown(word);
+        let buf = getReachKeywordMarkdown(word);
         hover.contents = buf;
         return hover;
       }


### PR DESCRIPTION
`getReachKeywordMarkdown` isn't `async`hronous, so an `await` preceding it doesn't do anything.