### PR TITLE
CORE-2531: Switch Fusion

### DIFF
--- a/hs/src/Reach/Optimize.hs
+++ b/hs/src/Reach/Optimize.hs
@@ -139,8 +139,8 @@ newScope m = do
   eVarsSet' <- liftIO $ dupeIORef eVarsSet
   eFusionCases' <- liftIO $ dupeIORef eFusionCases
   local (\e -> e { eEnvsR = eEnvsR'
-                  , eVarsSet = eVarsSet'
-                  , eFusionCases = eFusionCases' }) m
+                 , eVarsSet = eVarsSet'
+                 , eFusionCases = eFusionCases' }) m
 
 lookupCommon :: Ord a => (CommonEnv -> M.Map a b) -> a -> App (Maybe b)
 lookupCommon dict obj = do

--- a/hs/t/y/switch_fusion.rsh
+++ b/hs/t/y/switch_fusion.rsh
@@ -1,0 +1,194 @@
+'reach 0.1';
+
+/*
+
+Before switch fusion:
+
+local switch (ex/100 : Data({"Left": UInt, "Right": Bool})) {
+  case Left as ex/103 : UInt/True: {
+    only(Left "A") {
+      const v104 : Address* = selfAddress("A", False, 35 )();
+      const v105 : Bytes(6)* = "left 1";
+      protect<Null>("A".interact.log(v105 ));
+    };
+  }
+  case Right as ex/106 : Bool/True: {
+    only(Left "A") {
+      const v107 : Address* = selfAddress("A", False, 41 )();
+      const v108 : Bytes(7)* = "right 1";
+      protect<Null>("A".interact.log(v108 ));
+    };
+  }
+}
+local switch (ex/100 : Data({"Left": UInt, "Right": Bool})) {
+  case Left as ex/109 : UInt/True: {
+    only(Left "A") {
+      const v110 : Address* = selfAddress("A", False, 47 )();
+      const v111 : Bytes(6)* = "left 2";
+      protect<Null>("A".interact.log(v111 ));
+    };
+  }
+  case Right as ex/112 : Bool/True: {
+    only(Left "A") {
+      const v113 : Address* = selfAddress("A", False, 53 )();
+      const v114 : Bytes(7)* = "right 2";
+      protect<Null>("A".interact.log(v114 ));
+    };
+  }
+}
+local switch (ex/100 : Data({"Left": UInt, "Right": Bool})) {
+  case Left as ex/115 : UInt/True: {
+    only(Left "A") {
+      const v116 : Address* = selfAddress("A", False, 59 )();
+      const v117 : Bytes(6)* = "left 3";
+      protect<Null>("A".interact.log(v117 ));
+    };
+  }
+  case Right as ex/118 : Bool/True: {
+    only(Left "A") {
+      const v119 : Address* = selfAddress("A", False, 65 )();
+      const v120 : Bytes(7)* = "right 3";
+      protect<Null>("A".interact.log(v120 ));
+    };
+  }
+}
+only(Left "A") {
+  const v121 : Address* = selfAddress("A", False, 69 )();
+  let v122 : Null;
+  v122 : Null = null;
+};
+local switch (ex/100 : Data({"Left": UInt, "Right": Bool})) {
+  case Left as ex/123 : UInt/True: {
+    only(Left "A") {
+      const v124 : Address* = selfAddress("A", False, 74 )();
+      const v125 : Bytes(6)* = "left 4";
+      protect<Null>("A".interact.log(v125 ));
+    };
+  }
+  case Right as ex/126 : Bool/True: {
+    only(Left "A") {
+      const v127 : Address* = selfAddress("A", False, 80 )();
+      const v128 : Bytes(7)* = "right 4";
+      protect<Null>("A".interact.log(v128 ));
+    };
+  }
+}
+
+After switch fusion (variable defn breaks fusing switch 3 and 4):
+
+local switch (ex/100 : Data({"Left": UInt, "Right": Bool})) {
+  case Left as ex/103 : UInt/True: {
+    only(Left "A") {
+      const v104 : Address* = selfAddress("A", False, 35 )();
+      const v105 : Bytes(6)* = "left 1";
+      protect<Null>("A".interact.log(v105 ));
+    };
+    only(Left "A") {
+      const v110 : Address* = selfAddress("A", False, 47 )();
+      const v111 : Bytes(6)* = "left 2";
+      protect<Null>("A".interact.log(v111 ));
+    };
+    only(Left "A") {
+      const v116 : Address* = selfAddress("A", False, 59 )();
+      const v117 : Bytes(6)* = "left 3";
+      protect<Null>("A".interact.log(v117 ));
+    };
+  }
+  case Right as ex/106 : Bool/True: {
+    only(Left "A") {
+      const v107 : Address* = selfAddress("A", False, 41 )();
+      const v108 : Bytes(7)* = "right 1";
+      protect<Null>("A".interact.log(v108 ));
+    };
+    only(Left "A") {
+      const v113 : Address* = selfAddress("A", False, 53 )();
+      const v114 : Bytes(7)* = "right 2";
+      protect<Null>("A".interact.log(v114 ));
+    };
+    only(Left "A") {
+      const v119 : Address* = selfAddress("A", False, 65 )();
+      const v120 : Bytes(7)* = "right 3";
+      protect<Null>("A".interact.log(v120 ));
+    };
+  }
+}
+only(Left "A") {
+  const v121 : Address* = selfAddress("A", False, 69 )();
+  const v122 : Null* = null;
+};
+local switch (ex/100 : Data({"Left": UInt, "Right": Bool})) {
+  case Left as ex/123 : UInt/True: {
+    only(Left "A") {
+      const v124 : Address* = selfAddress("A", False, 74 )();
+      const v125 : Bytes(6)* = "left 4";
+      protect<Null>("A".interact.log(v125 ));
+    };
+  }
+  case Right as ex/126 : Bool/True: {
+    only(Left "A") {
+      const v127 : Address* = selfAddress("A", False, 80 )();
+      const v128 : Bytes(7)* = "right 4";
+      protect<Null>("A".interact.log(v128 ));
+    };
+  }
+}
+
+*/
+
+export const main = Reach.App(() => {
+  const A = Participant('A', {
+    log: Fun(true, Null),
+    b: Bool,
+    ex: Either(UInt, Bool)
+  });
+  init();
+
+  A.only(() => {
+    const b = declassify(interact.b);
+    const ex = declassify(interact.ex);
+  });
+  A.publish(b, ex);
+
+  switch (ex) {
+    case Left: {
+      A.interact.log("left 1");
+    }
+    case Right: {
+      A.interact.log("right 1");
+    }
+  }
+
+  switch (ex) {
+    case Left: {
+      A.interact.log("left 2");
+    }
+    case Right: {
+      A.interact.log("right 2");
+    }
+  }
+
+  switch (ex) {
+    case Left: {
+      A.interact.log("left 3");
+    }
+    case Right: {
+      A.interact.log("right 3");
+    }
+  }
+
+  A.only(() => {
+    const d = declassify(interact.b);
+  });
+
+  switch (ex) {
+    case Left: {
+      A.interact.log("left 4");
+    }
+    case Right: {
+      A.interact.log("right 4");
+    }
+  }
+
+  commit();
+});
+

--- a/hs/t/y/switch_fusion.txt
+++ b/hs/t/y/switch_fusion.txt
@@ -1,0 +1,5 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 3 theorems; No failures!


### PR DESCRIPTION
The comments should outline the process but let me know if I need to explain it more. 

One augmentation that could be handy in the future is to add metadata to `DL_LocalSwitch` to track if it sets a DLVar, like we do for floating `if`. Then, if we inline a switch that sets a DLVar, float that `DL_Var` too. Right now, it won't lift a switch if it sets a var in its branches.