### PR TITLE
CORE-1845: fix missing newline and drop extraneous wrapping

### DIFF
--- a/reach
+++ b/reach
@@ -117,19 +117,19 @@ run_s () {
 }
 
 gen_reachc_id () {
-  REACH_ENV_FILE="${CNF}/env"
+  REACH_ENV_FILE="$CNF/env"
   MD5_CMD=md5sum
   if [ ! "$(command -v $MD5_CMD)" ]; then
     MD5_CMD=md5
   fi
   PRE_REACHC_ID=$(head -n1 /dev/urandom | $MD5_CMD | head -c 30 | tr '[:lower:]' '[:upper:]')
-  if [ ! -e "${REACH_ENV_FILE}" ]; then
-    echo "export REACHC_ID=${PRE_REACHC_ID}" > "${REACH_ENV_FILE}"
-  elif ( ! grep REACHC_ID "${REACH_ENV_FILE}" > /dev/null 2>&1 ); then
-    echo "export REACHC_ID=${PRE_REACHC_ID}" >> "${REACH_ENV_FILE}"
+  if [ ! -e "$REACH_ENV_FILE" ]; then
+    echo "export REACHC_ID=$PRE_REACHC_ID" > "$REACH_ENV_FILE"
+  elif ! grep REACHC_ID "$REACH_ENV_FILE" > /dev/null 2>&1; then
+    printf '\nexport REACHC_ID=%s\n' "$PRE_REACHC_ID" >> "$REACH_ENV_FILE"
   fi
   # shellcheck disable=SC1090
-  . "${REACH_ENV_FILE}"
+  . "$REACH_ENV_FILE"
 }
 
 call_home () {


### PR DESCRIPTION
[Discussion thread](https://github.com/reach-sh/reach-lang/discussions/1029).
[The reason this is possible: we didn't ensure an EOF newline until fairly recently](https://github.com/reach-sh/reach-lang/blame/da44a3514175e609f6aa03fc5d3c8fac9bf6a0f8/hs/app/reach/Main.hs#L1691).