### PR TITLE
CORE-1916/REACHp: create initial test harness

### DIFF
--- a/hs/Makefile
+++ b/hs/Makefile
@@ -154,6 +154,10 @@ watch-tsa: expand
 watch-proto-stub: expand
 	@$(call w,exe:proto-stub) -T Main.main
 
+.PHONY: watch-proto-test
+watch-proto-test: expand
+	@$(call w,test:reach-test) -T Reach.Test_Proto.main
+
 .PHONY: repl-reach-cli
 repl-reach-cli: expand
 	@stack ghci app/reach/Main.hs $(MEVEREST) \

--- a/hs/package.mo.yaml
+++ b/hs/package.mo.yaml
@@ -35,6 +35,7 @@ dependencies:
 - hexstring
 - hspec
 - hspec-smallcheck
+- hspec-wai
 - http-client
 - http-client-tls
 - http-conduit

--- a/hs/test/Reach/Test_Proto.hs
+++ b/hs/test/Reach/Test_Proto.hs
@@ -1,0 +1,30 @@
+module Reach.Test_Proto
+  ( spec_proto
+  , main
+  ) where
+
+import Network.HTTP.Client
+import Reach.Proto
+import Servant.API
+import Servant.Client
+import Test.Hspec
+import qualified Network.Wai.Handler.Warp as Warp
+
+-- TODO leverage `servant-quickcheck` package?
+
+main :: IO ()
+main = hspec spec_proto
+
+spec_proto :: Spec
+spec_proto = around (Warp.testWithApplication (pure . appStubServer False $ Just "sleep 2 && echo yes")) $ do
+  u <- runIO $ parseBaseUrl "http://localhost"
+  m <- runIO $ newManager defaultManagerSettings
+  let env p = mkClientEnv m $ u { baseUrlPort = p }
+
+  describe "Requesting `reach compile`" $ do
+    it "should return a `Res` (which we'll flesh out later)" $ \p ->
+      runClientM (cmd'' "compile" $ Req [] Nothing mempty) (env p) >>= (`shouldBe` Right Res)
+
+  describe "`say`ing some freeform text to a `PID`" $ do
+    it "should succeed" $ \p ->
+      runClientM (say'' "1024" "pipe me through `PID`'s stdin") (env p) >>= (`shouldBe` Right NoContent)


### PR DESCRIPTION
~Dependent upon #1189; if that gets merged to `master` I'll rebase this and flip it out of "draft" mode.~

```
$ make watch-proto-test
Requesting `reach compile`
  should return a `Res` (which we'll flesh out later)
`say`ing some freeform text to a `PID`
  should succeed

Finished in 0.5190 seconds
2 examples, 0 failures
```

The prospect of building up a test suite like this raises an obvious question: how will you account for the tight-coupling of runtime concerns like databases and proxies and remote containers, etc?

My hand-wavy answer is that orienting work around tests like this _early_ naturally lends the product to mocking + simpler abstraction in the style of "functional core; imperative shell". If we design mainly in terms of nouns and datatypes instead of verbs and opaque side-effects I think we'll better understand our code's innards, and using spec tests like this encourages the discipline.

This PR is deliberately small lest I'm the only one who thinks it's a good idea :-)