### PR TITLE
Dct 429 docs must include a checksum of a referenced file

### DIFF
--- a/.circleci/config.pre.yml
+++ b/.circleci/config.pre.yml
@@ -145,6 +145,7 @@ jobs:
         git rm -r .
         cp -r /tmp/workspace/docs/* .
         [ -f index.html ] || exit 1
+        touch .nojekyll
         git add .
         # https://stackoverflow.com/questions/8123674/how-to-git-commit-nothing-without-an-error
         git diff-index --quiet HEAD || (git commit -m "[ci skip] docs for ${CIRCLE_SHA1}" && touch .did_change)

--- a/docs/src/frontend/index.md
+++ b/docs/src/frontend/index.md
@@ -223,6 +223,7 @@ Example:
 
 ```js
 load: /examples/ganache/index.mjs
+md5: cca336d85844697eb44884226f9d2ce0
 range: 10-13
 ```
 
@@ -311,6 +312,7 @@ This can only be used in private testing scenarios, as it uses a private faucet 
 
 ```js
 load: /examples/workshop-trust-fund/index.mjs
+md5: 29f9f977d13d9651062bf18288b6c072
 range: 29-33
 ```
 
@@ -342,6 +344,7 @@ Example:
 
 ```js
 load: /examples/rps-8-interact/index.mjs
+md5: 9f824fcd58e5fdda4f4761b99093cfdc
 range: 18-25
 ```
 
@@ -519,6 +522,7 @@ If you do this, you should inform your clients that they should pay attention to
 
 ```js
 load: /examples/atomic-swap/index.mjs
+md5: 9e2dd8f8db4ef6e83cc5c95fab50fd80
 range: 30-32
 ```
 
@@ -1028,6 +1032,7 @@ Hashes the value.
 
 ```js
 load: /examples/digest-mod/index.mjs
+md5: 73fef9371959b81f0609bd7622a9eb27
 range: 14-15
 ```
 

--- a/docs/src/guide/ganache/index.md
+++ b/docs/src/guide/ganache/index.md
@@ -25,12 +25,14 @@ You'll also need to add the `ethers` package, because you'll be directly interac
 After that, you need to import the two packages on the JavaScript side in your `index.mjs` file:
 ```
 load: /examples/ganache/index.mjs
+md5: cca336d85844697eb44884226f9d2ce0
 range: 3-4
 ```
 
 Next, you need to actually create the Ganache-based provider and connect it to Reach:
 ```
 load: /examples/ganache/index.mjs
+md5: cca336d85844697eb44884226f9d2ce0
 range: 9-13
 ```
 
@@ -38,6 +40,7 @@ This will work, but Reach will not consider the network to be "isolated", which 
 You can enable this by setting the Reach faucet:
 ```
 load: /examples/ganache/index.mjs
+md5: cca336d85844697eb44884226f9d2ce0
 range: 15-16
 ```
 

--- a/docs/src/rpc/client/index.md
+++ b/docs/src/rpc/client/index.md
@@ -10,11 +10,13 @@ HTTP servers, and networking:
 
 ```
 load: /rpc-client/py/src/reach_rpc/__init__.py
+md5: 6803a3a6da2cbfaa7c410f3f2894e444
 range: 1-9
 ```
 
 ```
 load: /rpc-client/py/src/reach_rpc/__init__.py
+md5: 6803a3a6da2cbfaa7c410f3f2894e444
 range: 11-27
 ```
 
@@ -22,6 +24,7 @@ The library provides a single function, `{!py} mk_rpc`, that accepts the @{secli
 
 ```
 load: /rpc-client/py/src/reach_rpc/__init__.py
+md5: 6803a3a6da2cbfaa7c410f3f2894e444
 range: 28-34
 ```
 
@@ -30,6 +33,7 @@ It displays a warning to users that they should be nervous about using this sett
 
 ```
 load: /rpc-client/py/src/reach_rpc/__init__.py
+md5: 6803a3a6da2cbfaa7c410f3f2894e444
 range: 35-47
 ```
 
@@ -37,6 +41,7 @@ Next, it attempts to connect to the Reach RPC Server and throws an error if it d
 
 ```
 load: /rpc-client/py/src/reach_rpc/__init__.py
+md5: 6803a3a6da2cbfaa7c410f3f2894e444
 range: 52-62
 ```
 
@@ -47,6 +52,7 @@ It prints debugging information for convenience.
 
 ```
 load: /rpc-client/py/src/reach_rpc/__init__.py
+md5: 6803a3a6da2cbfaa7c410f3f2894e444
 range: 63-79
 ```
 
@@ -66,6 +72,7 @@ It replaces the `{!py} p` value with the result of that continuation invocation 
 
 ```
 load: /rpc-client/py/src/reach_rpc/__init__.py
+md5: 6803a3a6da2cbfaa7c410f3f2894e444
 range: 80-80
 ```
 

--- a/docs/src/rsh/appinit/index.md
+++ b/docs/src/rsh/appinit/index.md
@@ -30,6 +30,7 @@ After which a local step is introduced:
 
 ```reach
 load: /examples/api-twice/index.rsh
+md5: 38ac4eabad2ced3f017a11fc24a72f6f
 range: 4 - 15
 ```
 
@@ -54,6 +55,7 @@ The @{defn("compilation options")} for the DApp may be set by calling `{!rsh} se
   See example below:
   ```reach
   load: /examples/map-simpl/index.rsh
+  md5: 2d6c1487d7b96d41016e067c9cd265ef
   range: 4 - 6
   ```
 
@@ -69,6 +71,7 @@ The @{defn("compilation options")} for the DApp may be set by calling `{!rsh} se
   See example below:
   ```reach
   load: /examples/uint256/index.rsh
+  md5: 41cfcbe36ef78fb15097f373bfea3c3e
   range: 3 - 5
   ```
 
@@ -87,6 +90,7 @@ The @{defn("compilation options")} for the DApp may be set by calling `{!rsh} se
   See example below:
   ```reach
   load: hs/t/y/overflow_con.rsh
+  md5: d3f64764da8d0c2ae1e68f23ca943c0a
   range: 3 - 6
   ```
 
@@ -100,6 +104,7 @@ The @{defn("compilation options")} for the DApp may be set by calling `{!rsh} se
   In the example below, only `ETH` and `ALGO` are chosen:
   ```reach
   load: /examples/popularity-contest/index.rsh
+  md5: ea12cdcd4f262bc0b0a0e0cc74f01e63
   range: 10 - 15
   ```
 
@@ -139,6 +144,7 @@ In the [Rock, Paper, and Scissors](##tut-3) tutorial, Alice and Bob receive the 
 
 ```
 load: /examples/rps-2-rps/index.rsh
+md5: 3ea7718e88c86dd41e97b503d7aa3b67
 range: 1-14
 ```
 
@@ -166,6 +172,7 @@ Each function must occur exactly once in the entire program.
 
 ```
 load: /examples/dominant-assurance/index.rsh
+md5: d327454b582bdfa6f03d71de5ce2dd97
 range: 24-27
 ```
 
@@ -192,12 +199,14 @@ A view is defined with `{!rsh} View(viewName, viewInterface)` or `{!rsh} View(vi
 For example, `{!rsh} View` is used in the code below without a `{!rsh} viewName`:
 ```reach
 load: /examples/remote-rsh/index.rsh
+md5: c7a305584ec5c689a8c61e53b544240b
 range: 16 - 19
 ```
 
 While the `{!rsh} View` in the following code contains a `{!rsh} viewName`:
 ```reach
 load: /examples/view-steps/index.rsh
+md5: 78e1541e01ce0791b4b41d2bcd57aaa2
 range: 11 - 12
 ```
 
@@ -222,12 +231,14 @@ An event is defined with `{!rsh} Events(eventName, eventInterface)` or `{!rsh} E
 For example, the `{!rsh} Events` in the code below has no `{!rsh} eventName`:
 ```reach
 load: /examples/event-monitor/index.rsh
+md5: c40c1da17f2d66d2906192ccfb40f4b5
 range: 10 - 13
 ```
 
 While the `{!rsh} Events` in following example has an `{!rsh} eventName`:
 ```reach
 load: /examples/dominant-assurance/index.rsh
+md5: d327454b582bdfa6f03d71de5ce2dd97
 range: 34 - 35
 ```
 

--- a/docs/src/rsh/compute/index.md
+++ b/docs/src/rsh/compute/index.md
@@ -658,16 +658,19 @@ This is demonstrated in the code below:
 
 ```reach
 load: /examples/uint256/index.rsh
+md5: 41cfcbe36ef78fb15097f373bfea3c3e
 range: 79 - 79
 ```
 
 ```reach
 load: /examples/uint256/index.rsh
+md5: 41cfcbe36ef78fb15097f373bfea3c3e
 range: 88 - 88
 ```
 
 ```reach
 load: /examples/uint256/index.rsh
+md5: 41cfcbe36ef78fb15097f373bfea3c3e
 range: 92 - 93
 ```
 
@@ -676,11 +679,13 @@ This is demonstrated in the code below:
 
 ```reach
 load: /hs/t/y/uint256-verify2.rsh
+md5: 698e681595bfaf0704f30a0167f6ddd8
 range: 6 - 6
 ```
 
 ```reach
 load: /hs/t/y/uint256-verify2.rsh
+md5: 698e681595bfaf0704f30a0167f6ddd8
 range: 12 - 12
 ```
 
@@ -746,11 +751,13 @@ The code below shows how `{!rsh} Padding` can be done:
 
 ```reach
 load: /examples/dan-storage/index.rsh
+md5: 10a27da3d0db49a29e29f79b6fd57dad
 range: 5 - 5
 ```
 
 ```reach
 load: /examples/dan-storage/index.rsh
+md5: 10a27da3d0db49a29e29f79b6fd57dad
 range: 9 - 9
 ```
 
@@ -1478,16 +1485,19 @@ The following examples demonstrate different usage of `{!rsh} Maybe`:
 
 ```reach
 load: /hs/t/y/data.rsh
+md5: 4e8539b9c12ac8b7f52a3dafd60d5497
 range: 3 - 3
 ```
 
 ```reach
 load: /hs/t/y/polyEq.rsh
+md5: e9bdf7824a2aa25af8d4665dd15e197f
 range: 36 - 36
 ```
 
 ```reach
 load: /examples/pr-1cc66/index.rsh
+md5: 4eb5b0969481439ffb9634c34215fd5c
 range: 8 - 8
 ```
 
@@ -1539,6 +1549,7 @@ This snippet demonstrates the convenience methods:
 
 ```reach
 load: /hs/t/y/either_stdlib.rsh
+md5: 546453700e69d829a998db424d0e8fc6
 range: 11 - 25
 ```
 
@@ -1638,6 +1649,7 @@ and the next N values are distinct `{!rsh} UInt`s.
 
 ```reach
 load: /examples/secured-loan/index.rsh
+md5: ed788f118c40a77028bf9414e1e2ac13
 range: 13 - 13
 ```
 
@@ -1659,6 +1671,7 @@ assert( claim, [msg] )
 
  ```reach
  load: /examples/rps-8-interact/index.rsh
+ md5: ee287e712cdfe8d91bbb038c383d25d3
  range: 6 - 11
  ```
 
@@ -1688,6 +1701,7 @@ For example, `A` makes the following `{!rsh} check` with a second (optional) arg
 
 ```reach
 load: /examples/map-sender/index.rsh
+md5: 7cdbe84f6a4dfa838fa86806d3008d70
 range: 18 - 22
 ```
 
@@ -1695,6 +1709,7 @@ While the `{!rsh} check` in the following example, takes just the first argument
 
 ```reach
 load: /examples/api-overload/index.rsh
+md5: 8423e5e116edca7b81cd1cdf8d88722a
 range: 61 - 62
 ```
 
@@ -1720,6 +1735,7 @@ The following code sample uses a couple of `{!rsh} forall` arguments to assert t
 
 ```reach
 load: /examples/rps-6-timeouts/index.rsh
+md5: b390a5f23cadf2f5da1533378a83f52f
 range: 13-15
 ```
 
@@ -1735,6 +1751,7 @@ It accepts an optional bytes argument, which is included in any reported violati
 
 ```reach
 load: /examples/algo-try-csp/index.rsh
+md5: 77303319a82af26faaecb2bd3295e644
 range: 30 - 32
 ```
 
@@ -1751,6 +1768,7 @@ The exact algorithm used depends on the connector.
 
 ```reach
 load: /examples/workshop-hash-lock/index.rsh
+md5: 0e93e2215a2f36f5be42930a5705549f
 range: 12 - 14
 ```
 
@@ -1771,6 +1789,7 @@ The example below shows non-network tokens being passed as arguments to the `{!r
 
 ```reach
 load: /examples/abstract-tok/index.rsh
+md5: aec14ab8610b29232a48b12841c09730
 range: 24 - 26
 ```
 
@@ -1778,6 +1797,7 @@ While in the following example, `{!rsh} balance` takes no argument:
 
 ```reach
 load: /examples/rps-7-loops/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 60 - 60
 ```
 
@@ -1793,6 +1813,7 @@ This function may not be called until after the first publication (which creates
 
 ```reach
 load: /examples/remote-rsh/index.rsh
+md5: c7a305584ec5c689a8c61e53b544240b
 range: 26-29
 ```
 
@@ -1811,6 +1832,7 @@ This function may not be called until after the first publication (which creates
 
 ```reach
 load: /examples/ctc-address/index.rsh
+md5: 32318a2e600f0a39a01bd0133e8a83d0
 range: 15-22
 ```
 
@@ -1845,12 +1867,13 @@ This may not be available if there was no such previous publication, such as at 
 
 ```reach
 load: /examples/realtime/index.rsh
+md5: 43c3e16e00ad2ec2be76a16d66a29e45
 range: 12 - 18
 ```
 
-In this code, `{!rsh} lastConsensusTime` is called on line 17 after the publication on line 12. 
-The `entry` function on line 15 takes `step` as an argument and produces an array. 
-The array contains the destructured `step`, `lab` that was passed into the parent function (`aStep`), 
+In this code, `{!rsh} lastConsensusTime` is called on line 17 after the publication on line 12.
+The `entry` function on line 15 takes `step` as an argument and produces an array.
+The array contains the destructured `step`, `lab` that was passed into the parent function (`aStep`),
 `{!rsh} lastConsensusTime()` and `{!rsh} lastConsensusSecs()`.
 
 ---
@@ -1864,6 +1887,7 @@ lastConsensusSecs()
 
 ```reach
 load: /examples/thisConsensusTime/index.rsh
+md5: 41694252bcb7388f2f8cefcc4f10036a
 range: 9 - 15
 ```
 
@@ -1894,6 +1918,7 @@ thisConsensusSecs()
 
 ```reach
 load: /examples/thisConsensusTime/index.rsh
+md5: 41694252bcb7388f2f8cefcc4f10036a
 range: 11-15
 ```
 
@@ -1986,6 +2011,7 @@ This pattern is so common that it can be abbreviated as `{!rsh} .timeRemaining`.
 
 ```reach
 load: /examples/raffle/index.rsh
+md5: b6632a71c54afc8e1da08f2d6c0dbad3
 range: 37-40
 ```
 
@@ -2002,6 +2028,7 @@ implies( x, y )
 
 ```reach
 load: /examples/raffle/index.rsh
+md5: b6632a71c54afc8e1da08f2d6c0dbad3
 range: 52 - 57
 ```
 
@@ -2028,6 +2055,7 @@ hasRandom
 
  ```reach
 load: /examples/rps-7-loops/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 20-24
 ```
 
@@ -2045,11 +2073,13 @@ hasConsoleLogger
 
  ```reach
  load: /examples/log/index.mjs
+ md5: 65e2b563606bbb05a0fb2a378af53519
  range: 11 - 14
  ```
 
  ```reach
  load: /examples/log/index.rsh
+ md5: 2c13063a805c6b3045911962d6906316
  range: 5 - 7
  ```
 
@@ -2083,6 +2113,7 @@ The resulting quotient must be less than `{!rsh} UInt.max`.
 
 ```reach
 load: /examples/pr855/index.rsh
+md5: 16e62b3c050a678808f1024c343a69f5
 range: 26 - 32
 ```
 
@@ -2112,6 +2143,7 @@ When used inside of any other step, it will generate an `{!rsh} assert` claim.
 
 ```reach
 load: /hs/t/y/verifyMuldiv.rsh
+md5: 66b1f803595c8726bceb96bf916a8db1
 range: 36 - 43
 ```
 
@@ -2132,6 +2164,7 @@ sqrt(81)
 
 ```reach
 load: /examples/sqrt/index.rsh
+md5: 77a676f01abbadee2bac90e17139c6e8
 range: 17 - 19
 ```
 
@@ -2387,11 +2420,13 @@ it does not matter who `{!rsh} publish`es, such as in a `{!rsh} timeout`.
 
 ```reach
 load: /examples/multiple-pr-case/index.rsh
+md5: dbe00208f36d738db09efb24caaec2fc
 range: 10 - 13
 ```
 
 ```reach
 load: /examples/multiple-pr-case/index.rsh
+md5: dbe00208f36d738db09efb24caaec2fc
 range: 46 - 49
 ```
 
@@ -2551,6 +2586,7 @@ Example:
 
 ```reach
 load: /examples/getUntrackedFunds3/index.rsh
+md5: 01a0c15c3e3a270e5d3adedc1d9d918f
 range: 28-30
 ```
 
@@ -2570,6 +2606,7 @@ Example:
 
 ```reach
 load: /hs/t/y/many_txns.rsh
+md5: 4bf192eb6742bf011d2d2330556ab77c
 range: 43 - 60
 ```
 

--- a/docs/src/rsh/consensus/index.md
+++ b/docs/src/rsh/consensus/index.md
@@ -21,6 +21,7 @@ For example, in the code below, the `{!rsh} commit();` on line 79 allows `Alice`
 
 ```reach
 load: /examples/rps-7-loops/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 77 - 84
 ```
 
@@ -48,6 +49,7 @@ For example, consider the following program:
 
 ```
 load: /examples/view-steps/index.rsh
+md5: 78e1541e01ce0791b4b41d2bcd57aaa2
 ```
 
 In this program, the Reach backend calls the frontend `{!rsh} interact` function, `{!rsh} checkView` with the expected value of the views at each point in the program.
@@ -130,6 +132,7 @@ Example:
 
 ```reach
 load: /examples/workshop-relay/index.rsh
+md5: 56b6338c7902247ed5943735e96eed3b
 range: 14 - 17
 ```
 
@@ -173,6 +176,7 @@ Read about finding [loop invariants](##guide-loop-invs) in the Reach guide.
 
 ```reach
 load: /examples/chicken-race/index.rsh
+md5: 2f62423e6b6ea82b9c1c89cba69104a1
 range: 43-64
 ```
 
@@ -230,6 +234,7 @@ When one of them publishes, the `keepGoing` function returns false, and the prog
 
 ```reach
 load: /examples/chicken-race/index.rsh
+md5: 2f62423e6b6ea82b9c1c89cba69104a1
 range: 53-58
 ```
 
@@ -408,6 +413,7 @@ A transfer expression may only occur within a consensus step.
 
 ```reach
 load: /examples/simple-nft-auction/index.rsh
+md5: 1f95425a9feb9f5bf1e677461a83df4e
 range: 59-60
 ```
 
@@ -429,6 +435,7 @@ If a publication would violate the requirement, the consensus network rejects th
 
 ``` reach
 load: /examples/abstract-tok/index.rsh
+md5: aec14ab8610b29232a48b12841c09730
 range: 20-22
 ```
 
@@ -449,11 +456,13 @@ The example below shows `{!rsh} checkCommitment` being used in a consensus step 
 
 ```reach
 load: /examples/rps-7-loops/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 64 - 68
 ```
 
 ```reach
 load: /examples/rps-7-loops/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 85 - 87
 ```
 
@@ -495,11 +504,13 @@ This value is intended to be a digest of a larger metadata document.
 The following examples demonstrate how the details above may be used:
 ```reach
 load: examples/token-decimals/index.rsh
+md5: 0b9ee900d1bd566dcc7383749d770ab1
 range: 14 - 17
 ```
 
 ```reach
 load: examples/mint-basic/index.rsh
+md5: 1ccb4872438f69d9c8af711b08d817a4
 range: 28 - 33
 ```
 
@@ -624,12 +635,14 @@ If `{!rsh} KEY_TYPE_EXPR` is not specified, it will default to `{!rsh} Address`.
 For example the code below contains only the `{!rsh} VAL_TYPE_EXPR`:
 ```reach
 load: /examples/splice1/index.rsh
+md5: 944291e790336dbb2b87784588d60eeb
 range: 7 - 7
 ```
 
 While the following code contains both the `{!rsh} KEY_TYPE_EXPR` and `{!rsh} VAL_TYPE_EXPR`:
 ```reach
 load: /examples/map-arbitrary-key/index.rsh
+md5: eb61fb5172abcedde155c34a21265fd6
 range: 24 - 24
 ```
 
@@ -670,6 +683,7 @@ The following example shows the usage of `{!rsh} s.insert(ADDRESS)`:
 
 ```reach
 load: /hs/t/y/merit-badge.rsh
+md5: 2186c788d7b38a8b4f222960a77586d9
 range: 46 - 48
 ```
 
@@ -677,6 +691,7 @@ While the example below shows the usage of  `{!rsh} s.remove(ADDRESS)`
 
 ```reach
 load: /examples/dominant-assurance/index.rsh
+md5: d327454b582bdfa6f03d71de5ce2dd97
 range: 143 - 143
 ```
 
@@ -686,6 +701,7 @@ The following example shows the usage of `{!rsh} s.member(ADDRESS)`
 
 ```reach
 load: /examples/dominant-assurance/index.rsh
+md5: d327454b582bdfa6f03d71de5ce2dd97
 range: 99 - 99
 ```
 

--- a/docs/src/rsh/errors/index.md
+++ b/docs/src/rsh/errors/index.md
@@ -598,6 +598,7 @@ Example:
 
 ```reach
 load: /hs/t/n/continue.rsh
+md5: 27ee6a16a890c05d6fe16640df03949a
 range: 4 - 9
 ```
 
@@ -608,6 +609,7 @@ Example:
 
 ```reach
 load: /hs/t/y/while_multi_inv.rsh
+md5: ba7262e27a3f5f48720b3fd88dbf16cb
 range: 14 - 24
 ```
 
@@ -990,6 +992,7 @@ You can fix this by using a static string as the key.
 
 ```reach
 load: /hs/t/y/dynamic_pay.rsh
+md5: d2b6bbbbc740d81db1ba2097f250a1b5
 range: 21 - 24
 ```
 
@@ -1034,6 +1037,7 @@ are valid object keys.
 
 ``` reach
 load: /hs/t/n/Err_Obj_IllegalNumberField.rsh
+md5: eece701143d5714f06ba03d48860eae2
 range: 3 - 3
 ```
 
@@ -1041,6 +1045,7 @@ You can fix this issue by replacing the erroneous key with a static string.
 
 ``` reach
 load: /hs/t/y/objects.rsh
+md5: 7ae70fab31a04e51d2150c6507ecd048
 range: 9 - 9
 ```
 
@@ -1259,6 +1264,7 @@ Example:
 
 ```reach
 load: /hs/t/n/Err_Eval_LookupUnderscore.rsh
+md5: 2ccbb40b7b71cfa9ba9213a0c840524f
 range: 3 - 6
 ```
 
@@ -1266,6 +1272,7 @@ You can fix this by using another identifier and referencing it as usual.
 
 ```reach
 load: /hs/t/y/underscore_unread.rsh
+md5: d3ed4b3338138e2f98c68d57d054f023
 range: 5-6
 ```
 
@@ -1344,6 +1351,7 @@ Example:
 
 ```reach
 load: /hs/t/n/Err_Switch_MissingCases.rsh
+md5: bcf5b2427943c6e5b432cf8d8e54bf8d
 range: 9 - 14
 ```
 
@@ -1354,6 +1362,7 @@ Example:
 
 ```reach
 load: /hs/t/y/switch_cases.rsh
+md5: 1442b3c48fa0604f624a312562a2fd2c
 range: 9 - 15
 ```
 
@@ -1366,6 +1375,7 @@ Example:
 
 ```reach
 load: /hs/t/n/Err_Switch_ExtraCases.rsh
+md5: 403e1a9741e81871ecf6b3af69405cd9
 range: 11 - 15
 ```
 
@@ -1374,6 +1384,7 @@ You can fix this issue by adding the unknown variant to the `{!rsh} Data` defini
 
 ```reach
 load: /hs/t/y/data.rsh
+md5: 4e8539b9c12ac8b7f52a3dafd60d5497
 range: 19 - 21
 ```
 
@@ -2192,6 +2203,7 @@ For example, the code below erroneously puts `{!rsh} didPublish()` before `{!rsh
 
 ``` reach
 load: /hs/t/n/Err_NotAfterFirst.rsh
+md5: 46e1eb604c95c16c2c5dcfeeb5e94aa7
 range: 6 - 10
 ```
 
@@ -2199,11 +2211,13 @@ This error can be corrected by placing `{!rsh} publish` before `{!rsh} didPublis
 
 ```reach
 load: /examples/raffle/index.rsh
+md5: b6632a71c54afc8e1da08f2d6c0dbad3
 range: 35 - 35
 ```
 
 ```reach
 load: /examples/raffle/index.rsh
+md5: b6632a71c54afc8e1da08f2d6c0dbad3
 range: 59 - 65
 ```
 
@@ -2284,6 +2298,7 @@ For example, the program below erroneously uses `{!rsh} Anybody.publish()` witho
 
 ```reach
 load: /hs/t/n/Err_No_Participants.rsh
+md5: cdb92dfbbb05b2f6f9eda2d462140e57
 range: 3 - 9
 ```
 
@@ -2291,11 +2306,13 @@ However, the correct thing to do is to declare at least one `{!rsh} Participant`
 
 ```reach
 load: /examples/api-call/index.rsh
+md5: 5bb3b74980f2ba84d75c68edc5b9e4e5
 range: 4 - 7
 ```
 
 ```reach
 load: /examples/api-call/index.rsh
+md5: 5bb3b74980f2ba84d75c68edc5b9e4e5
 range: 47 - 49
 ```
 

--- a/docs/src/rsh/local/index.md
+++ b/docs/src/rsh/local/index.md
@@ -34,6 +34,7 @@ An interaction expression may only occur in a local step.
 
 ``` reach
 load: /examples/rps-7-loops/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 45-48
 ```
 
@@ -55,6 +56,7 @@ If the claim dynamically evaluates to `false`, the frontend will raise an except
 
 ``` reach
 load: /examples/atomic-swap/index.rsh
+md5: 03b8d3534337fd397adb4120ff90a103
 range: 20-22
 ```
 
@@ -80,6 +82,7 @@ The @{defn("declassify")} primitive performs a declassification of the given arg
 
 ``` reach
 load: /examples/rps-7-array/index.rsh
+md5: d38eb05c7dc15d65d60114e7784da358
 range: 67-71
 ```
 
@@ -101,6 +104,7 @@ This is demonstrated in the example below.
 
 ```reach
 load: /examples/object-digest/index.rsh
+md5: 8d7e9f0180b6f53f80b36dcf172f5e73
 range: 16-22
 ```
 
@@ -118,10 +122,12 @@ For example, in the code below, a `{!rsh} didPublish` call is made on line 62 in
 
 ```reach
 load: /examples/raffle/index.rsh
+md5: b6632a71c54afc8e1da08f2d6c0dbad3
 range: 35-35
 ```
 
 ```reach
 load: /examples/raffle/index.rsh
+md5: b6632a71c54afc8e1da08f2d6c0dbad3
 range: 62-62
 ```

--- a/docs/src/rsh/step/index.md
+++ b/docs/src/rsh/step/index.md
@@ -441,6 +441,7 @@ It may only occur in a step.
 
 ``` reach
 load: /examples/simple-nft-auction/index.rsh
+md5: 1f95425a9feb9f5bf1e677461a83df4e
 range: 59-65
 ```
 
@@ -470,6 +471,7 @@ See [the guide section on races](##guide-race) to understand the benefits and da
 
 ```reach
 load: /examples/race/index.rsh
+md5: 10cf0e41a9cfa29a6277e0fc5fc147c6
 range: 51-55
 ```
 
@@ -489,6 +491,7 @@ It accepts an optional bytes argument, which is included in any reported violati
 
 ```reach
 load: /examples/rps-7-loops/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 73-73
 ```
 
@@ -521,6 +524,7 @@ The `{!rsh} nonNetPayAmt` parameter should be a pay amount. For example, when cl
 
 ```reach
 load: /examples/secured-loan/index.rsh
+md5: ed788f118c40a77028bf9414e1e2ac13
 range: 55 - 58
 ```
 

--- a/docs/src/tut/overview/index.md
+++ b/docs/src/tut/overview/index.md
@@ -43,6 +43,7 @@ The main part of the program looks like this:
 
 ```
 load: /examples/overview/index.rsh
+md5: c3ba149f23c49dec516123979898b14b
 range: 1-15
 ```
 
@@ -60,6 +61,7 @@ The elided lines, 14 through 34, contain the body of the application, which we c
 
 ```
 load: /examples/overview/index.rsh
+md5: c3ba149f23c49dec516123979898b14b
 range: 15-18
 ```
 
@@ -72,6 +74,7 @@ At this point, Bob's backend has learned the value of `{!rsh} request` and can d
 
 ```
 load: /examples/overview/index.rsh
+md5: c3ba149f23c49dec516123979898b14b
 range: 20-23
 ```
 
@@ -84,6 +87,7 @@ It's now Alice's turn again:
 
 ```
 load: /examples/overview/index.rsh
+md5: c3ba149f23c49dec516123979898b14b
 range: 25-29
 ```
 
@@ -96,6 +100,7 @@ The only thing left is for Bob's backend to deliver the information to his front
 
 ```
 load: /examples/overview/index.rsh
+md5: c3ba149f23c49dec516123979898b14b
 range: 31-33
 ```
 
@@ -148,6 +153,7 @@ Let's change the third step to leave a single unit in the balance:
 
 ```
 load: /examples/overview/index-error.rsh
+md5: 0756828e5a4ce18ee4835063706594ae
 range: 25-29
 ```
 
@@ -161,6 +167,7 @@ It will print out a detailed error message showing the violation.
 
 ```
 load: /examples/overview/index-error.txt
+md5: 7e916074ca72431b3520b6fc1996c8df
 range: 2-28
 ```
 
@@ -187,6 +194,7 @@ The program is just a few dozen lines long and the shell of it is quite simple:
 
 ```
 load: /examples/overview/index.mjs
+md5: b0ab403c2babb38238d85d34b318316a
 ```
 
 + Lines 1 and 2 import the Reach standard library loader and the compiled app backend.
@@ -205,6 +213,7 @@ Let's look at initializing and interfacing each participant, starting with Alice
 
 ```
 load: /examples/overview/index.mjs
+md5: b0ab403c2babb38238d85d34b318316a
 range: 13-16
 ```
 
@@ -216,6 +225,7 @@ Let's look at Bob next.
 
 ```
 load: /examples/overview/index.mjs
+md5: b0ab403c2babb38238d85d34b318316a
 range: 17-20
 ```
 
@@ -291,6 +301,7 @@ Let's take a look at some snippets from the React [index.js](@{REPO}/examples/ov
 
 ```
 load: /examples/overview-react/index.js
+md5: 6045f1f418f5096943132afe8db5bbe0
 range: 7-9
 ```
 
@@ -298,6 +309,7 @@ At the top of the file, we import the Reach-generated backend as `{!js} backend`
 
 ```
 load: /examples/overview-react/index.js
+md5: 6045f1f418f5096943132afe8db5bbe0
 range: 27-28
 ```
 
@@ -310,6 +322,7 @@ This is just like how in the Node.js deployment, the Reach programmer does not n
 
 ```
 load: /examples/overview-react/index.js
+md5: 6045f1f418f5096943132afe8db5bbe0
 range: 71-76
 ```
 
@@ -320,6 +333,7 @@ exactly as we did for the Node.js program.
 
 ```
 load: /examples/overview-react/index.js
+md5: 6045f1f418f5096943132afe8db5bbe0
 range: 79-85
 ```
 
@@ -327,6 +341,7 @@ Similarly, we implement a `{!js} runBackend` method that executes the Reach prog
 
 ```
 load: /examples/overview-react/index.js
+md5: 6045f1f418f5096943132afe8db5bbe0
 range: 112-121
 ```
 

--- a/docs/src/tut/rps/7-rpc/index.md
+++ b/docs/src/tut/rps/7-rpc/index.md
@@ -22,11 +22,13 @@ We begin by comparing the necessary imports and program body:
 
 ```
 load: /examples/rps-7-loops/index.mjs
+md5: 6af4573c7186ac0f544f46341767cff1
 range: 1-4
 ```
 
 ```
 load: /examples/rps-7-rpc/client-py/index.py
+md5: 5a2e97309d124148464f0cfcb3972a98
 range: 1-10
 ```
 
@@ -54,11 +56,13 @@ starting balance of `10`.
 
 ```
 load: /examples/rps-7-loops/index.mjs
+md5: 6af4573c7186ac0f544f46341767cff1
 range: 5-8
 ```
 
 ```
 load: /examples/rps-7-rpc/client-py/index.py
+md5: 5a2e97309d124148464f0cfcb3972a98
 range: 11-14
 ```
 
@@ -74,11 +78,13 @@ beginning balances:
 
 ```
 load: /examples/rps-7-loops/index.mjs
+md5: 6af4573c7186ac0f544f46341767cff1
 range: 9-13
 ```
 
 ```
 load: /examples/rps-7-rpc/client-py/index.py
+md5: 5a2e97309d124148464f0cfcb3972a98
 range: 15-23
 ```
 
@@ -88,11 +94,13 @@ Deploying and attaching to contracts works slightly differently over RPC:
 
 ```
 load: /examples/rps-7-loops/index.mjs
+md5: 6af4573c7186ac0f544f46341767cff1
 range: 14-16
 ```
 
 ```
 load: /examples/rps-7-rpc/client-py/index.py
+md5: 5a2e97309d124148464f0cfcb3972a98
 range: 24-25
 ```
 
@@ -113,11 +121,13 @@ equivalents:
 
 ```
 load: /examples/rps-7-loops/index.mjs
+md5: 6af4573c7186ac0f544f46341767cff1
 range: 17-18
 ```
 
 ```
 load: /examples/rps-7-rpc/client-py/index.py
+md5: 5a2e97309d124148464f0cfcb3972a98
 range: 26-28
 ```
 
@@ -127,11 +137,13 @@ Even participant interact interface definitions remain largely the same:
 
 ```
 load: /examples/rps-7-loops/index.mjs
+md5: 6af4573c7186ac0f544f46341767cff1
 range: 19-31
 ```
 
 ```
 load: /examples/rps-7-rpc/client-py/index.py
+md5: 5a2e97309d124148464f0cfcb3972a98
 range: 29-34
 ```
 
@@ -160,11 +172,13 @@ accordingly easily to implement in either language:
 
 ```
 load: /examples/rps-7-loops/index.mjs
+md5: 6af4573c7186ac0f544f46341767cff1
 range: 35-37
 ```
 
 ```
 load: /examples/rps-7-rpc/client-py/index.py
+md5: 5a2e97309d124148464f0cfcb3972a98
 range: 35-37
 ```
 
@@ -175,11 +189,13 @@ The same is true of `{!py} seeOutcome`:
 
 ```
 load: /examples/rps-7-loops/index.mjs
+md5: 6af4573c7186ac0f544f46341767cff1
 range: 32-34
 ```
 
 ```
 load: /examples/rps-7-rpc/client-py/index.py
+md5: 5a2e97309d124148464f0cfcb3972a98
 range: 38-47
 ```
 
@@ -198,11 +214,13 @@ code we have built up thus far to actually play a game of _Rock, Paper, Scissors
 
 ```
 load: /examples/rps-7-loops/index.mjs
+md5: 6af4573c7186ac0f544f46341767cff1
 range: 40-59
 ```
 
 ```
 load: /examples/rps-7-rpc/client-py/index.py
+md5: 5a2e97309d124148464f0cfcb3972a98
 range: 48-85
 ```
 

--- a/docs/src/tut/rps/index.md
+++ b/docs/src/tut/rps/index.md
@@ -100,6 +100,7 @@ For example, start off by typing the following into `index.rsh`:
 
 ```
 load: /examples/rps-1-setup/index.rsh
+md5: 31dcf80dd184f4e31efac02cc2c7f66e
 ```
 
 :::note
@@ -132,6 +133,7 @@ Open a new file named `index.mjs` and fill it with this:
 
 ```
 load: /examples/rps-1-setup/index.mjs
+md5: ed82d3f3222714d10cfe0536c19f7e54
 ```
 
 This JavaScript code is similarly schematic and will be consistent across all of your test programs.
@@ -196,6 +198,7 @@ The first step is to change the Reach program to specify that Alice and Bob's fr
 
 ```
 load: /examples/rps-2-rps/index.rsh
+md5: 3ea7718e88c86dd41e97b503d7aa3b67
 range: 1-17
 ```
 
@@ -208,6 +211,7 @@ Before continuing with the Reach application, let's move over to the JavaScript 
 
 ```
 load: /examples/rps-2-rps/index.mjs
+md5: 997ba05e8422c076a3c29cd5bcf427aa
 range: 12-32
 ```
 
@@ -245,6 +249,7 @@ First, the backend for Alice interacts with its frontend, gets Alice's hand, and
 
 ```
 load: /examples/rps-2-rps/index.rsh
+md5: 3ea7718e88c86dd41e97b503d7aa3b67
 range: 17-21
 ```
 
@@ -260,6 +265,7 @@ The next step is similar, in that Bob publishes his hand; however, we don't imme
 
 ```
 load: /examples/rps-2-rps/index.rsh
+md5: 3ea7718e88c86dd41e97b503d7aa3b67
 range: 23-29
 ```
 
@@ -274,6 +280,7 @@ Finally, we use the each form to have each of the participants send the final ou
 
 ```
 load: /examples/rps-2-rps/index.rsh
+md5: 3ea7718e88c86dd41e97b503d7aa3b67
 range: 31-33
 ```
 
@@ -357,6 +364,7 @@ We'll add this code in between account creation and contract deployment.
 
 ```
 load: /examples/rps-3-bets/index.mjs
+md5: fc6187211ecfeacd41be9495aa22deaf
 range: 5-12
 ```
 
@@ -368,6 +376,7 @@ Next, we'll update Alice's interface object to include her wager.
 
 ```
 load: /examples/rps-3-bets/index.mjs
+md5: fc6187211ecfeacd41be9495aa22deaf
 range: 31-34
 ```
 
@@ -379,6 +388,7 @@ For Bob, we'll modify his interface to show the wager and immediately accept it 
 
 ```
 load: /examples/rps-3-bets/index.mjs
+md5: fc6187211ecfeacd41be9495aa22deaf
 range: 35-40
 ```
 
@@ -388,6 +398,7 @@ Finally, after the computation is over, we'll get the balance again and show a m
 
 ```
 load: /examples/rps-3-bets/index.mjs
+md5: fc6187211ecfeacd41be9495aa22deaf
 range: 43-47
 ```
 
@@ -403,6 +414,7 @@ First, we need to update the participant interact interface.
 
 ```
 load: /examples/rps-3-bets/index.rsh
+md5: 4116cbc1247ecc15271aa776eedf1676
 range: 1-19
 ```
 
@@ -414,6 +426,7 @@ Let's look at Alice's first step first.
 
 ```
 load: /examples/rps-3-bets/index.rsh
+md5: 4116cbc1247ecc15271aa776eedf1676
 range: 19-25
 ```
 
@@ -428,6 +441,7 @@ Next, Bob needs to be shown the wager and given the opportunity to accept it and
 
 ```
 load: /examples/rps-3-bets/index.rsh
+md5: 4116cbc1247ecc15271aa776eedf1676
 range: 27-32
 ```
 
@@ -441,6 +455,7 @@ Before, it would compute the outcome and then commit the state; but now, it need
 
 ```
 load: /examples/rps-3-bets/index.rsh
+md5: 4116cbc1247ecc15271aa776eedf1676
 range: 34-41
 ```
 
@@ -561,6 +576,7 @@ If we change Bob's code to the following:
 
 ```
 load: /examples/rps-4-attack/index.rsh
+md5: bd577e73ff25f098ef38106416a3bff1
 range: 27-32
 ```
 
@@ -590,6 +606,7 @@ We can instruct Reach to prove this theorem by adding these lines after computin
 
 ```
 load: /examples/rps-4-attack/index.rsh
+md5: bd577e73ff25f098ef38106416a3bff1
 range: 34-37
 ```
 
@@ -600,6 +617,7 @@ Before we had this line in the file, when we ran `./reach compile`, it would pri
 
 ```
 load: /examples/rps-3-bets/index.txt
+md5: 45ed47e882a4edb92edf2e3d46469863
 range: 2-7
 ```
 
@@ -607,6 +625,7 @@ But now, it prints out
 
 ```
 load: /examples/rps-4-attack/index.txt
+md5: ddc6e13e30d19b2efce40b364614a41f
 range: 2-7
 ```
 
@@ -630,6 +649,7 @@ Let's start by undoing the changes we made earlier by changing
 
 ```
 load: /examples/rps-4-attack/index.rsh
+md5: bd577e73ff25f098ef38106416a3bff1
 range: 29-29
 ```
 
@@ -637,6 +657,7 @@ back to
 
 ```
 load: /examples/rps-4-attack/index-bad.rsh
+md5: c0015df1e967946be01b3bdab70c9c12
 range: 29-29
 ```
 
@@ -644,6 +665,7 @@ and removing
 
 ```
 load: /examples/rps-4-attack/index.rsh
+md5: bd577e73ff25f098ef38106416a3bff1
 range: 35-36
 ```
 
@@ -653,6 +675,7 @@ We should now have something that looks like
 
 ```
 load: /examples/rps-4-attack/index-bad.rsh
+md5: c0015df1e967946be01b3bdab70c9c12
 range: 27-41
 ```
 
@@ -662,6 +685,7 @@ When we run `./reach compile (reachexlink rps-4-attack/index-bad.rsh)`, it gives
 
 ```
 load: /examples/rps-4-attack/index-bad.txt
+md5: 272193fdf327080cc3192dbc90782efa
 range: 4-31
 ```
 
@@ -684,6 +708,7 @@ We'll add a single line to the program after Alice publishes, but before Bob tak
 
 ```
 load: /examples/rps-4-attack/index-fails.rsh
+md5: ee8173e8806e4b9757fe9b9e28a6d4b9
 range: 23-31
 ```
 
@@ -695,6 +720,7 @@ When we run `./reach run`, it reports that this assertion is false:
 
 ```
 load: /examples/rps-4-attack/index-fails.txt
+md5: 10ce8c3d19e7aefc50c8ebd58a858d1b
 range: 2-6
 ```
 
@@ -712,6 +738,7 @@ First, we'll define the rules of _Rock, Paper, Scissors!_ a little bit more abst
 
 ```
 load: /examples/rps-5-trust/index.rsh
+md5: 68fff9bccfaf2c29fba5ad5c1b41af17
 range: 1-7
 ```
 
@@ -726,6 +753,7 @@ However, Reach allows us to write such test cases directly into the Reach progra
 
 ```
 load: /examples/rps-5-trust/index.rsh
+md5: 68fff9bccfaf2c29fba5ad5c1b41af17
 range: 9-11
 ```
 
@@ -736,6 +764,7 @@ For example, we can state that no matter what values are provided for `{!rsh} ha
 
 ```
 load: /examples/rps-5-trust/index.rsh
+md5: 68fff9bccfaf2c29fba5ad5c1b41af17
 range: 13-15
 ```
 
@@ -743,6 +772,7 @@ And we can specify that whenever the same value is provided for both hands, no m
 
 ```
 load: /examples/rps-5-trust/index.rsh
+md5: 68fff9bccfaf2c29fba5ad5c1b41af17
 range: 17-18
 ```
 
@@ -757,6 +787,7 @@ We'll use these later on to protect Alice's hand.
 
 ```
 load: /examples/rps-5-trust/index.rsh
+md5: 68fff9bccfaf2c29fba5ad5c1b41af17
 range: 20-24
 ```
 
@@ -765,6 +796,7 @@ We'll use this to generate a random number to protect Alice's hand.
 
 ```
 load: /examples/rps-5-trust/index.mjs
+md5: d4b76de20d7406b04f2a430fc9c41b18
 range: 19-29
 ```
 
@@ -779,6 +811,7 @@ Next, we'll create the Reach app and the participant interact interface for Alic
 
 ```
 load: /examples/rps-5-trust/index.rsh
+md5: 68fff9bccfaf2c29fba5ad5c1b41af17
 range: 26-35
 ```
 
@@ -790,6 +823,7 @@ Reach's standard library comes with `{!rsh} makeCommitment` to make this easier 
 
 ```
 load: /examples/rps-5-trust/index.rsh
+md5: 68fff9bccfaf2c29fba5ad5c1b41af17
 range: 37-45
 ```
 
@@ -810,6 +844,7 @@ That's why we use a randomly generated salt.
 
 ```
 load: /examples/rps-5-trust/index.rsh
+md5: 68fff9bccfaf2c29fba5ad5c1b41af17
 range: 47-54
 ```
 
@@ -821,6 +856,7 @@ We now return to Alice who can reveal her secrets.
 
 ```
 load: /examples/rps-5-trust/index.rsh
+md5: 68fff9bccfaf2c29fba5ad5c1b41af17
 range: 56-61
 ```
 
@@ -833,6 +869,7 @@ The rest of the program is unchanged from the original version, except that it u
 
 ```
 load: /examples/rps-5-trust/index.rsh
+md5: 68fff9bccfaf2c29fba5ad5c1b41af17
 range: 63-74
 ```
 
@@ -948,6 +985,7 @@ First, we'll modify the participant interact interface to allow the frontend to 
 
 ```
 load: /examples/rps-6-timeouts/index.rsh
+md5: b390a5f23cadf2f5da1533378a83f52f
 range: 20-25
 ```
 
@@ -958,6 +996,7 @@ We'll make a slight tweak to our JavaScript frontend to be able to receive this 
 
 ```
 load: /examples/rps-6-timeouts/index.mjs
+md5: f1852dd1b33b99dcac138ee2c7fab9f2
 range: 19-32
 ```
 
@@ -966,6 +1005,7 @@ Similar to how she provides the wager, we will have Alice also provide the deadl
 
 ```
 load: /examples/rps-6-timeouts/index.rsh
+md5: b390a5f23cadf2f5da1533378a83f52f
 range: 28-32
 ```
 
@@ -978,6 +1018,7 @@ Next, at the start of the Reach application, we'll define a helper function to i
 
 ```
 load: /examples/rps-6-timeouts/index.rsh
+md5: b390a5f23cadf2f5da1533378a83f52f
 range: 39-43
 ```
 
@@ -992,6 +1033,7 @@ if she doesn't start the game, then no one is any worse off.
 
 ```
 load: /examples/rps-6-timeouts/index.rsh
+md5: b390a5f23cadf2f5da1533378a83f52f
 range: 45-54
 ```
 
@@ -1002,6 +1044,7 @@ However, we will adjust Bob's first message, because if he fails to participate,
 
 ```
 load: /examples/rps-6-timeouts/index.rsh
+md5: b390a5f23cadf2f5da1533378a83f52f
 range: 61-64
 ```
 
@@ -1015,6 +1058,7 @@ We will add a similar timeout handler to Alice's second message.
 
 ```
 load: /examples/rps-6-timeouts/index.rsh
+md5: b390a5f23cadf2f5da1533378a83f52f
 range: 70-71
 ```
 
@@ -1032,6 +1076,7 @@ Let's modify the JavaScript frontend to deliberately cause a timeout sometimes w
 
 ```
 load: /examples/rps-6-timeouts/index.mjs
+md5: f1852dd1b33b99dcac138ee2c7fab9f2
 range: 34-53
 ```
 
@@ -1124,6 +1169,7 @@ We'll modify the `{!js} Player` interact object so that it will have a different
 
 ```
 load: /examples/rps-7-loops/index.mjs
+md5: 6af4573c7186ac0f544f46341767cff1
 range: 19-38
 ```
 
@@ -1136,6 +1182,7 @@ It's just a matter of reverting to the simpler version from before.
 
 ```
 load: /examples/rps-7-loops/index.mjs
+md5: 6af4573c7186ac0f544f46341767cff1
 range: 40-52
 ```
 
@@ -1167,6 +1214,7 @@ Let's make these changes now.
 
 ```
 load: /examples/rps-7-loops/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 45-51
 ```
 
@@ -1175,6 +1223,7 @@ range: 45-51
 
 ```
 load: /examples/rps-7-loops/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 53-58
 ```
 
@@ -1200,6 +1249,7 @@ Here's what the structure looks like:
 
 ```
 load: /examples/rps-7-loops/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 59-61
 ```
 
@@ -1211,6 +1261,7 @@ Now, let's look at the body of the loop for the remaining steps, starting with A
 
 ```
 load: /examples/rps-7-loops/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 62-71
 ```
 
@@ -1219,6 +1270,7 @@ range: 62-71
 
 ```
 load: /examples/rps-7-loops/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 73-79
 ```
 
@@ -1226,6 +1278,7 @@ Similarly, Bob's code is almost identical to the prior version, except that he's
 
 ```
 load: /examples/rps-7-loops/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 81-87
 ```
 
@@ -1235,6 +1288,7 @@ Next is the end of the loop.
 
 ```
 load: /examples/rps-7-loops/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 89-91
 ```
 
@@ -1246,6 +1300,7 @@ The rest of the program could be exactly the same as it was before, except now i
 
 ```
 load: /examples/rps-7-loops/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 93-95
 ```
 
@@ -1333,6 +1388,7 @@ You'll see a lot of similarity between this and the last version, but for comple
 
 ```
 load: /examples/rps-8-interact/index.mjs
+md5: 9f824fcd58e5fdda4f4761b99093cfdc
 range: 1-4
 ```
 
@@ -1342,6 +1398,7 @@ We'll see how `ask` is used below.
 
 ```
 load: /examples/rps-8-interact/index.mjs
+md5: 9f824fcd58e5fdda4f4761b99093cfdc
 range: 5-10
 ```
 
@@ -1351,6 +1408,7 @@ range: 5-10
 
 ```
 load: /examples/rps-8-interact/index.mjs
+md5: 9f824fcd58e5fdda4f4761b99093cfdc
 range: 11-27
 ```
 
@@ -1360,6 +1418,7 @@ range: 11-27
 
 ```
 load: /examples/rps-8-interact/index.mjs
+md5: 9f824fcd58e5fdda4f4761b99093cfdc
 range: 28-39
 ```
 
@@ -1369,6 +1428,7 @@ range: 28-39
 
 ```
 load: /examples/rps-8-interact/index.mjs
+md5: 9f824fcd58e5fdda4f4761b99093cfdc
 range: 41-47
 ```
 
@@ -1376,6 +1436,7 @@ Next we define a few helper functions and start the participant interaction inte
 
 ```
 load: /examples/rps-8-interact/index.mjs
+md5: 9f824fcd58e5fdda4f4761b99093cfdc
 range: 49-52
 ```
 
@@ -1383,6 +1444,7 @@ Then we define a timeout handler.
 
 ```
 load: /examples/rps-8-interact/index.mjs
+md5: 9f824fcd58e5fdda4f4761b99093cfdc
 range: 54-71
 ```
 
@@ -1390,6 +1452,7 @@ Next, we request the wager amount or define the `{!js} acceptWager` method, depe
 
 ```
 load: /examples/rps-8-interact/index.mjs
+md5: 9f824fcd58e5fdda4f4761b99093cfdc
 range: 73-90
 ```
 
@@ -1397,6 +1460,7 @@ Next, we define the shared `{!js} getHand` method.
 
 ```
 load: /examples/rps-8-interact/index.mjs
+md5: 9f824fcd58e5fdda4f4761b99093cfdc
 range: 92-95
 ```
 
@@ -1404,6 +1468,7 @@ Finally, the `{!js} seeOutcome` method.
 
 ```
 load: /examples/rps-8-interact/index.mjs
+md5: 9f824fcd58e5fdda4f4761b99093cfdc
 range: 97-103
 ```
 
@@ -1561,6 +1626,7 @@ because [`rps-9-web/index.rsh`](@{REPO}/examples/rps-9-web/index.rsh) is the sam
 
 ```
 load: /examples/rps-9-web/index.js
+md5: 29b1b17df91e1d49053670f72eebc6b4
 range: 1-9
 ```
 
@@ -1576,6 +1642,7 @@ to achieve the desired effect.
 
 ```
 load: /examples/rps-9-web/index.js
+md5: 29b1b17df91e1d49053670f72eebc6b4
 range: 10-14
 ```
 
@@ -1589,11 +1656,13 @@ and tell it what to do once it mounts, which is the React term for starting.
 
 ```
 load: /examples/rps-9-web/index.js
+md5: 29b1b17df91e1d49053670f72eebc6b4
 range: 15-31
 ```
 
 ```
 load: /examples/rps-9-web/index.js
+md5: 29b1b17df91e1d49053670f72eebc6b4
 range: 39-41
 ```
 
@@ -1617,6 +1686,7 @@ Next, we define callbacks on `{!js} App` for what to do when the user clicks cer
 
 ```
 load: /examples/rps-9-web/index.js
+md5: 29b1b17df91e1d49053670f72eebc6b4
 range: 32-36
 ```
 
@@ -1633,6 +1703,7 @@ When we combine this with the view ([rps-9-web/views/AppViews.js](@{REPO}/exampl
 
 ```
 load: /examples/rps-9-web/index.js
+md5: 29b1b17df91e1d49053670f72eebc6b4
 range: 37-38
 ```
 
@@ -1652,6 +1723,7 @@ Our Web frontend needs to implement the participant interact interface for playe
 
 ```
 load: /examples/rps-9-web/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 20-25
 ```
 
@@ -1659,6 +1731,7 @@ We will provide these callbacks via the React component directly.
 
 ```
 load: /examples/rps-9-web/index.js
+md5: 29b1b17df91e1d49053670f72eebc6b4
 range: 42-55
 ```
 
@@ -1702,6 +1775,7 @@ Our Web frontend needs to implement the participant interact interface for Alice
 
 ```
 load: /examples/rps-9-web/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 28-32
 ```
 
@@ -1710,6 +1784,7 @@ and define some button handlers in order to trigger the deployment of the contra
 
 ```
 load: /examples/rps-9-web/index.js
+md5: 29b1b17df91e1d49053670f72eebc6b4
 range: 56-72
 ```
 
@@ -1753,6 +1828,7 @@ Our Web frontend needs to implement the participant interact interface for Bob, 
 
 ```
 load: /examples/rps-9-web/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 range: 33-36
 ```
 
@@ -1761,6 +1837,7 @@ and define some button handlers in order to attach to the deployed contract.
 
 ```
 load: /examples/rps-9-web/index.js
+md5: 29b1b17df91e1d49053670f72eebc6b4
 range: 73-95
 ```
 
@@ -1801,6 +1878,7 @@ The display when waiting for a turn ([rps-9-web/views/AttacherViews.js](@{REPO}/
 
 ```
 load: /examples/rps-9-web/index.js
+md5: 29b1b17df91e1d49053670f72eebc6b4
 range: 96-96
 ```
 
@@ -1942,18 +2020,21 @@ First, let's look at the Reach program:
 
 ```
 load: /examples/rps-8-interact/index.rsh
+md5: ee287e712cdfe8d91bbb038c383d25d3
 ```
 
 Next, the JavaScript command-line frontend:
 
 ```
 load: /examples/rps-8-interact/index.mjs
+md5: 9f824fcd58e5fdda4f4761b99093cfdc
 ```
 
 And finally, the Web frontend:
 
 ```
 load: /examples/rps-9-web/index.js
+md5: 29b1b17df91e1d49053670f72eebc6b4
 ```
 
 We wrote about a hundred lines of Reach and two different frontends.

--- a/docs/src/workshop/fomo-generalized/index.md
+++ b/docs/src/workshop/fomo-generalized/index.md
@@ -48,6 +48,7 @@ specialize it when we compile.
 
 ```
 load: /examples/workshop-fomo-generalized/index.rsh
+md5: e26e12724da243f13d5838f5281ba615
 range: 5-23
 ```
 
@@ -160,6 +161,7 @@ Let's look at our whole program now:
 
 ```
 load: /examples/workshop-fomo-generalized/index.rsh
+md5: e26e12724da243f13d5838f5281ba615
 ```
 
 ## {#workshop-fomo-generalized-de} Deployment Decisions
@@ -177,6 +179,7 @@ Here's the JavaScript frontend we wrote:
 
 ```
 load: /examples/workshop-fomo-generalized/index.mjs
+md5: 74b6cc410c339ee4ec5d023af5042095
 ```
 
 Let's see what it looks like when we run the program:

--- a/docs/src/workshop/fomo/index.md
+++ b/docs/src/workshop/fomo/index.md
@@ -83,6 +83,7 @@ Our participant interact interface, with the addition of some handy logging func
 
 ```
 load: /examples/workshop-fomo/index.rsh
+md5: ba9aaf213f98a723ff406ddf9209564f
 range: 4-22
 ```
 
@@ -181,6 +182,7 @@ Let's look at our whole program now:
 
 ```
 load: /examples/workshop-fomo/index.rsh
+md5: ba9aaf213f98a723ff406ddf9209564f
 ```
 
 ## {#workshop-fomo-de} Deployment Decisions
@@ -198,6 +200,7 @@ Here's the JavaScript frontend we wrote:
 
 ```
 load: /examples/workshop-fomo/index.mjs
+md5: f363477bbfe6ce16025fd0e18acab107
 ```
 
 Let's see what it looks like when we run the program:

--- a/docs/src/workshop/hash-lock/index.md
+++ b/docs/src/workshop/hash-lock/index.md
@@ -228,6 +228,7 @@ Here's what we did:
 
 ```
 load: /examples/workshop-hash-lock/index.rsh
+md5: 0e93e2215a2f36f5be42930a5705549f
 ```
 
 + Lines 11-14 have Alice declassify some of her values.
@@ -267,6 +268,7 @@ Here's the JavaScript frontend we wrote:
 
 ```
 load: /examples/workshop-hash-lock/index.mjs
+md5: 2893dd0e98313a8b5e408aa0f07b32fe
 ```
 
 In this case, Bob learns the password outside of the Reach program by directly sharing memory with Alice.

--- a/docs/src/workshop/relay/index.md
+++ b/docs/src/workshop/relay/index.md
@@ -65,6 +65,7 @@ Here's what we wrote in our program:
 
 ```
 load: /examples/workshop-relay/index.rsh
+md5: 56b6338c7902247ed5943735e96eed3b
 range: 6-8
 ```
 
@@ -151,6 +152,7 @@ Let's look at our whole program now:
 
 ```
 load: /examples/workshop-relay/index.rsh
+md5: 56b6338c7902247ed5943735e96eed3b
 ```
 
 ## {#workshop-relay-de} Deployment Decisions
@@ -167,6 +169,7 @@ Here's the JavaScript frontend we wrote:
 
 ```
 load: /examples/workshop-relay/index.mjs
+md5: c93d52a2841e3bf6979d8105257e901a
 ```
 
 We do a few sneaky things in this program:

--- a/docs/src/workshop/trust-fund/index.md
+++ b/docs/src/workshop/trust-fund/index.md
@@ -50,6 +50,7 @@ Here's what we wrote in our program:
 
 ```
 load: /examples/workshop-trust-fund/index.rsh
+md5: 06f0fa99d67d1d07af76ca83a0c8db3e
 range: 1-21
 ```
 
@@ -145,6 +146,7 @@ Let's look at our whole program now:
 
 ```
 load: /examples/workshop-trust-fund/index.rsh
+md5: 06f0fa99d67d1d07af76ca83a0c8db3e
 ```
 
 + Lines 33 and 34 use `{!rsh} each` to run the same code block `{!rsh} only` in each of the given participants.
@@ -172,6 +174,7 @@ Here's the JavaScript frontend we wrote:
 
 ```
 load: /examples/workshop-trust-fund/index.mjs
+md5: 29f9f977d13d9651062bf18288b6c072
 ```
 
 The most interesting part of this program is on lines 20 through 23 when we optionally cause a delay in the participant after they receive the signal that the account is funded.


### PR DESCRIPTION
This change adds `md5`s for about 223 examples in the documentation, to hopefully more easily catch documentation that is out-of-sync with `examples/`, as discussed in https://github.com/reach-sh/reach-lang/pull/986#issuecomment-1127884025.

This change also adds testing to our continuous integration that should catch examples added without an `md5sum`, or when an example linked from the documentation does not have an `md5sum` that matches the `md5` in the documentation.

The audio in this screen recording might be a bit loud, so you may want to lower your volume a bit before listening to it.

https://user-images.githubusercontent.com/43425812/169669105-63155536-7b7a-4128-8eb4-c30cd276c9d7.mp4