### PR TITLE
js: getEventSigs

### DIFF
--- a/docs/src/changelog/index.md
+++ b/docs/src/changelog/index.md
@@ -9,6 +9,8 @@ Versions and changes-within-versions are listed in reverse-chronological order: 
 
 @{rcHead("0.1.12-rc.3")}
 
++ 2022/10/07 Added `{!js} ctc.getEventTys`.
+
 @{rcHead("0.1.12-rc.2")}
 
 + 2022/09/23: Added `{!js} ctc.getInternalState`.

--- a/docs/src/frontend/index.md
+++ b/docs/src/frontend/index.md
@@ -903,6 +903,22 @@ When the `{!js} showFull` argument is not `{!js} true`, internal implementation
 details are omitted.
 
 ---
+@{ref("js", "ctc.getEventTys")}
+```js
+ctc.getEventTys() => Record<string, ReachType[]>
+```
+
+Returns a mapping from event name to the reach types of the data emitted for that event.
+This can be used to determine the connector-specific event signature.
+For example:
+
+```js
+const tys = ctc.getEventTys();
+const e = 'Swap';
+const sig = `${e}${tys[e].toString()}`;
+```
+
+---
 @{ref("js", "getInternalState")}
 ```js
 ctc.getInternalState() => Promise<{ [key: string], ReachType }>

--- a/docs/src/frontend/index.md
+++ b/docs/src/frontend/index.md
@@ -908,7 +908,7 @@ details are omitted.
 ctc.getEventTys() => Record<string, ReachType[]>
 ```
 
-Returns a mapping from event name to the reach types of the data emitted for that event.
+Returns a mapping from event name to the Reach types of the data emitted for that event.
 This can be used to determine the connector-specific event signature.
 For example:
 

--- a/examples/get-event-sigs/index.mjs
+++ b/examples/get-event-sigs/index.mjs
@@ -1,0 +1,13 @@
+import {Reach} from '@reach-sh/stdlib';
+import * as backend from './build/index.main.mjs';
+const reach = new Reach();
+const ctc = await reach.contract(backend);
+const e = ctc.getEventSigs();
+console.log(e);
+reach.assert(e.sigs.length === 1);
+reach.assert(e.sigs[0] === 'pub(UInt)');
+if (reach.connector === 'ALGO') {
+  reach.assert(e.ALGO.length === 1);
+  reach.assert(e.ALGO[0] === 'pub(uint64)');
+}
+console.log(`all assertions passed`);

--- a/examples/get-event-sigs/index.mjs
+++ b/examples/get-event-sigs/index.mjs
@@ -1,13 +1,58 @@
 import {Reach} from '@reach-sh/stdlib';
 import * as backend from './build/index.main.mjs';
+import { sha512_256 } from '@reach-sh/stdlib/node_modules/js-sha512/src/sha512.js';
 const reach = new Reach();
+
 const ctc = await reach.contract(backend);
-const e = ctc.getEventSigs();
-console.log(e);
-reach.assert(e.sigs.length === 1);
-reach.assert(e.sigs[0] === 'pub(UInt)');
+const tys = ctc.getEventTys();
+const p = tys && tys['pub'];
+const b = tys && tys['big'];
+reach.assert(p);
+reach.assert(b);
+reach.assert(p.length === 1);
+reach.assert(b.length === 2);
+reach.assert(p[0].name === 'UInt');
+reach.assert(b[0].name.replace(/\s/g, '') === 'Tuple(Data(None:Null,Some:Bool),Array(Bytes(2),2))');
+reach.assert(b[1].name.replace(/\s/g, '') === 'Tuple(Address,Contract,UInt,Digest)');
 if (reach.connector === 'ALGO') {
-  reach.assert(e.ALGO.length === 1);
-  reach.assert(e.ALGO[0] === 'pub(uint64)');
+  reach.assert(p[0].toString() === 'uint64');
+  reach.assert(b[0].toString() === '((byte,byte[1]),byte[2][2])');
+  reach.assert(b[1].toString() === '(address,uint64,uint256,digest)');
+} else { // 'ETH' || 'CFX'
+  reach.assert(p[0].toString() === 'uint256');
+  reach.assert(b[0].toString() === 'tuple(tuple(uint256 which,bool _None,bool _Some),bytes2[2])');
+  reach.assert(b[1].toString() === 'tuple(address,address,uint256,uint256)')
 }
-console.log(`all assertions passed`);
+console.log(`static assertions passed`);
+
+const amt = reach.parseCurrency('100');
+const deployer = await reach.newTestAccount(amt);
+const ctcD = deployer.contract(backend);
+const i = 7;
+await ctcD.p.Deployer({i});
+
+// We can use the info from getEventSigs to observe events "externally".
+// See ARC-0028. https://github.com/algorandfoundation/ARCs/pull/113
+if (reach.connector === 'ALGO') {
+  const appid = (await ctcD.getInfo()).toNumber();
+  await ctcD.e.big.next(); // just to ensure the indexer is caught up
+  const {indexer} = await reach.getProvider(); // This is a regular old algosdk Indexer
+  const log_b64s_nested = await indexer.lookupApplicationLogs(appid).do();
+  const log_b64s = log_b64s_nested['log-data'].map((x) => x.logs).flat();
+  const logs = log_b64s.map((l) => Buffer.from(l, 'base64'));
+  console.log('logs', logs);
+  for (const e of ['pub', 'big']) {
+    const sig = `${e}(${tys[e].toString()})`; // easy as that to construct the sig
+    const prefix_hex = sha512_256(sig).slice(0,8);
+    const explen = tys[e].reduce((s, t) => s + t.netSize, 4);
+    console.log(prefix_hex, 'size', explen, 'from', sig);
+    const elogs = logs.filter((b) => prefix_hex === b.slice(0,4).toString('hex'));
+    reach.assert(elogs.length === 1);
+    reach.assert(elogs[0].length == explen);
+    if (e === 'pub') {
+      const ihex = Buffer.from(reach.T_UInt.toNet(i)).toString('hex');
+      reach.assert(elogs[0].toString('hex') === `${prefix_hex}${ihex}`);
+    }
+  }
+  console.log(`log observation assertions passed`);
+}

--- a/examples/get-event-sigs/index.rsh
+++ b/examples/get-event-sigs/index.rsh
@@ -1,0 +1,11 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const Deployer = Participant('Deployer', {i: UInt});
+  const N = Events({pub: [UInt]});
+  init();
+  Deployer.only(() => { const i = declassify(interact.i); });
+  Deployer.publish(i);
+  N.pub(i);
+  commit();
+});

--- a/examples/get-event-sigs/index.rsh
+++ b/examples/get-event-sigs/index.rsh
@@ -2,10 +2,14 @@
 
 export const main = Reach.App(() => {
   const Deployer = Participant('Deployer', {i: UInt});
-  const N = Events({pub: [UInt]});
+  const N = Events({
+    pub: [UInt],
+    big: [Tuple(Maybe(Bool), Array(Bytes(2), 2)), Tuple(Address, Contract, UInt256, Digest)],
+  });
   init();
   Deployer.only(() => { const i = declassify(interact.i); });
   Deployer.publish(i);
   N.pub(i);
+  N.big([Maybe(Bool).Some(false), array(Bytes(2), ["hi", "ho"])], [this, getContract(), UInt256(42), digest(0)]);
   commit();
 });

--- a/examples/get-event-sigs/index.txt
+++ b/examples/get-event-sigs/index.txt
@@ -1,0 +1,5 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 3 theorems; No failures!

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -74,7 +74,8 @@ import {
   protectSecretKey,
   SecretKeyInput,
   SecretKey,
-  Mnemonic
+  Mnemonic,
+  mkGetEventTys,
 } from './shared_impl';
 import {
   bigNumberify,
@@ -2232,19 +2233,9 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
     const getABI = (isFull?:boolean) => ({
       sigs: (isFull ? ABI_sigs : ABI_sigs.map((name:string) => ({name})).filter(stdABIFilter).map(({name}:{name: string}) => name)),
     });
-    const getEventSigs = () => {
-      const sigs = []
-      const ALGO = [];
-      const events = bin._getEvents({ reachStdlib: stdlib });
-      for (const name in events) {
-        const e = events[name];
-        sigs.push(`${name}(${e.map((arg) => arg.name).join(', ')})`);
-        ALGO.push(`${name}(${e.map((arg) => arg.netName).join(',')})`);
-      }
-      return {sigs, ALGO};
-    };
+    const getEventTys = mkGetEventTys(bin, stdlib);
 
-    return stdContract({ bin, getABI, getEventSigs, waitUntilTime, waitUntilSecs, selfAddress, iam, stdlib, setupView, setupEvents, _setup, givenInfoP });
+    return stdContract({ bin, getABI, getEventTys, waitUntilTime, waitUntilSecs, selfAddress, iam, stdlib, setupView, setupEvents, _setup, givenInfoP });
   };
 
   function setDebugLabel(newLabel: string): Account {

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -2232,8 +2232,19 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
     const getABI = (isFull?:boolean) => ({
       sigs: (isFull ? ABI_sigs : ABI_sigs.map((name:string) => ({name})).filter(stdABIFilter).map(({name}:{name: string}) => name)),
     });
+    const getEventSigs = () => {
+      const sigs = []
+      const ALGO = [];
+      const events = bin._getEvents({ reachStdlib: stdlib });
+      for (const name in events) {
+        const e = events[name];
+        sigs.push(`${name}(${e.map((arg) => arg.name).join(', ')})`);
+        ALGO.push(`${name}(${e.map((arg) => arg.netName).join(',')})`);
+      }
+      return {sigs, ALGO};
+    };
 
-    return stdContract({ bin, getABI, waitUntilTime, waitUntilSecs, selfAddress, iam, stdlib, setupView, setupEvents, _setup, givenInfoP });
+    return stdContract({ bin, getABI, getEventSigs, waitUntilTime, waitUntilSecs, selfAddress, iam, stdlib, setupView, setupEvents, _setup, givenInfoP });
   };
 
   function setDebugLabel(newLabel: string): Account {

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -33,6 +33,7 @@ import {
   protectSecretKey,
   SecretKeyInput,
   Mnemonic,
+  mkGetEventTys,
 } from './shared_impl';
 import {
   bigNumberify,
@@ -846,18 +847,9 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
       return { createEventStream };
     };
     const getABI = stdGetABI(ABI);
-    const getEventSigs = () => {
-      const sigs = []
-      const events = bin._getEvents({ reachStdlib: stdlib });
-      for (const name in events) {
-        const e = events[name];
-        sigs.push(`${name}(${e.map((arg) => arg.name).join(', ')})`);
-      }
-      // TODO: add ETH-like event info
-     return {sigs};
-    };
+    const getEventTys = mkGetEventTys(bin, stdlib);
 
-    return stdContract({ bin, getABI, getEventSigs, waitUntilTime, waitUntilSecs, selfAddress, iam, stdlib, setupView, setupEvents, _setup, givenInfoP });
+    return stdContract({ bin, getABI, getEventTys, waitUntilTime, waitUntilSecs, selfAddress, iam, stdlib, setupView, setupEvents, _setup, givenInfoP });
   };
 
   function setDebugLabel(newLabel: string): Account {

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -846,8 +846,18 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
       return { createEventStream };
     };
     const getABI = stdGetABI(ABI);
+    const getEventSigs = () => {
+      const sigs = []
+      const events = bin._getEvents({ reachStdlib: stdlib });
+      for (const name in events) {
+        const e = events[name];
+        sigs.push(`${name}(${e.map((arg) => arg.name).join(', ')})`);
+      }
+      // TODO: add ETH-like event info
+     return {sigs};
+    };
 
-    return stdContract({ bin, getABI, waitUntilTime, waitUntilSecs, selfAddress, iam, stdlib, setupView, setupEvents, _setup, givenInfoP });
+    return stdContract({ bin, getABI, getEventSigs, waitUntilTime, waitUntilSecs, selfAddress, iam, stdlib, setupView, setupEvents, _setup, givenInfoP });
   };
 
   function setDebugLabel(newLabel: string): Account {

--- a/js/stdlib/ts/shared_impl.ts
+++ b/js/stdlib/ts/shared_impl.ts
@@ -124,7 +124,7 @@ export type IBackend<ConnectorTy extends AnyBackendTy> = {
   _Participants: {[n: string]: any},
   _APIs: {[n: string]: any | {[n: string]: any}},
   _stateSourceMap: {[key: number]: any},
-  _getEvents: (stdlib:Object) => ({ [n:string]: [any] })
+  _getEvents: (stdlib:Object) => ({ [n:string]: ConnectorTy[] })
 };
 
 export type OnProgress = (obj: {current: BigNumber, target: BigNumber}) => any;
@@ -183,10 +183,6 @@ export type ParticipantMap = {[key: string]: ParticipantVal};
 export type ViewVal = (...args:any) => Promise<any>;
 export type ViewFunMap = {[key: string]: ViewVal};
 export type ViewMap = {[key: string]: ViewVal | ViewFunMap};
-export type EventSigMap = {
-  sigs: string[],
-  ALGO?: string[],
-};
 export type APIMap = ViewMap;
 export type EventMap = { [key: string]: any }
 
@@ -227,7 +223,7 @@ export type ISetupRes<ContractInfo, RawAddress, Token, ConnectorTy extends AnyBa
 export type IStdContractArgs<ContractInfo, VerifyResult, RawAddress, Token, ConnectorTy extends AnyBackendTy> = {
   bin: IBackend<ConnectorTy>,
   getABI: (x?:boolean) => unknown,
-  getEventSigs: () => EventSigMap,
+  getEventTys: () => Record<string, ConnectorTy[]>,
   setupView: ISetupView<ContractInfo, VerifyResult, ConnectorTy>,
   setupEvents: ISetupEvent<ContractInfo, VerifyResult>,
   givenInfoP: (Promise<ContractInfo>|undefined)
@@ -240,7 +236,7 @@ export type IContract<ContractInfo, RawAddress, Token, ConnectorTy extends AnyBa
   getContractAddress: () => Promise<CBR_Address>,
   // backend-specific
   getABI: (x?:boolean) => unknown,
-  getEventSigs: () => EventSigMap,
+  getEventTys: () => Record<string, ConnectorTy[]>,
   getInternalState: () => Promise<{[key: string]: any }>;
   participants: ParticipantMap,
   p: ParticipantMap
@@ -329,7 +325,7 @@ export const stdContract =
   <ContractInfo, VerifyResult, RawAddress, Token, ConnectorTy extends AnyBackendTy>(
     stdContractArgs: IStdContractArgs<ContractInfo, VerifyResult, RawAddress, Token, ConnectorTy>):
   IContract<ContractInfo, RawAddress, Token, ConnectorTy> => {
-  const { bin, getABI, getEventSigs, waitUntilTime, waitUntilSecs, selfAddress, iam, stdlib, setupView, setupEvents, _setup, givenInfoP } = stdContractArgs;
+  const { bin, getABI, getEventTys, waitUntilTime, waitUntilSecs, selfAddress, iam, stdlib, setupView, setupEvents, _setup, givenInfoP } = stdContractArgs;
 
   type SomeSetupArgs = Pick<ISetupArgs<ContractInfo, VerifyResult>, ("setInfo"|"getInfo")>;
   const { setInfo, getInfo }: SomeSetupArgs = (() => {
@@ -477,7 +473,7 @@ export const stdContract =
   return {
     ...ctcC,
     getABI,
-    getEventSigs,
+    getEventTys,
     getInfo,
     getContractAddress: (() => _initialize().getContractAddress()),
     participants, p: participants,
@@ -1346,3 +1342,6 @@ export const protectMnemonic = (phrase: Mnemonic, numWords?: number): Mnemonic =
   }
   return words.join(" ");
 }
+
+export const mkGetEventTys = <BackendTy extends AnyBackendTy>(bin: IBackend<BackendTy>, stdlib: any) => () =>
+  bin._getEvents({ reachStdlib: stdlib });

--- a/js/stdlib/ts/shared_impl.ts
+++ b/js/stdlib/ts/shared_impl.ts
@@ -183,6 +183,10 @@ export type ParticipantMap = {[key: string]: ParticipantVal};
 export type ViewVal = (...args:any) => Promise<any>;
 export type ViewFunMap = {[key: string]: ViewVal};
 export type ViewMap = {[key: string]: ViewVal | ViewFunMap};
+export type EventSigMap = {
+  sigs: string[],
+  ALGO?: string[],
+};
 export type APIMap = ViewMap;
 export type EventMap = { [key: string]: any }
 
@@ -223,6 +227,7 @@ export type ISetupRes<ContractInfo, RawAddress, Token, ConnectorTy extends AnyBa
 export type IStdContractArgs<ContractInfo, VerifyResult, RawAddress, Token, ConnectorTy extends AnyBackendTy> = {
   bin: IBackend<ConnectorTy>,
   getABI: (x?:boolean) => unknown,
+  getEventSigs: () => EventSigMap,
   setupView: ISetupView<ContractInfo, VerifyResult, ConnectorTy>,
   setupEvents: ISetupEvent<ContractInfo, VerifyResult>,
   givenInfoP: (Promise<ContractInfo>|undefined)
@@ -235,6 +240,7 @@ export type IContract<ContractInfo, RawAddress, Token, ConnectorTy extends AnyBa
   getContractAddress: () => Promise<CBR_Address>,
   // backend-specific
   getABI: (x?:boolean) => unknown,
+  getEventSigs: () => EventSigMap,
   getInternalState: () => Promise<{[key: string]: any }>;
   participants: ParticipantMap,
   p: ParticipantMap
@@ -323,7 +329,7 @@ export const stdContract =
   <ContractInfo, VerifyResult, RawAddress, Token, ConnectorTy extends AnyBackendTy>(
     stdContractArgs: IStdContractArgs<ContractInfo, VerifyResult, RawAddress, Token, ConnectorTy>):
   IContract<ContractInfo, RawAddress, Token, ConnectorTy> => {
-  const { bin, getABI, waitUntilTime, waitUntilSecs, selfAddress, iam, stdlib, setupView, setupEvents, _setup, givenInfoP } = stdContractArgs;
+  const { bin, getABI, getEventSigs, waitUntilTime, waitUntilSecs, selfAddress, iam, stdlib, setupView, setupEvents, _setup, givenInfoP } = stdContractArgs;
 
   type SomeSetupArgs = Pick<ISetupArgs<ContractInfo, VerifyResult>, ("setInfo"|"getInfo")>;
   const { setInfo, getInfo }: SomeSetupArgs = (() => {
@@ -471,6 +477,7 @@ export const stdContract =
   return {
     ...ctcC,
     getABI,
+    getEventSigs,
     getInfo,
     getContractAddress: (() => _initialize().getContractAddress()),
     participants, p: participants,


### PR DESCRIPTION
```
$ REACH_CONNECTOR_MODE=ALGO reach run
static assertions passed
Warning: your program uses stdlib.fundFromFaucet. That means it only works on Reach devnets!
logs [
  <Buffer 82 c4 61 fe 00 00 00 00 00 00 00 07>,
  <Buffer 5c 4c 54 5c 00 00 00 00 00 00 00 07>,
  <Buffer d2 a5 9f 6c 01 00 68 69 68 6f 23 41 9a 66 49 b0 3f e7 06 dd 77 fe 1d 9e 39 bc 02 ea 1a b3 c4 ef a9 42 87 88 67 58 9d a1 7e ad 00 00 00 00 00 00 00 30 ... 64 more bytes>
]
5c4c545c size 12 from pub(uint64)
d2a59f6c size 114 from big(((byte,byte[1]),byte[2][2]),(address,uint64,uint256,digest))
log observation assertions passed
```