### PR TITLE
CORE-1507: fix screwy `reach compile --output` args

### DIFF
--- a/examples/cli-tricky-directories/README.md
+++ b/examples/cli-tricky-directories/README.md
@@ -42,3 +42,7 @@ Tests the CLI's ability to channel compilation output to another directory.
 ##### **`.tmp/EXIT`**
 If any `$TARGET` should fail its tests this file will be updated to contain `1`; otherwise it'll contain a default of `0`.
 The test suite terminates with `exit "$(cat ".tmp/EXIT")"` to ensure propagating a true go/no-go status.
+
+## Note
+Executing `make run` twice will fail due to a quirk with Docker volumes and the fact that `run.sh` deletes test directories after invoking `go.sh`.
+Use `reach down` between invocations of `make run` if you need to make this work.

--- a/examples/cli-tricky-directories/go.sh
+++ b/examples/cli-tricky-directories/go.sh
@@ -57,8 +57,10 @@ else
   o="$("$ROOT"/reach compile --intermediate-files "$r" main --output="/foo/bar/$b" 2>&1)"
   set -e
   [ "$o" = "-o|--output must be a relative subdirectory of $(pwd)." ] || (printf '\n%s' "$o"; exit 1)
-  printf 'Done.'
+  printf 'Done.\n\n'
 
   g compile --intermediate-files "$(printf ''%s'' "$r")" main --output="$(printf ''%s'' "${b#"$(pwd)"/}")"
+  g compile --intermediate-files "$(printf ''%s'' "$r")" main --output "$(printf ''%s'' "${b#"$(pwd)"/}")"
+  g compile --intermediate-files "$(printf ''%s'' "$r")" main       -o "$(printf ''%s'' "${b#"$(pwd)"/}")"
 fi
 echo

--- a/reach
+++ b/reach
@@ -69,9 +69,9 @@ run_d () {
         --dir-config-host="$CNF" \
         "$@"
   else
-    cid="$(docker ps -q \
-      -f "ancestor=$IMG" \
-      -f "label=sh.reach.dir-project=$(pwd)" \
+    cid="$(docker ps -f "ancestor=$IMG" --format '{{.ID}} {{.Labels}}' \
+      | grep " sh.reach.dir-project=$(pwd)\$" \
+      | awk '{print $1}' \
       | head -n1)"
 
     if [ -z "$cid" ]; then


### PR DESCRIPTION
Notes:
- I'm not handling `-o=` because `optparse-applicative` doesn't allow `=` for short-forms either; `-o` is fine.
- The `docker ps ...` changes mitigate the issue I mentioned on Slack where multiple containers would be spawned since querying didn't work for directories with spaces or other odd characters.