### PR TITLE
DCT-497 make tut dropdown behave like `Language`'s

### DIFF
--- a/docs/src/tut/config.json
+++ b/docs/src/tut/config.json
@@ -1,5 +1,4 @@
 {
   "bookRank": 20,
-  "hasOtp": true, 
-  "bookTitle": "Tutorials"
+  "hasOtp": true
 }


### PR DESCRIPTION
#### Without this change

These screen recordings do have audio, but I recommend listening at a lower volume due to the microphone quality.

https://user-images.githubusercontent.com/43425812/180097710-07c5a6c8-23c6-4f86-a46b-93ef235e0d79.mp4

Selecting [`Tutorials`](https://docs.reach.sh/tut/) in the table of contents at docs.reach.sh causes the lefthand table of contents to change, but we want clicking of the [`Tutorials`](https://docs.reach.sh/tut/) section to not do that.

#### With this change

https://user-images.githubusercontent.com/43425812/180097732-26d93ef2-1a61-455e-8807-8cb8bbf0e3d3.mp4