### PR TITLE
CORE-2275 Reduce try/catch surface in getView1

### DIFF
--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -2187,20 +2187,21 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
           debug('getView1', v, k, args);
           const { decode } = vim;
           const ch = await getC();
-          const step = await getCurrentStep_(ch);
-          const vi = bigNumberToNumber(step);
-          const vTys = vs[vi];
-          if ( ! vTys ) { throw Error(`no views for state ${step}`); }
-          const vVals = (await getState_(getC, _ => vTys))[1];
-          let val;
-          try { val = await decode(vi, vVals, args); }
-          catch (e) {
+          let vi, vvs;
+          try {
+            const step = await getCurrentStep_(ch);
+            vi = bigNumberToNumber(step);
+            const vtys = vs[vi];
+            if (!vtys) { throw Error(`no views for state ${step}`); }
+            vvs = await getState_(getC, _ => vtys)[1];
+          } catch (e) {
             debug(`getView1`, v, k, 'error', e);
-            if (!isSafe) { throw Error(`View ${k ? `${v}.${k}` : v} is not set.`); }
+            if (!isSafe) { throw Error(`View ${v}.${k} is not set.`); }
             return ['None', null];
           }
-          debug({ val });
-          return isSafe ? ['Some', val] : val;
+          const vres = await decode(vi, vvs, args);
+          debug({ vres });
+          return isSafe ? ['Some', vres] : vres;
       };
       return { getView1, viewLib };
     };

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -2187,23 +2187,20 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
           debug('getView1', v, k, args);
           const { decode } = vim;
           const ch = await getC();
-          try {
-            const step = await getCurrentStep_(ch);
-            const vi = bigNumberToNumber(step);
-            const vtys = vs[vi];
-            if ( ! vtys ) { throw Error(`no views for state ${step}`); }
-            const [ _, vvs ] = await getState_(getC, _ => vtys);
-            const vres = await decode(vi, vvs, args);
-            debug({vres});
-            return isSafe ? ['Some', vres] : vres;
-          } catch (e) {
+          const step = await getCurrentStep_(ch);
+          const vi = bigNumberToNumber(step);
+          const vTys = vs[vi];
+          if ( ! vTys ) { throw Error(`no views for state ${step}`); }
+          const vVals = (await getState_(getC, _ => vTys))[1];
+          let val;
+          try { val = await decode(vi, vVals, args); }
+          catch (e) {
             debug(`getView1`, v, k, 'error', e);
-            if (isSafe) {
-              return ['None', null];
-            } else {
-              throw Error(`View ${v}.${k} is not set.`);
-            }
+            if (!isSafe) { throw Error(`View ${k ? `${v}.${k}` : v} is not set.`); }
+            return ['None', null];
           }
+          debug({ val });
+          return isSafe ? ['Some', val] : val;
       };
       return { getView1, viewLib };
     };

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -2187,21 +2187,20 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
           debug('getView1', v, k, args);
           const { decode } = vim;
           const ch = await getC();
-          let vi, vvs;
           try {
             const step = await getCurrentStep_(ch);
-            vi = bigNumberToNumber(step);
+            const vi = bigNumberToNumber(step);
             const vtys = vs[vi];
             if (!vtys) { throw Error(`no views for state ${step}`); }
-            vvs = (await getState_(getC, _ => vtys))[1];
+            const vvs = (await getState_(getC, _ => vtys))[1];
+            const vres = await decode(vi, vvs, args);
+            debug({ vres });
+            return isSafe ? ['Some', vres] : vres;
           } catch (e) {
             debug(`getView1`, v, k, 'error', e);
             if (!isSafe) { throw Error(`View ${v}.${k} is not set.`); }
             return ['None', null];
           }
-          const vres = await decode(vi, vvs, args);
-          debug({ vres });
-          return isSafe ? ['Some', vres] : vres;
       };
       return { getView1, viewLib };
     };

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -2193,7 +2193,7 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
             vi = bigNumberToNumber(step);
             const vtys = vs[vi];
             if (!vtys) { throw Error(`no views for state ${step}`); }
-            vvs = await getState_(getC, _ => vtys)[1];
+            vvs = (await getState_(getC, _ => vtys))[1];
           } catch (e) {
             debug(`getView1`, v, k, 'error', e);
             if (!isSafe) { throw Error(`View ${v}.${k} is not set.`); }

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -807,19 +807,16 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
           const mungedArgs = args.map((arg, i) => dom[i].munge(arg));
           debug(label, 'getView1', v, k, 'args', args, vkn, dom, rng);
           debug(label, `getView1 mungedArgs = ${mungedArgs}`);
-          try {
-            const val = await ethersC[vkn](...mungedArgs);
-            debug(label, 'getView1', v, k, 'val', val);
-            const uv = rng.unmunge(val);
-            return isSafe ? ['Some', uv] : uv;
-          } catch (e) {
+          let val;
+          try { val = await ethersC[vkn](...mungedArgs); }
+          catch (e) {
             debug(label, 'getView1', v, k, 'error', e);
-            if (isSafe) {
-              return ['None', null];
-            } else {
-              throw Error(`View ${v}.${k} is not set.`);
-            }
+            if (!isSafe) { throw Error(`View ${k ? `${v}.${k}` : v} is not set.`); }
+            return ['None', null];
           }
+          debug(label, 'getView1', v, k, 'val', val);
+          const uv = rng.unmunge(val);
+          return isSafe ? ['Some', uv] : uv;
         };
       return { getView1, viewLib };
     };


### PR DESCRIPTION
A couple weeks ago we fixed a bug that was hard to find because it was caught in this try block and ignored. Though it has been fixed, I believe it is smarter to have less code surface that blindly ignores errors. So this strips the getView1 try to a the critical read action only, and shortens the rest a little.