### PR TITLE
makeSeal

### DIFF
--- a/hs/rsh/stdlib.rsh
+++ b/hs/rsh/stdlib.rsh
@@ -266,31 +266,38 @@ export const Foldable_imax1 = (c) => () => Foldable_imax(c);
 
 export const FixedPoint = Object({ sign: Bool, i: Object({ scale: UInt, i: UInt }) });
 
+const [fxSeal, fxUnseal] = makeSeal("FixedPoint");
 export const fx = (scale) => (sign, i) =>
-  ({sign, i: { scale, i }});
+  // TODO - if we use seals here, then we need to make the literal syntax also use the fx function.
+  fxSeal({sign, i: { scale, i }});
 
 export const fxint = (i) =>
-  ({ sign: i.sign, i: { i: i.i, scale: 1 }})
+  fxSeal({ sign: i.sign, i: { i: i.i, scale: 1 }})
 
-const fxi2int = (x) =>
-  int(x.sign, x.i.i);
+const fxi2int = (x_) => {
+  const x = fxUnseal(x_);
+  return int(x.sign, x.i.i);
+}
 
 // do not export, but count it as used in strict mode
 void fxi2int;
 
-export const fxrescale = (x, scale) => {
+export const fxrescale = (x_, scale) => {
+  const x = fxUnseal(x_);
   if (x.i.scale == scale) {
-    return x
+    return x_
   } else {
-    const r = idiv( imul( fxi2int(x), + scale ), int(Pos, x.i.scale) );
+    const r = idiv( imul( fxi2int(x_), + scale ), int(Pos, x.i.scale) );
     return fx(scale)(r.sign, r.i);
   }
 }
 
-export const fxunify = (x, y) => {
+export const fxunify = (x__, y__) => {
+  const x = fxUnseal(x__);
+  const y = fxUnseal(y__);
   const scale = x.i.scale < y.i.scale ? y.i.scale : x.i.scale;
-  const x_ = fxrescale(x, scale);
-  const y_ = fxrescale(y, scale);
+  const x_ = fxrescale(x__, scale);
+  const y_ = fxrescale(y__, scale);
   return [ scale, x_, y_ ];
 }
 

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -174,6 +174,7 @@ data SLVal
   | SLV_Map DLMVar
   | SLV_Deprecated Deprecation SLVal
   | SLV_ContractCode SrcLoc ConnectorObject
+  | SLV_Sealed SrcLoc String Integer SLVal
   deriving (Eq, Generic)
 
 uintTyM :: SLVal -> Maybe UIntTy
@@ -423,6 +424,7 @@ instance Pretty SLVal where
     SLV_Anybody -> "Anybody"
     SLV_Deprecated d s -> "<deprecated: " <> viaShow d <> ">(" <> pretty s <> ")"
     SLV_ContractCode {} -> "<contractCode>"
+    SLV_Sealed _ label _ v -> "<sealed: " <> viaShow label <> " " <> pretty v <> ">"
 
 instance SrcLocOf SLVal where
   srclocOf = \case
@@ -450,6 +452,7 @@ instance SrcLocOf SLVal where
     SLV_Map _ -> sb
     SLV_Deprecated _ v -> srclocOf v
     SLV_ContractCode a _ -> a
+    SLV_Sealed a _ _ _ -> a
 
 isSmallLiteralArray :: SLVal -> Bool
 isSmallLiteralArray = \case
@@ -828,6 +831,9 @@ data SLPrimitive
   | SLPrim_Contract_new
   | SLPrim_Contract_new_ctor DLContractNews
   | SLPrim_toStringDyn
+  | SLPrim_makeSeal
+  | SLPrim_wrapSeal
+  | SLPrim_unwrapSeal
   deriving (Eq, Generic)
 
 instance Equiv SLPrimitive where

--- a/hs/src/Reach/EditorInfo.hs
+++ b/hs/src/Reach/EditorInfo.hs
@@ -83,6 +83,7 @@ completionKind v =
     SLV_Kwd _ -> Just CK_Keyword
     SLV_DLVar _ -> Just CK_Variable
     SLV_Anybody -> Just CK_Keyword
+    SLV_Sealed {} -> Just CK_Variable
     SLV_Prim slp ->
       case slp of
         SLPrim_makeEnum -> Just CK_Function
@@ -187,6 +188,9 @@ completionKind v =
         SLPrim_Contract_new -> Just CK_Function
         SLPrim_Contract_new_ctor {} -> Just CK_Function
         SLPrim_toStringDyn -> Just CK_Function
+        SLPrim_makeSeal -> Just CK_Function
+        SLPrim_wrapSeal -> Just CK_Function
+        SLPrim_unwrapSeal -> Just CK_Function
     SLV_Form slf ->
       case slf of
         SLForm_App -> Just CK_Constructor


### PR DESCRIPTION
This isn't finished, but I thought I might as well start a draft PR.  I'll re-summarize my comments to you from slack:

This feature improves error messages for cases where the sealed type is expected, but not for cases where the sealed type is unexpectedly used.  Changing that would require changes to type checking all over Eval/Core, I think, and so would be difficult.  Also, while this gives a better error message, I think we need more features to make the new sealed error messages feel cohesive.  Eg. if you want to have an array of fixed points or pass fixed points through an interact interface or API, you still need to write the object type, you can't just write FixedPoint. 