### PR TITLE
CORE-1976: ease duplicate containers predicate

### DIFF
--- a/hs/app/reach/Main.hs
+++ b/hs/app/reach/Main.hs
@@ -1117,7 +1117,7 @@ compile = command "compile" $ info f d
 
         else
           cid="$(docker ps -f "ancestor=reachsh/reach:$v" --format '{{.ID}} {{.Labels}}' \
-            | grep " sh.reach.dir-project=$$PWD\$$" \
+            | grep "sh.reach.dir-project=$$PWD" \
             | awk '{print $$1}' \
             | head -n1)"
 

--- a/hs/app/reach/Main.hs
+++ b/hs/app/reach/Main.hs
@@ -1117,7 +1117,8 @@ compile = command "compile" $ info f d
 
         else
           cid="$(docker ps -f "ancestor=reachsh/reach:$v" --format '{{.ID}} {{.Labels}}' \
-            | grep "sh.reach.dir-project=$$PWD" \
+            | grep -e "sh.reach.dir-project=$$(pwd)\$$" \
+                   -e "sh.reach.dir-project=$$(pwd)," \
             | awk '{print $$1}' \
             | head -n1)"
 

--- a/reach
+++ b/reach
@@ -80,7 +80,8 @@ run_d () {
         "$@"
   else
     cid="$(docker ps -f "ancestor=$IMG" --format '{{.ID}} {{.Labels}}' \
-      | grep "sh.reach.dir-project=$(pwd)" \
+      | grep -e "sh.reach.dir-project=$(pwd)\$" \
+             -e "sh.reach.dir-project=$(pwd)," \
       | awk '{print $1}' \
       | head -n1)"
 

--- a/reach
+++ b/reach
@@ -80,7 +80,7 @@ run_d () {
         "$@"
   else
     cid="$(docker ps -f "ancestor=$IMG" --format '{{.ID}} {{.Labels}}' \
-      | grep " sh.reach.dir-project=$(pwd)\$" \
+      | grep "sh.reach.dir-project=$(pwd)" \
       | awk '{print $1}' \
       | head -n1)"
 


### PR DESCRIPTION
A handful of people have reported containers not being reused... Turns out Docker Desktop appends metadata labels that defeated the brittle `grep` predicate we use to pluck existing container IDs from the heap, so unfortunately I have to make it more brittle still.

_Why use a naive `grep` filter instead of Docker's own label-querying feature?_ The short answer is "directories with spaces". There doesn't seem to be any way of escaping query text that's usable for our needs (otherwise: same issue with spawning more and more containers), which is why I replaced it.
