### PR TITLE
update righthand column icons for consistency

### DIFF
--- a/docs/src/base.html
+++ b/docs/src/base.html
@@ -159,7 +159,10 @@
                       class="btn btn-outline-secondary btn-sm show-otp-col"
                       onclick="setItemToBlock(event, 'otp-col')"
                     >
-                      <i class="fas fa-bars"></i>
+                      <img
+                        alt="open right sidebar"
+                        src="/assets/icons/Colorway=Light Mode, State=Hover, Action=Collapse.svg"
+                      />
                     </button>
                   </div>
                 </div>
@@ -188,7 +191,10 @@
                 class="btn btn-outline-secondary btn-sm hide-otp-icon"
                 onclick="setItemToNone(event, 'otp-col')"
               >
-                <i class="fas fa-times"></i>
+                <img
+                  alt="close right sidebar"
+                  src="/assets/icons/Colorway=Dark Mode, State=Hover, Action=Expand.svg"
+                />
               </button>
             </div>
           </div>


### PR DESCRIPTION
#### Current righthand column icon appearance

![current righthand expand icon](https://user-images.githubusercontent.com/43425812/178077892-9670123b-21c2-4b13-bfb0-daa6fabbaccb.png)

![current righthand collapse icon](https://user-images.githubusercontent.com/43425812/178077894-9312379b-83d7-4e2c-9de4-fbfa19ec491a.png)

#### Appearance with this change

![new righthand expand icon](https://user-images.githubusercontent.com/43425812/178077904-a25cea62-ac73-4ccd-818e-58680059979b.png)

![new righthand column collapse icon](https://user-images.githubusercontent.com/43425812/178077910-f949f9c8-453b-41d7-851d-223fceebcab6.png)