### PR TITLE
CORE-2011/REACHp: propose response types + dispatch/interpreter

### DIFF
--- a/hs/Makefile
+++ b/hs/Makefile
@@ -176,4 +176,5 @@ proto-stub-serve: hs-build
 .PHONY: proto-stub-client
 proto-stub-client: hs-build
 	@stack exec -- proto-stub cmd init --help
+	@stack exec -- proto-stub cmd no-such --cli || :
 	@stack exec -- proto-stub cmd compile --verify-fail-once

--- a/hs/Makefile
+++ b/hs/Makefile
@@ -164,6 +164,7 @@ watch-reachpc: expand
 
 .PHONY: repl-reach-cli
 repl-reach-cli: expand
+	@stack build --fast $(MEVEREST)
 	@stack ghci app/reach/Main.hs $(MEVEREST) \
 	  --package pretty-simple \
 	  --ghci-options "-interactive-print=Text.Pretty.Simple.pPrint"

--- a/hs/Makefile
+++ b/hs/Makefile
@@ -174,8 +174,5 @@ proto-stub-serve: hs-build
 
 .PHONY: proto-stub-client
 proto-stub-client: hs-build
-	@stack exec -- proto-stub cmd help
+	@stack exec -- proto-stub cmd init --help
 	@stack exec -- proto-stub cmd compile --verify-fail-once
-	@stack exec -- proto-stub cmd run examples/ttt foo bar baz
-	@stack exec -- proto-stub say
-	@stack exec -- proto-stub listen

--- a/hs/app/proto-stub/Main.hs
+++ b/hs/app/proto-stub/Main.hs
@@ -10,6 +10,8 @@ import System.Environment
 import System.Exit
 import System.IO
 import qualified Data.ByteString.Lazy.UTF8 as BL
+import qualified Data.Map.Strict as M
+import qualified Data.Text as T
 import qualified Data.Text.IO as T
 
 main :: IO ()
@@ -19,7 +21,10 @@ main = do
     ["serve"] -> do
       putStrLn . color Magenta $ "Serving on port: " <> (style Bold $ show stubPort) <> "..."
       runStubServer
-    c -> cmd' m (maybe "help" id $ (drop 1 c) `atMay` 0) $ Req (drop 2 c) Nothing mempty
+    c -> cmd' m
+      (maybe "help" id $ (drop 1 c) `atMay` 0)
+      (Just $ XProject "matt" "rps")
+      $ Req (drop 2 c) Nothing mempty
  where
   err e = putStrLn ("Failed with:\n" <> e) >> exitWith (ExitFailure 1)
   env m = mkClientEnv m $ BaseUrl Http "localhost" stubPort ""
@@ -37,22 +42,26 @@ main = do
       $ "Listening to stub server on port: " <> (style Bold $ show stubPort) <> "..."
     listen (env m) err msg p Stdboth'
 
-  cmd' m c r@Req{..} = do
-    putStrLn . color Magenta $ (style Bold $ "`reach " <> c <> " " <> intercalate " " req_args <> "`")
+  cmd' m c mp r@Req{..} = do
+    let as = if null req_args then "" else " " <> intercalate " " req_args
+    putStrLn . color Magenta $ (style Bold $ "`reach " <> c <> as <> "`")
       <> " to stub server on port: " <> show stubPort <> "..."
-    cmd (env m) c r $ \case
+    cmd (env m) err c mp r $ \case
       -- TODO redirects mean we'll need to swap the "manager" that lives in our `ClientEnv`
       Redirect h -> putStrLn $ "Received redirect to host: " <> h
-      Interpret i -> interpret i
-   where
-    interpret = \case
-      ExitStdout n t -> T.hPutStrLn stdout (t <> "\n") *> exitWith' n
-      ExitStderr n t -> T.hPutStrLn stderr (t <> "\n") *> exitWith' n
-      PutProjectUpdates _ -> pure () -- TODO
-      AttachStreamJustListen p _n -> listen' m p
-      AttachStreamListenSpeak _ _ -> do
-        -- TODO: this will involve a multi-threaded system whereby we wait for
-        -- input from local stdin and immediately `say` it while simultaneously
-        -- `listen`ing for std(out|err) coming from the cloud and piping that
-        -- to console in an async-safe way
-        pure ()
+      Interpret i -> case i of
+        ExitStdout n t -> T.hPutStrLn stdout (t <> "\n") *> exitWith' n
+        ExitStderr n t -> T.hPutStrLn stderr (t <> "\n") *> exitWith' n
+        AttachStreamJustListen p _n -> listen' m p
+        AttachStreamListenSpeak _ _ -> do
+          -- TODO: this will involve a multi-threaded system whereby we wait for
+          -- input from local stdin and immediately `say` it while simultaneously
+          -- `listen`ing for std(out|err) coming from the cloud and piping that
+          -- to console in an async-safe way
+          pure ()
+        PutProjectUpdates _ -> maybe (fail "You must specify a project!") pure mp >>= \p -> do
+          putStrLn . color Magenta
+            $ "Syncing project `"
+           <> T.unpack (fromXProject p)
+           <> "` to stub server on port: " <> (style Bold $ show stubPort) <> "..."
+          projPut (env m) p . ReqProjPut $ M.fromList [] -- TODO

--- a/hs/app/proto-stub/Main.hs
+++ b/hs/app/proto-stub/Main.hs
@@ -1,41 +1,58 @@
 module Main (main) where
 
+import Data.List (intercalate)
 import Network.HTTP.Client
 import Reach.Proto
 import Safe
 import Servant.Client
+import System.Console.Pretty
 import System.Environment
 import System.Exit
-import qualified Data.Text as T
+import System.IO
+import qualified Data.ByteString.Lazy.UTF8 as BL
+import qualified Data.Text.IO as T
 
 main :: IO ()
 main = do
   m <- newManager defaultManagerSettings
   getArgs >>= \case
-    ["serve"] -> putStrLn ("Serving on port: " <> show stubPort <> "...") >> runStubServer
-    ["say"] -> say' m
-    ["listen"] -> listen' m
-    c -> cmd' m (maybe "help" id $ (drop 1 c) `atMay` 0) $ Req (T.pack <$> drop 2 c) Nothing mempty
+    ["serve"] -> do
+      putStrLn . color Magenta $ "Serving on port: " <> (style Bold $ show stubPort) <> "..."
+      runStubServer
+    c -> cmd' m (maybe "help" id $ (drop 1 c) `atMay` 0) $ Req (drop 2 c) Nothing mempty
  where
-  pid = "54321"
   err e = putStrLn ("Failed with:\n" <> e) >> exitWith (ExitFailure 1)
   env m = mkClientEnv m $ BaseUrl Http "localhost" stubPort ""
 
+  exitWith' n = exitWith (if n == 0 then ExitSuccess else ExitFailure n)
+
   msg = \case
-    Stdout n m -> putStrLn $ "id# " <> show n <> " (stdout): " <> show m
-    Stderr n m -> putStrLn $ "id# " <> show n <> " (stderr): " <> show m
+    Stdout n m -> putStrLn $ "id# " <> show n <> " (stdout): " <> BL.toString m
+    Stderr n m -> putStrLn $ "id# " <> show n <> " (stderr): " <> BL.toString m
     Keepalive  -> putStrLn $ "(keepalive)"
-    ExitCode' n m -> putStrLn ("id# " <> show n <> " (exit code): " <> show m)
-      *> exitWith (if m == 0 then ExitSuccess else ExitFailure m)
+    ExitCode' n m -> putStrLn ("id# " <> show n <> " (exit code): " <> show m) *> exitWith' m
 
-  say' m = do
-    putStrLn $ "Say `hello` to PID# " <> T.unpack pid <> " at stub server on port: " <> show stubPort <> "..."
-    say (env m) pid "hello"
+  listen' m p = do
+    putStrLn . color Magenta
+      $ "Listening to stub server on port: " <> (style Bold $ show stubPort) <> "..."
+    listen (env m) err msg p Stdboth'
 
-  listen' m = do
-    putStrLn $ "Listening to stub server on port: " <> show stubPort <> "..."
-    listen (env m) err msg pid Stdboth'
-
-  cmd' m c r = do
-    putStrLn $ "`reach " <> c <> "` to stub server on port: " <> show stubPort <> "..."
-    cmd (env m) c r
+  cmd' m c r@Req{..} = do
+    putStrLn . color Magenta $ (style Bold $ "`reach " <> c <> " " <> intercalate " " req_args <> "`")
+      <> " to stub server on port: " <> show stubPort <> "..."
+    cmd (env m) c r $ \case
+      -- TODO redirects mean we'll need to swap the "manager" that lives in our `ClientEnv`
+      Redirect h -> putStrLn $ "Received redirect to host: " <> h
+      Interpret i -> interpret i
+   where
+    interpret = \case
+      ExitStdout n t -> T.hPutStrLn stdout (t <> "\n") *> exitWith' n
+      ExitStderr n t -> T.hPutStrLn stderr (t <> "\n") *> exitWith' n
+      PutProjectUpdates _ -> pure () -- TODO
+      AttachStreamJustListen p _n -> listen' m p
+      AttachStreamListenSpeak _ _ -> do
+        -- TODO: this will involve a multi-threaded system whereby we wait for
+        -- input from local stdin and immediately `say` it while simultaneously
+        -- `listen`ing for std(out|err) coming from the cloud and piping that
+        -- to console in an async-safe way
+        pure ()

--- a/hs/package.open.yaml
+++ b/hs/package.open.yaml
@@ -52,6 +52,7 @@ dependencies:
 - loop
 - main-tester
 - memory
+- mmorph
 - mtl
 - mysql-simple
 - optparse-applicative

--- a/hs/src/Reach/Proto.hs
+++ b/hs/src/Reach/Proto.hs
@@ -92,7 +92,7 @@ ecode = \case
   ExitFailure n -> n
 
 data XProject = XProject
-  { xproj_orgOrUser :: Text
+  { xproj_orgOrUser :: Text -- CORE-2027
   , xproj_name :: Text
   } deriving (Eq, Show)
 

--- a/hs/test/Reach/Test_Proto.hs
+++ b/hs/test/Reach/Test_Proto.hs
@@ -22,11 +22,16 @@ import qualified Servant.Client.Streaming as S
 
 main :: IO ()
 main = hspec $ do
+  spec_account
   spec_headerParse
   spec_proto
 
 type MXP = Maybe XProject
 type EXP = Either String XProject
+
+spec_account :: Spec
+spec_account = describe "Parsing an `Account`" $ do
+  it "<has yet to be specified>" $ pendingWith "CORE-2029"
 
 spec_headerParse :: Spec
 spec_headerParse = describe "Parsing an" $ do

--- a/hs/test/Reach/Test_Proto.hs
+++ b/hs/test/Reach/Test_Proto.hs
@@ -1,43 +1,80 @@
 module Reach.Test_Proto
-  ( spec_proto
+  ( spec_headerParse
+  , spec_proto
   , main
   ) where
 
+import Control.Monad.Except
+import Data.Aeson
 import Network.HTTP.Client
 import Reach.Proto
 import Safe
 import Servant.API
 import Servant.Client
+import Servant.Types.SourceT
 import Test.Hspec
+import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import qualified Network.Wai.Handler.Warp as Warp
+import qualified Servant.Client.Streaming as S
 
 -- TODO leverage `servant-quickcheck` package?
 
 main :: IO ()
-main = hspec spec_proto
+main = hspec $ do
+  spec_headerParse
+  spec_proto
+
+type MXP = Maybe XProject
+type EXP = Either String XProject
+
+spec_headerParse :: Spec
+spec_headerParse = describe "Parsing an" $ do
+  describe "X-Reach-Project header" $ do
+    it "without a preceding `@` character will fail" $ do
+      let x = "Error in $: (line 1, column 1):\nunexpected \"r\"\nexpecting \"@\""
+      eitherDecode "\"reach-sh/foo\"" `shouldBe` (Left x :: EXP)
+
+    it "missing a separating `/` character will fail" $ do
+      let x = "Error in $: (line 1, column 10):\nunexpected end of input\nexpecting letter or digit or \"-\""
+      eitherDecode "\"@reach-sh\"" `shouldBe` (Left x :: EXP)
+
+    it "will fail if non-alphanumerics occur at beginning or end" $ do
+      decode "\"@-reach-sh/foo\"" `shouldBe` (Nothing :: MXP)
+      decode "\"@reach-sh/foo-\"" `shouldBe` (Nothing :: MXP)
+      decode "\"@a/b$\"" `shouldBe` (Nothing :: MXP)
+
+    it "such as `@jay/rsvp` will succeed" $ do
+      eitherDecode "\"@jay/rsvp\"" `shouldBe` Right (XProject "jay" "rsvp")
 
 spec_proto :: Spec
 spec_proto = around (Warp.testWithApplication app) $ do
   u <- runIO $ parseBaseUrl "http://localhost"
   m <- runIO $ newManager defaultManagerSettings
   let env p = mkClientEnv m $ u { baseUrlPort = p }
-  let run p x = runClientM x (env p) >>= either (fail . show) (pure . id)
+  let run p x = S.withClientM x (env p) . either (fail . show) $ \a ->
+            runExceptT (runSourceT a) >>= either (fail . show) pure
 
+  -- TODO FS mock
   describe "Requesting `reach compile`" $ do
     it "with a bogus flag like --nope will fail" $ \p -> do
-      Interpret (ExitStderr n t) <- run p . cmd'' "compile" $ Req ["--nope"] Nothing mempty
+      [Interpret (ExitStderr n t)] <- run p $ cmd'' "compile" Nothing $ Req ["--nope"] Nothing mempty
       n `shouldBe` 1
       headMay (T.splitOn "\n" t) `shouldBe` Just "Invalid option `--nope'"
 
     it "with a supported flag like --print-keyword-info will succeed" $ \p -> do
-      run p (cmd'' "compile" $ Req ["--print-keyword-info"] Nothing mempty) >>= \case
-        Interpret (AttachStreamJustListen _ _) -> pure ()
-        x -> x `shouldNotBe` x
+      [Interpret (AttachStreamJustListen _ _)] <- run p . cmd'' "compile" Nothing $ Req
+        ["--print-keyword-info"]
+        (Just $ M.fromList
+          [ ("index.mjs", "<hash>")
+          , ("index.rsh", "<hash>")
+          ])
+        mempty
+      pure ()
 
   describe "`say`ing some freeform text to a `PID`" $ do
     it "should succeed" $ \p ->
       runClientM (say'' "1024" "pipe me through `PID`'s stdin") (env p) >>= (`shouldBe` Right NoContent)
 
  where
-  app = pure . appStubServer stubDispatchReach False $ Just "sleep 2 && echo yes"
+  app = pure . appStubServer StubConfig stubDispatchReach False $ Just "sleep 2 && echo yes"

--- a/hs/test/Reach/Test_Proto.hs
+++ b/hs/test/Reach/Test_Proto.hs
@@ -32,7 +32,7 @@ type EXP = Either String XProject
 
 spec_account :: Spec
 spec_account = describe "Parsing an `Account`" $ do
-  it "<has yet to be specified>" $ pendingWith "CORE-2029"
+  it "<has yet to be specified/CORE-2029>" $ True
 
 spec_headerParse :: Spec
 spec_headerParse = describe "Parsing an" $ do

--- a/hs/test/Reach/Test_Proto.hs
+++ b/hs/test/Reach/Test_Proto.hs
@@ -5,9 +5,11 @@ module Reach.Test_Proto
 
 import Network.HTTP.Client
 import Reach.Proto
+import Safe
 import Servant.API
 import Servant.Client
 import Test.Hspec
+import qualified Data.Text as T
 import qualified Network.Wai.Handler.Warp as Warp
 
 -- TODO leverage `servant-quickcheck` package?
@@ -16,15 +18,26 @@ main :: IO ()
 main = hspec spec_proto
 
 spec_proto :: Spec
-spec_proto = around (Warp.testWithApplication (pure . appStubServer False $ Just "sleep 2 && echo yes")) $ do
+spec_proto = around (Warp.testWithApplication app) $ do
   u <- runIO $ parseBaseUrl "http://localhost"
   m <- runIO $ newManager defaultManagerSettings
   let env p = mkClientEnv m $ u { baseUrlPort = p }
+  let run p x = runClientM x (env p) >>= either (fail . show) (pure . id)
 
   describe "Requesting `reach compile`" $ do
-    it "should return a `Res` (which we'll flesh out later)" $ \p ->
-      runClientM (cmd'' "compile" $ Req [] Nothing mempty) (env p) >>= (`shouldBe` Right Res)
+    it "with a bogus flag like --nope will fail" $ \p -> do
+      Interpret (ExitStderr n t) <- run p . cmd'' "compile" $ Req ["--nope"] Nothing mempty
+      n `shouldBe` 1
+      headMay (T.splitOn "\n" t) `shouldBe` Just "Invalid option `--nope'"
+
+    it "with a supported flag like --print-keyword-info will succeed" $ \p -> do
+      run p (cmd'' "compile" $ Req ["--print-keyword-info"] Nothing mempty) >>= \case
+        Interpret (AttachStreamJustListen _ _) -> pure ()
+        x -> x `shouldNotBe` x
 
   describe "`say`ing some freeform text to a `PID`" $ do
     it "should succeed" $ \p ->
       runClientM (say'' "1024" "pipe me through `PID`'s stdin") (env p) >>= (`shouldBe` Right NoContent)
+
+ where
+  app = pure . appStubServer stubDispatchReach False $ Just "sleep 2 && echo yes"

--- a/hs/test/Reach/Test_Proto.hs
+++ b/hs/test/Reach/Test_Proto.hs
@@ -1,5 +1,6 @@
 module Reach.Test_Proto
-  ( spec_headerParse
+  ( spec_account
+  , spec_headerParse
   , spec_proto
   , main
   ) where


### PR DESCRIPTION
This PR offers a sketch of how we might approach:
- [An open spec question](https://github.com/reach-sh/reach-everest/pull/5#discussion_r899189655)
- Keeping `reachpc`'s knowledge minimal
- Maintaining our current CLI features

Basically: boring old dispatch/interpret patterns. This isn't intended to be complete but I think we could use it as a foundation to continue building upon if there's rough consensus about the design.

*`Res` is short for "response"*
```haskell
data ResInterpret
  = ExitStdout Int Text
  | ExitStderr Int Text
  | AttachStreamJustListen Pid Integer
  | AttachStreamListenSpeak Pid Integer
  -- TODO spec further:
  --  * We'll want to batch PUTs rather than send them all at once
  --  * Once the cloud is satisfied it has everything we'll redirect the client
  | PutProjectUpdates ProjectContent
  deriving (Eq, Show, Generic, FromJSON, ToJSON)

data Res
  = Redirect String
  | Interpret ResInterpret
  deriving (Eq, Show, Generic, FromJSON, ToJSON)
```

`PutProjectUpdates` is how a cloud service might ask `reachpc` to push updated project modules up over the wire. The client may need to do this before receiving an `AttachStreamJustListen`, for instance.

[![asciicast](https://asciinema.org/a/0sz2fuf5GrgEHzsMVn99Yiy8y.svg)](https://asciinema.org/a/0sz2fuf5GrgEHzsMVn99Yiy8y)
[![asciicast](https://asciinema.org/a/16q0HfwdKSRpjDC3NCa8QMqhu.svg)](https://asciinema.org/a/16q0HfwdKSRpjDC3NCa8QMqhu)