### PR TITLE
js: views throw exn when verifyContract fails

### DIFF
--- a/examples/view-exns/index.mjs
+++ b/examples/view-exns/index.mjs
@@ -1,0 +1,50 @@
+// Behold, two dapps with identical ABIs,
+// but differing behaviors.
+import * as dapp_plus from './build/index.dapp_plus.mjs';
+import * as dapp_sub from './build/index.dapp_sub.mjs';
+import * as reachsdk from '@reach-sh/stdlib';
+const stdlib = reachsdk.loadStdlib();
+// XXX https://reachsh.atlassian.net/browse/CORE-2056
+if (stdlib.connector !== 'ALGO') {
+  console.log(`skipping test for connector ${stdlib.connector}`);
+  process.exit(0);
+}
+const amt = stdlib.parseCurrency('100');
+const [ deployer, observer ] = await stdlib.newTestAccounts(2, amt);
+const plusD = deployer.contract(dapp_plus);
+const subD = deployer.contract(dapp_sub);
+await Promise.all([
+  {ctc: plusD, lab: 'plus', argL: 1, argR: 1},
+  {ctc: subD, lab: 'sub', argL: 2, argR: 2},
+].map(async ({ctc, lab, argL, argR}) => {
+  console.log(`${lab}: start...`);
+  await stdlib.withDisconnect(async () => {
+    await ctc.p.D({
+      argL, argR, ready: stdlib.disconnect,
+    });
+  });
+  console.log(`${lab}: ready`);
+}));
+const plusInfo = await plusD.getInfo();
+const subInfo = await subD.getInfo();
+// Views on the corresponding contracts work correctly.
+const resP = await observer.contract(dapp_plus, plusInfo).v.args();
+console.log(`plus: view: ${JSON.stringify(resP)}`);
+const resS = await observer.contract(dapp_sub, subInfo).v.args();
+console.log(`sub: view: ${JSON.stringify(resS)}`);
+// Views on the wrong contract throw an exn
+const expectFail = async (p) => {
+  try {
+    const res = await p;
+    console.error('Fail; this should have been unreachable');
+    console.error(res);
+    process.exit(1);
+  } catch (e) {
+    console.log(`failed successfully: ${e}`);
+  }
+};
+expectFail(observer.contract(dapp_sub, plusInfo).v.args());
+expectFail(observer.contract(dapp_plus, subInfo).v.args());
+// let the ctcs end
+await plusD.a.go();
+await subD.a.go();

--- a/examples/view-exns/index.rsh
+++ b/examples/view-exns/index.rsh
@@ -1,0 +1,34 @@
+'reach 0.1';
+
+const Args = Struct([
+  ["argL", UInt],
+  ["argR", UInt],
+]);
+
+const mkApp = (op) => Reach.App(() => {
+  const V = View({ args: Args });
+  const D = Participant('D', {
+    argL: UInt,
+    argR: UInt,
+    ready: Fun([], Null),
+  });
+  const A = API({ go: Fun([], UInt) });
+  init();
+  D.only(() => {
+    const argL = declassify(interact.argL);
+    const argR = declassify(interact.argR);
+  });
+  D.publish(argL, argR);
+  V.args.set(Args.fromObject({argL, argR}));
+  commit();
+  D.interact.ready();
+  const [ [], k ] = call(A.go);
+  k(op(argL, argR));
+  commit();
+});
+
+export const dapp_plus = mkApp((x, y) => x + y);
+export const dapp_sub = mkApp((x, y) => {
+  if (x > y) { return x - y; } else { return 0; }
+});
+export const main = dapp_plus;

--- a/examples/view-exns/index.txt
+++ b/examples/view-exns/index.txt
@@ -1,0 +1,18 @@
+Compiling "dapp_plus"...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 7 theorems; No failures!
+Compiling "dapp_sub"...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 7 theorems; No failures!
+Compiling "main"...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 7 theorems; No failures!

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -1561,8 +1561,8 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
       };
     };
 
-    const getCurrentStep_ = async (getC:GetC): Promise<BigNumber> => {
-      const { getAppState, getGlobalState } = await getC();
+    const getCurrentStep_ = async (ch:ContractHandler): Promise<BigNumber> => {
+      const { getAppState, getGlobalState } = ch;
       const appSt = await getAppState();
       if ( !appSt ) { throw Error(`getCurrentStep_: no appSt`); }
       const gs = await getGlobalState(appSt);
@@ -1613,7 +1613,7 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
       };
 
       const getCurrentStep = async () => {
-        return await getCurrentStep_(getC);
+        return await getCurrentStep_(await getC());
       }
 
       const getState = async (vibne:BigNumber, vtys:AnyALGO_Ty[]): Promise<Array<any>> => {
@@ -2135,8 +2135,9 @@ export const connectAccount = async (networkAccount: NetworkAccount): Promise<Ac
         async (...args: any[]): Promise<any> => {
           debug('getView1', v, k, args);
           const { decode } = vim;
+          const ch = await getC();
           try {
-            const step = await getCurrentStep_(getC);
+            const step = await getCurrentStep_(ch);
             const vi = bigNumberToNumber(step);
             const vtys = vs[vi];
             if ( ! vtys ) { throw Error(`no views for state ${step}`); }


### PR DESCRIPTION
The example used to fail on ALGO:

```
$ REACH_CONNECTOR_MODE=ALGO reach run
...
plus: start...
sub: start...
plus: ready
sub: ready
plus: view: ["Some",{"argL":{"type":"BigNumber","hex":"0x01"},"argR":{"type":"BigNumber","hex":"0x01"}}]
sub: view: ["Some",{"argL":{"type":"BigNumber","hex":"0x02"},"argR":{"type":"BigNumber","hex":"0x02"}}]
Fail; this should have been unreachable
[ 'None', null ]
ERROR: 1
```

Now it works as expected:

```
plus: start...
sub: start...
plus: ready
sub: ready
plus: view: ["Some",{"argL":{"type":"BigNumber","hex":"0x01"},"argR":{"type":"BigNumber","hex":"0x01"}}]
sub: view: ["Some",{"argL":{"type":"BigNumber","hex":"0x02"},"argR":{"type":"BigNumber","hex":"0x02"}}]
failed successfully: Error: EI2P: verifyContract failed: Approval program does not match Reach backend: expected "BiAEAAEI0OvYtw0mAgABACI1ADEYQQFAKGRJIls1ASRbNQI2GgAXSUEAMyI1BCM1BkklDEAAGyUSRDQBIxJEKWRJNQNXAAg0A1cICFA1B0IA/oGYmuHZBRJEKEIAFjYaAhc1BDYaAzYaARdJIwxAAEsjEkQjNAESRDQESSISTDQCEhFEKWQ1A0k1BTX/gAQxvPMWNP9QsIAIAAAAAAAAAFI0AyJbNAMkWwgWULA0AyJbNAMkWwgWNQdCAExIgaCNBogAsiI0ARJENARJIhJMNAISEURJNQVJIls1/yRbNf6ABKzRH8M0/xZQNP4WULA0/xY0/hZQKUsBVwAQZ0gjNQEyBjUCQgAcMRmBBRJEsSKyASKyCCOyEDIJsgkyCrIHs0IABTEZIhJEKDQBFjQCFlBnNAZBAAqABBUffHU0B1CwNABJIwgyBBJEMRYSRCNDMRkiEkRC/98iMTQSRIECMTUSRCIxNhJEIjE3EkQiNQEiNQJC/640AElKIwg1ADgHMgoSRDgQIxJEOAgSRIk=", got "BiAEAAEI0OvYtw0mAgABACI1ADEYQQFRKGRJIls1ASRbNQI2GgAXSUEAMyI1BCM1BkklDEAAGyUSRDQBIxJEKWRJNQNXAAg0A1cICFA1B0IBD4GYmuHZBRJEKEIAFjYaAhc1BDYaAzYaARdJIwxAAFwjEkQjNAESRDQESSISTDQCEhFEKWRJNQNJIls1/yRbNf5JNQU1/YAEMbzzFjT9ULA0/zT+DUEACjT/NP4JNfxCAAMiNfyACAAAAAAAAAC0NPwWULA0/BY1B0IATEiBoI0GiACyIjQBEkQ0BEkiEkw0AhIRREk1BUkiWzX/JFs1/oAErNEfwzT/FlA0/hZQsDT/FjT+FlApSwFXABBnSCM1ATIGNQJCABwxGYEFEkSxIrIBIrIII7IQMgmyCTIKsgezQgAFMRkiEkQoNAEWNAIWUGc0BkEACoAEFR98dTQHULA0AEkjCDIEEkQxFhJEI0MxGSISREL/3yIxNBJEgQIxNRJEIjE2EkQiMTcSRCI1ASI1AkL/rjQASUojCDUAOAcyChJEOBAjEkQ4CBJEiQ=="
failed successfully: Error: EI2P: verifyContract failed: Approval program does not match Reach backend: expected "BiAEAAEI0OvYtw0mAgABACI1ADEYQQFRKGRJIls1ASRbNQI2GgAXSUEAMyI1BCM1BkklDEAAGyUSRDQBIxJEKWRJNQNXAAg0A1cICFA1B0IBD4GYmuHZBRJEKEIAFjYaAhc1BDYaAzYaARdJIwxAAFwjEkQjNAESRDQESSISTDQCEhFEKWRJNQNJIls1/yRbNf5JNQU1/YAEMbzzFjT9ULA0/zT+DUEACjT/NP4JNfxCAAMiNfyACAAAAAAAAAC0NPwWULA0/BY1B0IATEiBoI0GiACyIjQBEkQ0BEkiEkw0AhIRREk1BUkiWzX/JFs1/oAErNEfwzT/FlA0/hZQsDT/FjT+FlApSwFXABBnSCM1ATIGNQJCABwxGYEFEkSxIrIBIrIII7IQMgmyCTIKsgezQgAFMRkiEkQoNAEWNAIWUGc0BkEACoAEFR98dTQHULA0AEkjCDIEEkQxFhJEI0MxGSISREL/3yIxNBJEgQIxNRJEIjE2EkQiMTcSRCI1ASI1AkL/rjQASUojCDUAOAcyChJEOBAjEkQ4CBJEiQ==", got "BiAEAAEI0OvYtw0mAgABACI1ADEYQQFAKGRJIls1ASRbNQI2GgAXSUEAMyI1BCM1BkklDEAAGyUSRDQBIxJEKWRJNQNXAAg0A1cICFA1B0IA/oGYmuHZBRJEKEIAFjYaAhc1BDYaAzYaARdJIwxAAEsjEkQjNAESRDQESSISTDQCEhFEKWQ1A0k1BTX/gAQxvPMWNP9QsIAIAAAAAAAAAFI0AyJbNAMkWwgWULA0AyJbNAMkWwgWNQdCAExIgaCNBogAsiI0ARJENARJIhJMNAISEURJNQVJIls1/yRbNf6ABKzRH8M0/xZQNP4WULA0/xY0/hZQKUsBVwAQZ0gjNQEyBjUCQgAcMRmBBRJEsSKyASKyCCOyEDIJsgkyCrIHs0IABTEZIhJEKDQBFjQCFlBnNAZBAAqABBUffHU0B1CwNABJIwgyBBJEMRYSRCNDMRkiEkRC/98iMTQSRIECMTUSRCIxNhJEIjE3EkQiNQEiNQJC/640AElKIwg1ADgHMgoSRDgQIxJEOAgSRIk="
```

The example fails on ETH and CFX for a different, earlier reason; there's an issue with the txns needed to get to `ready`. (The same view issue might exist but this issue is preventing us from seeing it.) Details moved to a separate follow-up issue: https://reachsh.atlassian.net/browse/CORE-2056