### PR TITLE
DCT-95 show tooltip after clicking copy button

### DIFF
--- a/docs/dev/generator.js
+++ b/docs/dev/generator.js
@@ -653,6 +653,7 @@ const processMd = async ({baseConfig, relDir, in_folder, iPath, oPath}) => {
     }
   }
   const mkEl = (s) => doc.createRange().createContextualFragment(s);
+  let numberOfCopyButtons = 0;
   for (const pre of doc.querySelectorAll('pre') ) {
     const code = pre.querySelector('code');
     if (!code) { continue; }
@@ -766,6 +767,12 @@ const processMd = async ({baseConfig, relDir, in_folder, iPath, oPath}) => {
     cpEl.setAttribute("data-clipboard-text",
       splitRange(copyCode, (i, l) => `${l}\n`)[0].trimEnd());
     cpEl.href = "#";
+
+    // Set up tooltips on copy.
+    numberOfCopyButtons++;
+    cpEl.id = `copyBtn${numberOfCopyButtons}`;
+    cpEl.setAttribute('title', 'Copy to clipboard');
+
     chEl.appendChild(cpEl);
     pre.append(chEl);
     pre.append(mkEl(olStr));

--- a/docs/src/assets/scripts.js
+++ b/docs/src/assets/scripts.js
@@ -344,6 +344,16 @@ const clickFollowLink = async (evt) => {
   if ( t.classList && t.classList.contains("copyBtn") ) {
     evt.preventDefault();
     await navigator.clipboard.writeText(t.getAttribute('data-clipboard-text'));
+    const id = t.getAttribute('id');
+    $(`#${id}`).attr('title', "Copied!")
+      .tooltip('enable')
+      .tooltip('show');
+    const milliseconds = 1000;
+    setTimeout(() => {
+      $(`#${id}`)
+        .tooltip('disable')
+        .attr('title', "Copy to clipboard");
+    }, milliseconds);
     return;
   }
   const href = t.href;

--- a/docs/src/base.html
+++ b/docs/src/base.html
@@ -205,6 +205,8 @@
 
   </main>
   <script src="https://cdn.jsdelivr.net/npm/axios@0.24.0/dist/axios.min.js"></script>
+  <!-- //ajax... is necessary for tooltips on copy. -->
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js" type="text/javascript"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/algoliasearch@4.5.1/dist/algoliasearch-lite.umd.js" integrity="sha256-EXPXz4W6pQgfYY3yTpnDa3OH8/EPn16ciVsPQ/ypsjk=" crossorigin="anonymous"></script>
   <script src="/assets/scripts.js?v=61" type="module"></script>


### PR DESCRIPTION
### Without this change

There's no user interface update on copy.

<details>
<summary>Without this change (Browser: Edge)</summary>
<br>

https://user-images.githubusercontent.com/43425812/181856469-d8bd0d4c-9324-44a0-969b-a55c4d51610e.mp4
</details>

### With this change

A tooltip displays after clicking the copy button.

<details>
<summary>With this change (Browser: Edge)</summary>
<br>

https://user-images.githubusercontent.com/43425812/181856446-3bf0c519-e0dd-4199-8867-a8824fe855d5.mp4
</details>

<details>
<summary>With this change (Browser: Firefox)</summary>
<br>

https://user-images.githubusercontent.com/43425812/181858344-ef3abf61-8338-4f04-b342-ab7a70414177.mp4
</details>