### PR TITLE
CORE-2213: Fix Solidity Map Sets

### DIFF
--- a/hs/t/y/sol_storage_assign.rsh
+++ b/hs/t/y/sol_storage_assign.rsh
@@ -1,0 +1,40 @@
+'reach 0.1';
+
+export const f = (ty) => Reach.App(() => {
+  const A = Participant('A', {
+    get: Fun([], ty),
+    log: Fun(true, Null),
+  });
+  init();
+
+  A.publish();
+
+  const map = new Map(ty);
+
+  commit();
+
+  A.only(() => {
+    const x = declassify(interact.get());
+  });
+  A.publish(x);
+  map[A] = x;
+  commit();
+
+  A.publish();
+  A.interact.log(map[A]);
+  commit();
+
+});
+
+export const test1 = f(StringDyn);
+export const test2 = f(BytesDyn);
+export const test3 = f(Bytes(64));
+export const test4 = f(Bytes(4));
+export const test5 = f(Array(UInt, 5));
+export const test6 = f(Array(Tuple(UInt, Bool), 5));
+export const test7 = f(Array(Tuple(Array(UInt, 5), Bool), 5));
+export const test8 = f(Object({ x: UInt, y: Bool }));
+export const test9 = f(Object({ x: UInt, y: Array(Array(UInt, 4), 5) }));
+export const test10 = f(Struct([["x", UInt], ["y", UInt]]));
+export const test11 = f(Struct([["x", UInt], ["y", Array(Array(Array(UInt, 4), 4), 5)]]));
+export const test12 = f(Object({ x: Array(Bytes(64), 10), y: Bool }));

--- a/hs/t/y/sol_storage_assign.txt
+++ b/hs/t/y/sol_storage_assign.txt
@@ -1,0 +1,100 @@
+Compiling "test1"...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 7 theorems; No failures!
+Compiling "test10"...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 7 theorems; No failures!
+Compiling "test11"...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 7 theorems; No failures!
+Compiling "test12"...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 7 theorems; No failures!
+Compiling "test2"...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 7 theorems; No failures!
+Compiling "test3"...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 7 theorems; No failures!
+Compiling "test4"...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 7 theorems; No failures!
+Compiling "test5"...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 7 theorems; No failures!
+Compiling "test6"...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 7 theorems; No failures!
+Compiling "test7"...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 7 theorems; No failures!
+Compiling "test8"...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 7 theorems; No failures!
+Compiling "test9"...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 7 theorems; No failures!
+WARNING: Compiler instructed to emit for Algorand, but the conservative analysis found these potential problems:
+ * This program was compiled with trustworthy maps, but maps are not trustworthy on Algorand, because they are represented with local state. A user can delete their local state at any time, by sending a ClearState transaction. The only way to use local state properly on Algorand is to ensure that a user doing this can only 'hurt' themselves and not the entire system.
+WARNING: Compiler instructed to emit for Algorand, but we can statically determine that this program will not work on Algorand, because:
+ * Uses a dynamically sized type, like BytesDyn or StringDyn.
+WARNING: Compiler instructed to emit for Algorand, but the conservative analysis found these potential problems:
+ * This program was compiled with trustworthy maps, but maps are not trustworthy on Algorand, because they are represented with local state. A user can delete their local state at any time, by sending a ClearState transaction. The only way to use local state properly on Algorand is to ensure that a user doing this can only 'hurt' themselves and not the entire system.
+WARNING: Compiler instructed to emit for Algorand, but the conservative analysis found these potential problems:
+ * This program was compiled with trustworthy maps, but maps are not trustworthy on Algorand, because they are represented with local state. A user can delete their local state at any time, by sending a ClearState transaction. The only way to use local state properly on Algorand is to ensure that a user doing this can only 'hurt' themselves and not the entire system.
+WARNING: Compiler instructed to emit for Algorand, but the conservative analysis found these potential problems:
+ * This program was compiled with trustworthy maps, but maps are not trustworthy on Algorand, because they are represented with local state. A user can delete their local state at any time, by sending a ClearState transaction. The only way to use local state properly on Algorand is to ensure that a user doing this can only 'hurt' themselves and not the entire system.
+WARNING: Compiler instructed to emit for Algorand, but the conservative analysis found these potential problems:
+ * This program was compiled with trustworthy maps, but maps are not trustworthy on Algorand, because they are represented with local state. A user can delete their local state at any time, by sending a ClearState transaction. The only way to use local state properly on Algorand is to ensure that a user doing this can only 'hurt' themselves and not the entire system.
+WARNING: Compiler instructed to emit for Algorand, but we can statically determine that this program will not work on Algorand, because:
+ * Uses a dynamically sized type, like BytesDyn or StringDyn.
+WARNING: Compiler instructed to emit for Algorand, but the conservative analysis found these potential problems:
+ * This program was compiled with trustworthy maps, but maps are not trustworthy on Algorand, because they are represented with local state. A user can delete their local state at any time, by sending a ClearState transaction. The only way to use local state properly on Algorand is to ensure that a user doing this can only 'hurt' themselves and not the entire system.
+WARNING: Compiler instructed to emit for Algorand, but the conservative analysis found these potential problems:
+ * This program was compiled with trustworthy maps, but maps are not trustworthy on Algorand, because they are represented with local state. A user can delete their local state at any time, by sending a ClearState transaction. The only way to use local state properly on Algorand is to ensure that a user doing this can only 'hurt' themselves and not the entire system.
+WARNING: Compiler instructed to emit for Algorand, but the conservative analysis found these potential problems:
+ * This program was compiled with trustworthy maps, but maps are not trustworthy on Algorand, because they are represented with local state. A user can delete their local state at any time, by sending a ClearState transaction. The only way to use local state properly on Algorand is to ensure that a user doing this can only 'hurt' themselves and not the entire system.
+WARNING: Compiler instructed to emit for Algorand, but the conservative analysis found these potential problems:
+ * This program was compiled with trustworthy maps, but maps are not trustworthy on Algorand, because they are represented with local state. A user can delete their local state at any time, by sending a ClearState transaction. The only way to use local state properly on Algorand is to ensure that a user doing this can only 'hurt' themselves and not the entire system.
+WARNING: Compiler instructed to emit for Algorand, but the conservative analysis found these potential problems:
+ * This program was compiled with trustworthy maps, but maps are not trustworthy on Algorand, because they are represented with local state. A user can delete their local state at any time, by sending a ClearState transaction. The only way to use local state properly on Algorand is to ensure that a user doing this can only 'hurt' themselves and not the entire system.
+WARNING: Compiler instructed to emit for Algorand, but the conservative analysis found these potential problems:
+ * This program was compiled with trustworthy maps, but maps are not trustworthy on Algorand, because they are represented with local state. A user can delete their local state at any time, by sending a ClearState transaction. The only way to use local state properly on Algorand is to ensure that a user doing this can only 'hurt' themselves and not the entire system.
+WARNING: Compiler instructed to emit for Algorand, but the conservative analysis found these potential problems:
+ * This program was compiled with trustworthy maps, but maps are not trustworthy on Algorand, because they are represented with local state. A user can delete their local state at any time, by sending a ClearState transaction. The only way to use local state properly on Algorand is to ensure that a user doing this can only 'hurt' themselves and not the entire system.


### PR DESCRIPTION
Solidity cannot assign struct arrays from memory to storage spaces, such as maps. These changes will rewrite the problematic map sets:

```solidity
map[idx] = x;
```
to something like
```solidity
map[idx]._a = x._a;
map[idx]._b = x._b;
// or
map[idx][0]= x[0];
map[idx][1]= x[1];
```