### PR TITLE
CORE-1569: Use `apiStateMismatchError` for API Wrappers

### DIFF
--- a/examples/api-state-mismatch/index.mjs
+++ b/examples/api-state-mismatch/index.mjs
@@ -1,0 +1,44 @@
+import { loadStdlib } from '@reach-sh/stdlib';
+import { util } from '@reach-sh/stdlib';
+const { thread, Signal, Timeout } = util;
+import * as backend from './build/index.main.mjs';
+
+const stdlib = loadStdlib(process.env);
+
+const ready = new Signal();
+
+const startingBalance = stdlib.parseCurrency(100);
+
+const [ accAlice, accBob ] =
+  await stdlib.newTestAccounts(2, startingBalance);
+
+const ctcAdmin = accAlice.contract(backend);
+const ctcBob = accBob.contract(backend, ctcAdmin.getInfo());
+
+const expectedError = `Expected the DApp to be in state(s) [1,3], but it was actually in state 2.
+
+State 1 corresponds to the commit() at : Module
+  at ./index.rsh:15:11:after expr stmt semicolon,
+State 3 corresponds to the commit() at : Module
+  at ./index.rsh:23:11:after expr stmt semicolon
+State 2 corresponds to the commit() at : Module
+  at ./index.rsh:19:11:after expr stmt semicolon`
+
+await Promise.all([
+  backend.Alice(ctcAdmin, {
+    done: () => ready.notify()
+  }),
+  thread(async () => {
+    await ready.wait();
+    const f = ctcBob.a.B.f;
+    await f();
+    try {
+      await f();
+    } catch (e) {
+      const msg = e.toString();
+      console.log(`Error thrown: `, msg);
+      stdlib.assert(msg.includes(expectedError), "Contains expected error message");
+      process.exit();
+    }
+  }),
+]);

--- a/examples/api-state-mismatch/index.rsh
+++ b/examples/api-state-mismatch/index.rsh
@@ -1,0 +1,29 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const A = Participant('Alice', {
+    done: Fun([], Null)
+  });
+  const B = API('B', {
+    f: Fun([], Null),
+    g: Fun([], Null),
+  })
+  init();
+
+  A.publish();
+  A.interact.done();
+  commit();
+
+  const [ _, k1] = call(B.f);
+  k1(null);
+  commit();
+
+  const [ _, k2 ] = call(B.g);
+  k2(null);
+  commit();
+
+  const [ _, k3 ] = call(B.f);
+  k3(null);
+  commit();
+
+});

--- a/examples/api-state-mismatch/index.txt
+++ b/examples/api-state-mismatch/index.txt
@@ -1,0 +1,5 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 13 theorems; No failures!

--- a/hs/src/Reach/Backend/JS.hs
+++ b/hs/src/Reach/Backend/JS.hs
@@ -215,15 +215,18 @@ jsBool = \case
 jsNum :: Integer -> Doc
 jsNum = jsString . show
 
+jsChkBigNum :: SrcLoc -> UIntTy -> Doc -> App Doc
+jsChkBigNum at uit i = do
+  uim <- case uit of
+            UI_Word -> jsArg (DLA_Constant $ DLC_UInt_max)
+            UI_256 -> return $ jsNum $ uint256_Max
+  return $ jsApply "stdlib.checkedBigNumberify" [jsAt at, uim, i]
+
 jsCon :: AppT DLLiteral
 jsCon = \case
   DLL_Null -> return "null"
   DLL_Bool b -> return $ jsBool b
-  DLL_Int at uit i -> do
-    uim <- case uit of
-             UI_Word -> jsArg (DLA_Constant $ DLC_UInt_max)
-             UI_256 -> return $ jsNum $ uint256_Max
-    return $ jsApply "stdlib.checkedBigNumberify" [jsAt at, uim, jsNum i]
+  DLL_Int at uit i -> jsChkBigNum at uit $ jsNum i
   DLL_TokenZero ->
     return "stdlib.Token_zero"
 
@@ -946,16 +949,18 @@ setupPart who = [
 jsApiWrapper :: B.ByteString -> [Int] -> App Doc
 jsApiWrapper p whichs = do
   let who = pretty $ bunpack p
-  allowed <- pretty <$> mapM (jsCon . DLL_Int srcloc_builtin UI_Word . fromIntegral) whichs
+  let aux = jsChkBigNum srcloc_builtin UI_Word
+  allowed <- pretty <$> mapM (aux . jsNum . fromIntegral) whichs
   let jmps = map (\ which -> do
           let inst = "_" <> who <> pretty which
           "if" <+> parens ("step" <+> "==" <+> pretty which) <+> braces ("return " <> inst <> parens "ctcTop, interact" <> semi)
         ) whichs
+  curStep <- aux "step"
   let body = vsep $
         setupPart who
         <> [ "const step = await ctc.getCurrentStep()" ]
         <> jmps
-        <> [ "throw stdlib.apiStateMismatchError({ _stateSourceMap }, " <> allowed <> ", step)" ]
+        <> [ "throw stdlib.apiStateMismatchError({ _stateSourceMap }, " <> allowed <> ", " <> curStep <> ")" ]
   return $ "export" <+> jsFunction who ["ctcTop", "interact"] body
 
 iExpect :: Doc -> Doc -> Doc -> Doc

--- a/js/stdlib/ts/shared_backend.ts
+++ b/js/stdlib/ts/shared_backend.ts
@@ -5,11 +5,13 @@ import {
   bigNumberToNumber,
 } from './CBR';
 import {
+  apiStateMismatchError,
   debug,
   j2s,
 } from './shared_impl';
 export {
   bigNumberToNumber,
+  apiStateMismatchError,
 };
 void(debug);
 

--- a/js/stdlib/ts/shared_impl.ts
+++ b/js/stdlib/ts/shared_impl.ts
@@ -1196,14 +1196,18 @@ export const formatWithDecimals = (amt: unknown, decimals: number): string => {
   return handleFormat(amt, decimals, decimals)
 }
 
-export const apiStateMismatchError = (bin: IBackend<any>, es: BigNumber, as: BigNumber) : Error => {
+export const apiStateMismatchError = (bin: IBackend<any>, es: BigNumber | BigNumber[], as: BigNumber) : Error => {
   const formatLoc = (s:BigNumber) =>
     formatAssertInfo(bin._stateSourceMap[s.toNumber()]);
-  const el = formatLoc(es);
+  const msg = (s: any, l: any) => `\nState ${s} corresponds to the commit() at ${l}`;
+  const el = Array.isArray(es)
+              ? es.map((s) => msg(s, formatLoc(s)))
+              :  msg(es, formatLoc(es));
   const al = formatLoc(as);
-  return Error(`Expected the DApp to be in state ${es}, but it was actually in state ${as}.\n`
-    + `\nState ${es} corresponds to the commit() at ${el}`
-    + `\nState ${as} corresponds to the commit() at ${al}`
+  const fmtEs = Array.isArray(es) ? "[" + es + "]" : es;
+  return Error(`Expected the DApp to be in state(s) ${fmtEs}, but it was actually in state ${as}.\n`
+    + el
+    + msg(as, al)
     + (el == al ? "\n(This means that the commit() is in the continuation of impure control-flow.)" : ""));
 };
 


### PR DESCRIPTION
Updates the function to allow a list of expected steps