### PR TITLE
CORE-2212: Fix Prim Op

### DIFF
--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -2261,7 +2261,7 @@ evalPrimOp sp sargs = do
     mtOkay mt = mtOkay' mt . uintTyM
     arg1ty n =
       case args of
-        x : _ -> fst <$> typeOf x
+        x : _ -> mustBeUIntTy =<< fst <$> typeOf x
         _ -> do
           at <- withAt id
           expect_ $ Err_Apply_ArgCount at n (length args)
@@ -2633,6 +2633,11 @@ mustBeObjectTy :: (DLType -> EvalError) -> DLType -> App (M.Map SLVar (SecurityL
 mustBeObjectTy err = \case
   T_Object x -> return $ M.mapWithKey (curry $ bimap idLevel id) x
   t -> expect_ $ err t
+
+mustBeUIntTy :: DLType -> App DLType
+mustBeUIntTy ty = case ty of
+  T_UInt {} -> return ty
+  _ -> expect_ $ Err_Type_Mismatch (T_UInt UI_Word) ty
 
 structKeyRegex :: App RE
 structKeyRegex = liftIO $ compileRegex "^([_a-zA-Z][_a-zA-Z0-9]*)$"

--- a/hs/t/n/bool_add.rsh
+++ b/hs/t/n/bool_add.rsh
@@ -1,0 +1,3 @@
+'reach 0.1';
+
+check(true + false > false);

--- a/hs/t/n/bool_add.txt
+++ b/hs/t/n/bool_add.txt
@@ -1,0 +1,10 @@
+reachc: error[RE0088]: These types are mismatched:
+  expected: UInt
+       got: Bool
+
+  ./bool_add.rsh:3:12:application
+
+  3| check(true + false > false);
+
+For further explanation of this error, see: https://docs.reach.sh/rsh/errors/#RE0088
+

--- a/hs/t/n/default.txt
+++ b/hs/t/n/default.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: Data({"None": Null, "Some": UInt})
-       got: UInt
+  expected: UInt
+       got: Data({"None": Null, "Some": UInt})
 
   ./default.rsh:15:27:application
 

--- a/hs/t/n/gh_1328.rsh
+++ b/hs/t/n/gh_1328.rsh
@@ -1,0 +1,6 @@
+'reach 0.1';
+
+const fooFx = fx(1)(Pos, 3);
+const barFx = fx(1)(Pos, 2);
+const zeroFx = fx(1)(Pos, 0);
+check(fooFx + barFx > zeroFx, 'Foo+Bar must be positive');

--- a/hs/t/n/gh_1328.txt
+++ b/hs/t/n/gh_1328.txt
@@ -1,0 +1,10 @@
+reachc: error[RE0088]: These types are mismatched:
+  expected: UInt
+       got: Object({"i": Object({"i": UInt, "scale": UInt}), "sign": Bool})
+
+  ./gh_1328.rsh:6:13:application
+
+  6| check(fooFx + barFx > zeroFx, 'Foo+Bar must be positive');
+
+For further explanation of this error, see: https://docs.reach.sh/rsh/errors/#RE0088
+


### PR DESCRIPTION
nn2n was allowing prim ops on any type, so long as all the arguments were of the same type. Updated it to expect a UInt `Word | 256` type