### PR TITLE
check k2d only on vsce publish

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@ ROOT=..
 include $(ROOT)/DEPS
 
 .PHONY: build
-build: check
+build: kToD.ts
 	DOCKER_BUILDKIT=1 docker build \
 	  --build-arg REACHC_HASH="$$(../scripts/git-hash.sh)" \
 	  --build-arg DOCS_IMAGE=${DOCS_IMAGE} \
@@ -17,17 +17,6 @@ kToD.ts:
 	  --pull=false \
 	  -o $$(pwd) \
 	  -f update_ext_hover_doc/Dockerfile ..
-
-KDP=../vsce/server/src/keywordToDocumentation.ts
-.PHONY: check
-check: kToD.ts
-	@if ! cmp $^ "${KDP}"; then \
-		echo Fix with \`make check-accept\` && exit 1; \
-	fi
-
-.PHONY: check-accept
-check-accept: kToD.ts
-	mv $^ "${KDP}"
 
 .PHONY: update-search
 update-search:

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,15 +7,3 @@ $ make serve-up
 
 We use [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
 
-Did CI complain at you about the `docs-render`, saying something like this?
-
-```
-cmp kToD.ts "../vsce/server/src/keywordToDocumentation.ts"
-kToD.ts ../vsce/server/src/keywordToDocumentation.ts differ: byte 157250, line 138
-```
-
-Do this:
-
-```
-make check-accept
-```

--- a/vsce/Makefile
+++ b/vsce/Makefile
@@ -25,7 +25,24 @@ package.json: base.package.json
 	cp package.json base.package.json
 	node build.package.json.js
 
-publish:
+K2DF=kToD.ts
+K2DD=../docs
+K2D=${K2DD}/${K2DF}
+KDP=./server/src/keywordToDocumentation.ts
+
+.PHONY: check
+check:
+	(cd "${K2DD}" && rm -f "${K2DF}" && make "${K2DF}")
+	@if ! cmp "${K2D}" "${KDP}"; then \
+		echo Fix with \`make check-accept\` && exit 1; \
+	else echo looks good; \
+	fi
+
+.PHONY: check-accept
+check-accept: ${K2D}
+	mv "${K2D}" "${KDP}"
+
+publish: check
 	@echo
 	@echo "Now attempting to publish version $(VSCE_VER)"
 	@echo "of the extension using $(NODE_IMAGE)..."


### PR DESCRIPTION
The k2d stuff is weird and I don't get why part of it lives in docs. But I'm doing the bare minimum just to make it so that the check doesn't happen on docs build and instead happens on vsce publish.

It appears to me that docs build does not need `kToD.ts` at all but I'm superstitiously leaving it in there.