### PR TITLE
CORE-1567: Fix issue when `.api_` has multi-arity domain

### DIFF
--- a/examples/rsvp/index.rsh
+++ b/examples/rsvp/index.rsh
@@ -35,27 +35,24 @@ export const main = Reach.App(() => {
       && RSVPs.Map.size() == howMany
     )
     .while( keepGoing )
-    .api_(A.iWillGo,
-      () => {
-        const who = this;
-        check( ! RSVPs.member(who), "not yet" );
-        return [ price, (k) => {
-          k(true);
-          RSVPs.insert(who);
-          return [ keepGoing, howMany + 1 ];
-        }];
-      })
-    .api_(C.theyCame,
-      (who) => {
-        check( this == D, "you are the boss");
-        check( RSVPs.member(who), "yep" );
-        return [(k) => {
-          k(true);
-          transfer(price).to(who);
-          RSVPs.remove(who);
-          return [ keepGoing, howMany - 1 ];
-        }];
-      })
+    .api_(A.iWillGo, () => {
+      check( ! RSVPs.member(this), "not yet" );
+      return [ price, (k) => {
+        k(true);
+        RSVPs.insert(this);
+        return [ keepGoing, howMany + 1 ];
+      }];
+    })
+    .api_(C.theyCame, (who) => {
+      check( this == D, "you are the boss");
+      check( RSVPs.member(who), "yep" );
+      return [ 0, (k) => {
+        k(true);
+        transfer(price).to(who);
+        RSVPs.remove(who);
+        return [ keepGoing, howMany - 1 ];
+      }];
+    })
     .timeout( deadlineBlock, () => {
       const [ [], k ] = call(C.timesUp);
       k(true);

--- a/examples/rsvp/index.txt
+++ b/examples/rsvp/index.txt
@@ -2,6 +2,6 @@ Verifying knowledge assertions
 Verifying for generic connector
   Verifying when ALL participants are honest
   Verifying when NO participants are honest
-Checked 40 theorems; No failures!
+Checked 42 theorems; No failures!
 WARNING: Compiler instructed to emit for Algorand, but the conservative analysis found these potential problems:
  * This program was compiled with trustworthy maps, but maps are not trustworthy on Algorand, because they are represented with local state. A user can delete their local state at any time, by sending a ClearState transaction. The only way to use local state properly on Algorand is to ensure that a user doing this can only 'hurt' themselves and not the entire system.

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -5087,9 +5087,10 @@ doForkAPI2Case isSingleFun args = do
         (domain, body) <- deconstructFunStmts f
         (chks, mpay, con) <- splitApiConsensus body
         chk_ss <- flip jsInlineCall [dotdom] $ jsArrowStmts fa domain chks
-        let no_op = jsArrowStmts fa (ignore <$ domain) []
+        let iargs = ignore <$ domain
+        let no_op = jsArrowStmts fa iargs []
         let assume = mkAssume chk_ss no_op
-        con_e <- mkConsensus w chk_ss =<< prependFunArgs [ignore] con
+        con_e <- mkConsensus w chk_ss =<< prependFunArgs iargs con
         mpay_e <- forM mpay $ mkPay chks . jsArrowExpr fa domain
         return (assume, mpay_e, con_e)
   let goSingle who f = do


### PR DESCRIPTION
When generating the CONSENSUS_EXPR closure in the `.api_` macro, it would inject one ignored parameter into the function domain instead of n parameters for an n-length domain