### PR TITLE
Add a code sample of the issue to `RE0066`

### DIFF
--- a/docs/src/rsh/errors/index.md
+++ b/docs/src/rsh/errors/index.md
@@ -1260,7 +1260,7 @@ Example:
 
 ```reach
 load: /hs/t/n/Err_IncompatibleStates.rsh
-md5: c87e4091641e0c9ac0b57e46fec73ac2
+md5: b2e9bd138a8c42e7e31f4e5928136a46
 range: 38 - 51
 ```
 

--- a/docs/src/rsh/errors/index.md
+++ b/docs/src/rsh/errors/index.md
@@ -1251,11 +1251,20 @@ commit();
 ## {#RE0066} RE0066
 
 This error indicates that the state of the program differs in the continuation of a
-branching statement. That is, if a Reach program may execute multiple different code paths at
-runtime, the continuation of those branches must make the same assumption about state.
+branching statement. That is, if a Reach program may execute multiple different code paths at runtime, the continuation of those branches must make the same assumption about state.
 
 For example, this error may be caused by having one branch end in consensus step and
 the other in a step. You can fix this by ensuring both branches end in the same mode.
+
+Example:
+
+```reach
+load: /hs/t/n/Err_IncompatibleStates.rsh
+md5: c87e4091641e0c9ac0b57e46fec73ac2
+range: 38 - 51
+```
+
+This fork ends in two different states, Step and Consensus, but after removing the `{!rsh} commit` both fork statements end in Consensus Step.
 
 Another example is a `{!rsh} Participant` makes their first publication in the branch
 of a conditional. You can fix this by having the `{!rsh} Participant` make their first

--- a/hs/t/n/Err_IncompatibleStates.rsh
+++ b/hs/t/n/Err_IncompatibleStates.rsh
@@ -1,0 +1,60 @@
+'reach 0.1';
+'use strict';
+
+export const main = Reach.App(() => {
+  const N = 32;
+  const UInts = Array(UInt, N);
+  const A = Participant('A', {
+    x: UInt,
+    fork: Fun([UInts], Null),
+  });
+  const B = Participant('B', {
+    ...hasConsoleLogger,
+  });
+  const P = API({
+    f: Fun([UInts], Null),
+    g: Fun([], Null),
+  });
+  init();
+
+  A.only(() => {
+    const ax = declassify(interact.x);
+    const xs = Array.replicate(N, ax);
+  });
+  A.publish(xs);
+  commit();
+  const same = (ys) =>
+    xs.forEachWithIndex((x, i) => check(x == ys[i]));
+
+  B.only(() => {
+    const ys = xs;
+  });
+  B.publish(ys);
+  same(ys);
+  B.interact.log(xs, ys);
+  commit();
+
+  A.interact.fork(xs);
+  fork()
+    .api(P.f,
+      (zs) => same(zs),
+      (_) => 0,
+      (zs, k) => {
+        same(zs);
+        B.interact.log(xs, ys, zs);
+        k(null);
+		commit()
+      })
+    .api(P.g,
+      () => 0,
+      (k) => {
+        k(null);
+      })
+  ;
+  commit();
+
+  A.publish();
+  commit();
+
+  exit();
+});

--- a/hs/t/n/Err_IncompatibleStates.rsh
+++ b/hs/t/n/Err_IncompatibleStates.rsh
@@ -43,7 +43,7 @@ export const main = Reach.App(() => {
         same(zs);
         B.interact.log(xs, ys, zs);
         k(null);
-		commit()
+        commit()
       })
     .api(P.g,
       () => 0,

--- a/hs/t/n/Err_IncompatibleStates.txt
+++ b/hs/t/n/Err_IncompatibleStates.txt
@@ -2,7 +2,7 @@ reachc: error[RE0066]: Incompatible states:
 The expected state of the program varies between branches because:
   * Expected to be in step , but in consensus step.
 
-  ./ErrFailure.rsh:38:7:case
+  ./Err_IncompatibleStates.rsh:38:7:case
 
   38|   fork()
 

--- a/hs/t/n/Err_IncompatibleStates.txt
+++ b/hs/t/n/Err_IncompatibleStates.txt
@@ -1,0 +1,10 @@
+reachc: error[RE0066]: Incompatible states:
+The expected state of the program varies between branches because:
+  * Expected to be in step , but in consensus step.
+
+  ./ErrFailure.rsh:38:7:case
+
+  38|   fork()
+
+For further explanation of this error, see: https://docs.reach.sh/rsh/errors/#RE0066
+


### PR DESCRIPTION
Modify an existing `index.rsh` file to create a fork that ends in two different states of the program, and add it to the `/n` folder. Then create a code sample for the `RE0066` issue