### PR TITLE
js:ETH - ignore "after last accepted block"

### DIFF
--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -259,7 +259,7 @@ const newEventQueue = (): EventQueue => {
     } catch (e) {
       const es = `${e}`;
       debug(dhead, `err`, e, es);
-      if ( es.includes('Unable to find block hash') ) {
+      if ( es.includes('Unable to find block hash') || es.includes('after last accepted block')) {
         debug(dhead, 'ignore');
         toBlock = undefined;
       } else {

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -259,7 +259,7 @@ const newEventQueue = (): EventQueue => {
     } catch (e) {
       const es = `${e}`;
       debug(dhead, `err`, e, es);
-      if ( es.includes('Unable to find block hash') || es.includes('after last accepted block')) {
+      if ( es.includes('Unable to find block hash') || es.includes('after last accepted block') ) {
         debug(dhead, 'ignore');
         toBlock = undefined;
       } else {


### PR DESCRIPTION
Not tested yet. Not sure if there's a good way to add anything to our examples or test suite for this.