### PR TITLE
update Z3 version in README to match DEPS file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you want to work on the Reach compiler, you'll need:
 - [`goal`](https://github.com/algorand/go-algorand) OR link [`goal-devnet`](https://github.com/reach-sh/reach-lang/blob/master/scripts/goal-devnet) to `goal` in your `PATH`
 - `mo`
 
-The versions of our dependencies are specified in `DEPS`.
+The versions of our dependencies are specified in [`DEPS`](https://github.com/reach-sh/reach-lang/blob/master/DEPS).
 
 Installation on macOS:
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Read the [documentation](https://docs.reach.sh).
 
 If you want to work on the Reach compiler, you'll need:
 - stack v2.7.5
-- z3 v4.8.14
+- z3 v4.8.17
 - solidity v0.8.12
 - [mo](https://github.com/tests-always-included/mo) v2.2.0
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you want to work on the Reach compiler, you'll need:
 - `z3`
 - `solc`
 - [`goal`](https://github.com/algorand/go-algorand) OR link [`goal-devnet`](https://github.com/reach-sh/reach-lang/blob/master/scripts/goal-devnet) to `goal` in your `PATH`
-- [mo](https://github.com/tests-always-included/mo) v2.2.0
+- `mo`
 
 The versions of our dependencies are specified in `DEPS`.
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Read the [documentation](https://docs.reach.sh).
 
 If you want to work on the Reach compiler, you'll need:
 - stack v2.7.5
-- z3 v4.8.17
-- solidity v0.8.12
+- `z3`
+- `solc`
+- [`goal`](https://github.com/algorand/go-algorand) OR link [`goal-devnet`](https://github.com/reach-sh/reach-lang/blob/master/scripts/goal-devnet) to `goal` in your `PATH`
 - [mo](https://github.com/tests-always-included/mo) v2.2.0
 
 The versions of our dependencies are specified in `DEPS`.


### PR DESCRIPTION
Or we could remove the versions from the README, but make it say to check the versions in the DEPS file.