### PR TITLE
DCT-486: add documentation for `reach support`

### DIFF
--- a/docs/src/tool/index.md
+++ b/docs/src/tool/index.md
@@ -219,6 +219,18 @@ $ reach scaffold
 
 The files created are the same as those used temporarily by `{!cmd} reach run`.
 
+# {#ref-usage-support} @{ref("cmd", "reach support")} `reach support`
+
+You can upload a gist to GitHub using
+
+```cmd
+$ reach support
+```
+
+Successful completion of this command gives you a link to a gist on GitHub that anyone with the link can view.
+
+`{!cmd} reach support` uploads `index.rsh` from the current directory, if it can find it, and `index.mjs` from the current directory, if it can find it.
+
 # {#ref-usage-react} @{ref("cmd", "reach react")} `reach react`
 
 You can run a simple React app by executing

--- a/docs/xrefs.json
+++ b/docs/xrefs.json
@@ -1307,6 +1307,10 @@
     "title": "<span class=\"ref\" id=\"cmd_reach%20scaffold\" data-scope=\"cmd\" data-symbol=\"reach scaffold\"> </span>   reach scaffold",
     "path": "/tool/#ref-usage-scaffold"
   },
+  "ref-usage-support": {
+    "title": "<span class=\"ref\" id=\"cmd_reach%20support\" data-scope=\"cmd\" data-symbol=\"reach support\"> </span>   reach support",
+    "path": "/tool/#ref-usage-support"
+  },
   "ref-usage-update": {
     "title": "<span class=\"ref\" id=\"cmd_reach%20update\" data-scope=\"cmd\" data-symbol=\"reach update\"> </span>   reach update",
     "path": "/tool/#ref-usage-update"


### PR DESCRIPTION
My plan is to add a commit that further updates the documentation to #1063, after successful merging of this pull request, to avoid merge conflicts.

8a5cf6b3bfb52d69b520e9dce2cd0edbb8474f03 makes the documentation look like this.

![image](https://user-images.githubusercontent.com/43425812/175792107-d8548b84-906d-4cc9-8625-ef7992abb15c.png)