### PR TITLE
make `Makefile` say "Fix with `make check-accept`"

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,7 +21,10 @@ kToD.ts:
 KDP=../vsce/server/src/keywordToDocumentation.ts
 .PHONY: check
 check: kToD.ts
-	cmp $^ "${KDP}"
+	@if ! cmp $^ "${KDP}"; then \
+		echo Fix with \`make check-accept\` && exit 1; \
+	fi
+
 .PHONY: check-accept
 check-accept: kToD.ts
 	mv $^ "${KDP}"


### PR DESCRIPTION
This change adds a message on how to fix issues with `make` in the `docs/` directory, as Jay suggested.

https://user-images.githubusercontent.com/43425812/182721749-d45fd112-26bc-4884-ab41-04efab10647e.mp4