### PR TITLE
Verify multiplication zero

### DIFF
--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -2369,7 +2369,9 @@ evalPrimOp sp sargs = do
                   _ -> impossible "mul args"
             ra <- doOp (T_UInt t) (DIV t pv) [lim_maxUInt_a, b]
             ca <- doCmp (PLE t) [a, ra]
-            dopClaim ca "mul overflow"
+            denomZero <- doCmp (PEQ t) [(DLA_Literal $ DLL_Int at t 0), b]
+            orDenomZeroCa <- doOp (T_Bool) IF_THEN_ELSE [denomZero, (DLA_Literal $ DLL_Bool True), ca]
+            dopClaim orDenomZeroCa "mul overflow"
       let shouldVerifyArith = \case
             PV_Veri -> True
             PV_Safe -> False

--- a/hs/t/n/safeMul_new_ctxt.txt
+++ b/hs/t/n/safeMul_new_ctxt.txt
@@ -8,15 +8,15 @@ Verification failed:
 
   // Violation Witness
 
-  const x/52 = "A".interact.x;
+  const x/54 = "A".interact.x;
   //    ^ could = 0
   //      from: ./safeMul_new_ctxt.rsh:4:33:property binding
 
   // Theorem Formalization
 
-  const v64 = (x/52 * 5) < UInt.max;
+  const v68 = (x/54 * 5) < UInt.max;
   //    ^ would be false
-  assert(v64);
+  assert(v68);
 
   Verifying when NO participants are honest
 Checked 9 theorems; 2 failures (and 1 omitted repeats) :'(

--- a/hs/t/n/veriMul.txt
+++ b/hs/t/n/veriMul.txt
@@ -11,15 +11,15 @@ Verification failed:
 
   const UInt.max = 1;
 
-  const x/46 = "A".interact.x;
+  const x/48 = "A".interact.x;
   //    ^ could = 1
   //      from: ./veriMul.rsh:4:33:property binding
 
   // Theorem Formalization
 
-  const v54 = x/46 <= (UInt.max / 5);
+  const v56 = x/48 <= (UInt.max / 5);
   //    ^ would be false
-  assert(v54);
+  assert(v56);
 
   Verifying when NO participants are honest
 Checked 7 theorems; 2 failures (and 1 omitted repeats) :'(

--- a/hs/t/y/verifyMulZero.rsh
+++ b/hs/t/y/verifyMulZero.rsh
@@ -1,0 +1,33 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const A = Participant('A', {
+    params: Object({
+      x: UInt,
+      y: UInt,
+    }),
+    show: Fun(true, Null),
+  });
+  setOptions({ verifyArithmetic: true });
+  init();
+
+  A.only(() => {
+    const params = declassify(interact.params);
+    check(params.x != 0);
+    check(params.y <= UInt.max / params.x);
+  });
+  A.publish(params);
+  check(params.x != 0);
+  check(params.y <= UInt.max / params.x);
+
+  const { x, y } = params;
+
+  const r = x * y;
+  // Just in case someone reverses the order in the compiler for some reason...
+  const r2 = y * x;
+
+  A.interact.show(r);
+  A.interact.show(r2);
+  commit();
+
+});

--- a/hs/t/y/verifyMulZero.txt
+++ b/hs/t/y/verifyMulZero.txt
@@ -1,0 +1,5 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 16 theorems; No failures!

--- a/hs/t/y/verifyMuldiv.txt
+++ b/hs/t/y/verifyMuldiv.txt
@@ -2,4 +2,4 @@ Verifying knowledge assertions
 Verifying for generic connector
   Verifying when ALL participants are honest
   Verifying when NO participants are honest
-Checked 27 theorems; No failures!
+Checked 28 theorems; No failures!


### PR DESCRIPTION
This fixes the bug with verification of multiplication overflow.  The problem is that verification that overflow doesn't happen relies on using division, but SMT defines division by zero as zero instead of an error.  This allows a situation where if the second argument of a multiplication can be zero then it triggers division by zero, leading to failure to prove the desired fact about the division.  This adds a check for whether the second argument is zero and does a logical OR of the zero test and the division test.