### PR TITLE
WIP - working on BytesDyn casting

### DIFF
--- a/docs/src/changelog/index.md
+++ b/docs/src/changelog/index.md
@@ -6,6 +6,7 @@ Versions and changes-within-versions are listed in reverse-chronological order: 
 ## 0.1.12: 2022/09 - present
 
 @{verRC("0.1.12")}
++ 2022/10/25: Added `{!rsh} BytesDyn` casting from fixed-length bytes.
 
 @{rcHead("0.1.12-rc.5")}
 

--- a/docs/src/rsh/compute/index.md
+++ b/docs/src/rsh/compute/index.md
@@ -2976,7 +2976,7 @@ The `IDs` component is intended to hold byte strings that represent ERC-165 inte
 For example, we define all of the interfaces that are part of the [ERC-721](https://eips.ethereum.org/EIPS/eip-721) NFT specification using `{!rsh} mixin`:
 ```reach
 load: /examples/ERC721/index.rsh
-md5: fc2bac5972751cb3280a6e974d864096
+md5: c31c20d4e9add1a3ef3038596d965089
 range: 8 - 59
 ```
 

--- a/docs/src/rsh/compute/index.md
+++ b/docs/src/rsh/compute/index.md
@@ -415,7 +415,7 @@ Reach's @{defn("type")}s are represented in programs by the following identifier
 + @{ref("rsh", "Bytes")} `{!rsh} Bytes(length)`, which denotes a sequence of bytes of length at most `{!rsh} length`.
   Bytes of different lengths are not compatible; however the shorter bytes may be [padded](##padding).
 + @{ref("rsh", "BytesDyn")} `{!rsh} BytesDyn`, which denotes a sequence of bytes of dynamic length.
-  Bytes of fixed length and bytes of dynamic length are totally incompatible.
+  Bytes of fixed length and bytes of dynamic length are totally incompatible, but bytes of fixed length can be casted into `{!rsh} BytesDyn` with `{!rsh} BytesDyn` applied as a function.
 + @{ref("rsh", "StringDyn")} `{!rsh} StringDyn`, which denotes a string of UTF-8 code points of dynamic length.
   Strings and bytes are totally incompatible, but static bytes can be casted into dynamic strings with `{!rsh} StringDyn` applied as function.
 + @{ref("rsh", "Digest")} `{!rsh} Digest`, which denotes a digest.
@@ -2976,7 +2976,7 @@ The `IDs` component is intended to hold byte strings that represent ERC-165 inte
 For example, we define all of the interfaces that are part of the [ERC-721](https://eips.ethereum.org/EIPS/eip-721) NFT specification using `{!rsh} mixin`:
 ```reach
 load: /examples/ERC721/index.rsh
-md5: c31c20d4e9add1a3ef3038596d965089
+md5: fc2bac5972751cb3280a6e974d864096
 range: 8 - 59
 ```
 

--- a/docs/src/rsh/compute/index.md
+++ b/docs/src/rsh/compute/index.md
@@ -2976,13 +2976,13 @@ The `IDs` component is intended to hold byte strings that represent ERC-165 inte
 For example, we define all of the interfaces that are part of the [ERC-721](https://eips.ethereum.org/EIPS/eip-721) NFT specification using `{!rsh} mixin`:
 ```reach
 load: /examples/ERC721/index.rsh
-md5: c31c20d4e9add1a3ef3038596d965089
+md5: fc2bac5972751cb3280a6e974d864096
 range: 8 - 59
 ```
 
 Then, we construct the final mixed contract, and overriding `ERC721EnumerablePartial`'s base with `ERC721Metadata` (because we want _both_ extensions to ERC-721):
 ```reach
 load: /examples/ERC721/index.rsh
-md5: c31c20d4e9add1a3ef3038596d965089
+md5: fc2bac5972751cb3280a6e974d864096
 range: 79 - 80
 ```

--- a/examples/BytesDynCast/index.mjs
+++ b/examples/BytesDynCast/index.mjs
@@ -1,0 +1,23 @@
+import {loadStdlib} from '@reach-sh/stdlib';
+import * as backend from './build/index.main.mjs';
+const stdlib = loadStdlib();
+
+if ( stdlib.connector === 'ALGO' ) { process.exit(0); }
+
+const startingBalance = stdlib.parseCurrency(100);
+const [ accA, accB ] = await stdlib.newTestAccounts(2, startingBalance);
+
+const ctcA = accA.contract(backend);
+const ctcB = accB.contract(backend, ctcA.getInfo());
+const iface = { post: () => "hiya", }
+await Promise.all([
+  ctcA.p.A(iface),
+  ctcB.p.B(iface),
+]);
+const e1 = await ctcA.e.e.next();
+const e2 = await ctcA.e.e.next();
+console.log(e1)
+console.log(e2)
+stdlib.assert(e1.what[0], "e1")
+stdlib.assert(! e2.what[0], "e2")
+

--- a/examples/BytesDynCast/index.rsh
+++ b/examples/BytesDynCast/index.rsh
@@ -1,0 +1,17 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const iface = { post: Fun([], Bytes(4)) };
+  const A = Participant('A', iface);
+  const B = Participant('B', iface);
+  const E = Events({ e: [Bool] });
+  init();
+  A.only(() => { const v1 = declassify(interact.post()); });
+  A.publish(v1);
+  E.e(BytesDyn(v1) == BytesDyn("hiya"))
+  commit();
+  B.only(() => { const v2 = declassify(interact.post()); });
+  B.publish(v2);
+  E.e(BytesDyn(v2) == BytesDyn("goodbye"))
+  commit();
+});

--- a/examples/BytesDynCast/index.txt
+++ b/examples/BytesDynCast/index.txt
@@ -1,0 +1,9 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 5 theorems; No failures!
+/home/wgh/s/mk/reach-lang/hs/reach.cabal was generated with a newer version of hpack,
+please upgrade and try again.
+WARNING: Compiler instructed to emit for Algorand, but we can statically determine that this program will not work on Algorand, because:
+ * Uses a dynamically sized type, like BytesDyn or StringDyn.

--- a/examples/BytesDynCast/index.txt
+++ b/examples/BytesDynCast/index.txt
@@ -3,7 +3,5 @@ Verifying for generic connector
   Verifying when ALL participants are honest
   Verifying when NO participants are honest
 Checked 5 theorems; No failures!
-/home/wgh/s/mk/reach-lang/hs/reach.cabal was generated with a newer version of hpack,
-please upgrade and try again.
 WARNING: Compiler instructed to emit for Algorand, but we can statically determine that this program will not work on Algorand, because:
  * Uses a dynamically sized type, like BytesDyn or StringDyn.

--- a/examples/ERC721/index.rsh
+++ b/examples/ERC721/index.rsh
@@ -212,7 +212,7 @@ export const main = Reach.App(() => {
       .api_(I.safeTransferFrom2, (from_, to, tokenId) => {
         transferChecks(this, from_, to, tokenId);
         return [ (k) => {
-          doSafeTransferFrom(this, from_, to, tokenId, BytesDynCast(""));
+          doSafeTransferFrom(this, from_, to, tokenId, BytesDyn(""));
           k(null);
           return [ ];
         }];

--- a/examples/ERC721/index.rsh
+++ b/examples/ERC721/index.rsh
@@ -212,7 +212,7 @@ export const main = Reach.App(() => {
       .api_(I.safeTransferFrom2, (from_, to, tokenId) => {
         transferChecks(this, from_, to, tokenId);
         return [ (k) => {
-          doSafeTransferFrom(this, from_, to, tokenId, emptyBytesDyn);
+          doSafeTransferFrom(this, from_, to, tokenId, BytesDynCast(""));
           k(null);
           return [ ];
         }];

--- a/hs/smt2/runtime.smt2
+++ b/hs/smt2/runtime.smt2
@@ -44,6 +44,8 @@
 
 (declare-sort BytesDyn 0)
 (declare-fun BytesDyn_toBytes (BytesDyn) Bytes)
+(declare-fun bytesDyn (Int) BytesDyn)
+(declare-fun Bytes_toBytesDyn (Bytes) BytesDyn)
 
 (declare-sort StringDyn 0)
 (declare-fun stringDyn (Int) StringDyn)

--- a/hs/src/Reach/AST/DLBase.hs
+++ b/hs/src/Reach/AST/DLBase.hs
@@ -839,6 +839,7 @@ data DLExpr
   | DLE_ArrayRef SrcLoc DLArg DLArg
   | DLE_ArraySet SrcLoc DLArg DLArg DLArg
   | DLE_ArrayConcat SrcLoc DLArg DLArg
+  | DLE_BytesDynCast SrcLoc DLArg
   | DLE_TupleRef SrcLoc DLArg Integer
   | DLE_TupleSet SrcLoc DLArg Integer DLArg
   | DLE_ObjectRef SrcLoc DLArg String
@@ -953,6 +954,9 @@ instance PrettySubst DLExpr where
     DLE_ArrayConcat _ x y -> do
       as' <- render_dasM [x, y]
       return $ "Array.concat" <> parens as'
+    DLE_BytesDynCast _ x -> do
+      x' <- prettySubst x
+      return $ "BytesDyn" <> parens x'
     DLE_TupleRef _ a i -> do
       a' <- prettySubst a
       return $ a' <> brackets (pretty i)
@@ -1081,6 +1085,7 @@ instance IsPure DLExpr where
     DLE_ArrayRef {} -> True
     DLE_ArraySet {} -> True
     DLE_ArrayConcat {} -> True
+    DLE_BytesDynCast {} -> True
     DLE_TupleRef {} -> True
     DLE_ObjectRef {} -> True
     DLE_Interact {} -> False
@@ -1123,6 +1128,7 @@ instance IsLocal DLExpr where
     DLE_ArrayRef {} -> True
     DLE_ArraySet {} -> True
     DLE_ArrayConcat {} -> True
+    DLE_BytesDynCast {} -> True
     DLE_TupleRef {} -> True
     DLE_ObjectRef {} -> True
     DLE_Interact {} -> True
@@ -1161,6 +1167,7 @@ instance CanDupe DLExpr where
     DLE_ArrayRef {} -> True
     DLE_ArraySet {} -> True
     DLE_ArrayConcat {} -> True
+    DLE_BytesDynCast {} -> True
     DLE_TupleRef {} -> True
     DLE_TupleSet {} -> True
     DLE_ObjectRef {} -> True

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -146,6 +146,7 @@ data SLVal
   | SLV_Bool SrcLoc Bool
   | SLV_Int SrcLoc (Maybe UIntTy) Integer
   | SLV_Bytes SrcLoc B.ByteString
+  | SLV_BytesDyn SrcLoc B.ByteString
   | SLV_String SrcLoc T.Text
   | SLV_Array SrcLoc DLType [SLVal]
   | SLV_Tuple SrcLoc [SLVal]
@@ -394,6 +395,7 @@ instance Pretty SLVal where
     SLV_Bool _ b -> pretty b
     SLV_Int _ _ i -> pretty i
     SLV_Bytes _ b -> pretty b
+    SLV_BytesDyn _ b -> pretty b
     SLV_String _ t -> pretty t
     SLV_Array at t as ->
       "array" <> parens (pretty t <> comma <+> pretty (SLV_Tuple at as))
@@ -429,6 +431,7 @@ instance SrcLocOf SLVal where
     SLV_Bool a _ -> a
     SLV_Int a _ _ -> a
     SLV_Bytes a _ -> a
+    SLV_BytesDyn a _ -> a
     SLV_String a _ -> a
     SLV_Array a _ _ -> a
     SLV_Tuple a _ -> a
@@ -740,6 +743,7 @@ data SLPrimitive
   | SLPrim_Fun
   | SLPrim_Refine
   | SLPrim_Bytes
+  | SLPrim_BytesDynCast
   | SLPrim_Data
   | SLPrim_Data_variant (M.Map SLVar SLType) SLVar SLType
   | SLPrim_data_match

--- a/hs/src/Reach/AnalyzeVars.hs
+++ b/hs/src/Reach/AnalyzeVars.hs
@@ -138,6 +138,7 @@ instance FreeVars DLExpr where
     DLE_ArrayRef _ a b -> freeVars [a, b]
     DLE_ArraySet _ a b c -> freeVars [a, b, c]
     DLE_ArrayConcat _ a b -> freeVars [a, b]
+    DLE_BytesDynCast _ a -> freeVars a
     DLE_TupleRef _ a _ -> freeVars a
     DLE_ObjectRef _ a _ -> freeVars a
     DLE_Interact _ _ _ _ _ a -> freeVars a

--- a/hs/src/Reach/AnalyzeVars.hs
+++ b/hs/src/Reach/AnalyzeVars.hs
@@ -90,6 +90,7 @@ instance FreeVars DLLargeArg where
     DLLA_Data _ _ a -> freeVars a
     DLLA_Struct m -> freeVars $ map snd m
     DLLA_Bytes {} -> mempty
+    DLLA_BytesDyn {} -> mempty
     DLLA_StringDyn {} -> mempty
 
 instance FreeVars DLPayAmt where

--- a/hs/src/Reach/Backend/JS.hs
+++ b/hs/src/Reach/Backend/JS.hs
@@ -263,6 +263,7 @@ jsLargeArg = \case
   DLLA_Struct kvs ->
     jsLargeArg $ DLLA_Obj $ M.fromList kvs
   DLLA_Bytes b -> return $ jsBytes b
+  DLLA_BytesDyn b -> return $ jsBytes b
   DLLA_StringDyn t -> return $ jsString $ T.unpack t
 
 jsBytes :: B.ByteString -> Doc

--- a/hs/src/Reach/Backend/JS.hs
+++ b/hs/src/Reach/Backend/JS.hs
@@ -423,6 +423,7 @@ jsExpr = \case
     x' <- jsArg x
     y' <- jsArg y
     return $ x' <> "." <> jsApply "concat" [y']
+  DLE_BytesDynCast _ x -> jsArg x
   DLE_TupleRef at aa i -> do
     aa' <- jsArg aa
     i' <- jsCon $ DLL_Int at UI_Word i

--- a/hs/src/Reach/CollectCounts.hs
+++ b/hs/src/Reach/CollectCounts.hs
@@ -120,6 +120,7 @@ instance Countable DLLargeArg where
     DLLA_Data _ _ v -> counts v
     DLLA_Struct kvs -> counts $ map snd kvs
     DLLA_Bytes _ -> mempty
+    DLLA_BytesDyn _ -> mempty
     DLLA_StringDyn _ -> mempty
 
 instance Countable DLTokenNew where

--- a/hs/src/Reach/CollectCounts.hs
+++ b/hs/src/Reach/CollectCounts.hs
@@ -166,6 +166,7 @@ instance Countable DLExpr where
     DLE_ArrayRef _ aa ea -> counts [aa, ea]
     DLE_ArraySet _ aa ia va -> counts [aa, ia, va]
     DLE_ArrayConcat _ x y -> counts x <> counts y
+    DLE_BytesDynCast _ x -> counts x
     DLE_TupleRef _ t _ -> counts t
     DLE_ObjectRef _ aa _ -> counts aa
     DLE_Interact _ _ _ _ _ as -> counts as

--- a/hs/src/Reach/CollectTypes.hs
+++ b/hs/src/Reach/CollectTypes.hs
@@ -148,6 +148,7 @@ instance CollectsTypes DLExpr where
     DLE_ArrayRef _ a i -> cts a <> cts i
     DLE_ArraySet _ a i v -> cts a <> cts i <> cts v
     DLE_ArrayConcat _ x y -> cts x <> cts y
+    DLE_BytesDynCast _ x -> cts x
     DLE_TupleRef _ t _ -> cts t
     DLE_ObjectRef _ a _ -> cts a
     DLE_Interact _ _ _ _ t as -> cts t <> cts as

--- a/hs/src/Reach/Connector/ALGO.hs
+++ b/hs/src/Reach/Connector/ALGO.hs
@@ -1733,6 +1733,7 @@ cla = \case
   DLLA_Struct kvs ->
     cconcatbs $ map (\a -> (argTypeOf a, ca a)) $ map snd kvs
   DLLA_Bytes bs -> cbs bs
+  DLLA_BytesDyn bs -> cbs bs
   DLLA_StringDyn t -> cbs $ bpack $ T.unpack t
 
 cbs :: B.ByteString -> App ()

--- a/hs/src/Reach/Connector/ALGO.hs
+++ b/hs/src/Reach/Connector/ALGO.hs
@@ -1964,6 +1964,8 @@ ce = \case
     xtz <- typeSizeOf xt
     check_concat_len $ (xlen + ylen) * xtz
     op "concat"
+  DLE_BytesDynCast _ v -> do
+    ca v
   DLE_TupleRef at ta idx -> do
     ca ta
     cTupleRef at (argTypeOf ta) idx

--- a/hs/src/Reach/Connector/ETH_Solidity.hs
+++ b/hs/src/Reach/Connector/ETH_Solidity.hs
@@ -436,6 +436,7 @@ instance DepthOf DLExpr where
     DLE_ArrayRef _ x y -> add1 $ depthOf [x, y]
     DLE_ArraySet _ x y z -> depthOf [x, y, z]
     DLE_ArrayConcat _ x y -> add1 $ depthOf [x, y]
+    DLE_BytesDynCast _ x -> add1 $ depthOf x
     DLE_TupleRef _ x _ -> add1 $ depthOf x
     DLE_TupleSet _ t _ v -> add1 $ depthOf [t, v]
     DLE_ObjectRef _ x _ -> add1 $ depthOf x
@@ -743,6 +744,9 @@ solExpr sp = \case
     spa $ return $ solApply (solArraySet ti) args'
   DLE_ArrayConcat {} ->
     impossible "array concat"
+  DLE_BytesDynCast _ ae -> do
+    ae' <- solArg ae
+    return $ "bytes.concat" <> parens ae'
   DLE_TupleRef _ ae i -> do
     ae' <- solArg ae
     return $ ae' <> ".elem" <> pretty i <> sp

--- a/hs/src/Reach/EditorInfo.hs
+++ b/hs/src/Reach/EditorInfo.hs
@@ -65,6 +65,7 @@ completionKind v =
     SLV_Bool _ _ -> Just CK_Constant
     SLV_Int _ _ _ -> Just CK_Constant
     SLV_Bytes _ _ -> Just CK_Constant
+    SLV_BytesDyn _ _ -> Just CK_Constant
     SLV_String _ _ -> Just CK_Constant
     SLV_Array _ _ _ -> Just CK_Constant
     SLV_Tuple _ _ -> Just CK_Constant
@@ -98,6 +99,7 @@ completionKind v =
         SLPrim_Fun -> Just CK_TypeParameter
         SLPrim_Refine -> Just CK_TypeParameter
         SLPrim_Bytes -> Just CK_TypeParameter
+        SLPrim_BytesDynCast -> Just CK_Function
         SLPrim_Data -> Just CK_TypeParameter
         SLPrim_Data_variant _ _ _ -> Nothing
         SLPrim_data_match -> Just CK_Method

--- a/hs/src/Reach/Eval.hs
+++ b/hs/src/Reach/Eval.hs
@@ -245,6 +245,7 @@ instance Pandemic DLLargeArg where
     DLLA_Data m s a -> DLLA_Data m s <$> pan a
     DLLA_Struct vars_args -> DLLA_Struct <$> pan vars_args
     DLLA_Bytes s -> return $ DLLA_Bytes s
+    DLLA_BytesDyn s -> return $ DLLA_BytesDyn s
     DLLA_StringDyn s -> return $ DLLA_StringDyn s
 
 instance Pandemic DLSend where

--- a/hs/src/Reach/Eval.hs
+++ b/hs/src/Reach/Eval.hs
@@ -150,6 +150,7 @@ instance Pandemic DLExpr where
     DLE_ArrayRef at a i -> DLE_ArrayRef at <$> pan a <*> pan i
     DLE_ArraySet at a i v -> DLE_ArraySet at <$> pan a <*> pan i <*> pan v
     DLE_ArrayConcat at x y -> DLE_ArrayConcat at <$> pan x <*> pan y
+    DLE_BytesDynCast at x -> DLE_BytesDynCast at <$> pan x
     DLE_TupleRef at a i -> DLE_TupleRef at <$> pan a <*> pure i
     DLE_ObjectRef at a f -> DLE_ObjectRef at <$> pan a <*> pure f
     DLE_Interact at cxt slp s ty as -> DLE_Interact at cxt slp s ty <$> pan as

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -699,6 +699,7 @@ dlvToDL = \case
   DLV_Struct _ menv -> DLAE_Struct <$> all_just (map recAssoc menv)
   DLV_Data _ t s mdv -> DLAE_Data t s <$> dlvToDL mdv
   DLV_Bytes _ b -> return $ DLAE_Bytes b
+  DLV_BytesDyn _ b -> return $ DLAE_BytesDyn b
   DLV_StringDyn _ s -> return $ DLAE_StringDyn s
   _ -> Nothing
   where
@@ -945,6 +946,8 @@ compileArgExpr mt = \case
     mk $ DLLA_Struct kvs'
   DLAE_Bytes b -> do
     mk $ DLLA_Bytes b
+  DLAE_BytesDyn b -> do
+    mk $ DLLA_BytesDyn b
   DLAE_StringDyn t -> do
     mk $ DLLA_StringDyn t
   where

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -575,7 +575,6 @@ base_env_slvals =
   , ("UInt256", SLV_Type $ ST_UInt UI_256)
   , ("Bytes", SLV_Prim SLPrim_Bytes)
   , ("BytesDyn", SLV_Type $ ST_BytesDyn)
-  , ("BytesDynCast", SLV_Prim SLPrim_BytesDynCast)
   , ("StringDyn", SLV_Type $ ST_StringDyn)
   , ("Contract", SLV_Type ST_Contract)
   , ("ContractCode", SLV_Prim $ SLPrim_ContractCode)
@@ -2936,18 +2935,6 @@ evalPrim p sargs =
       case map snd sargs of
         [(SLV_Int _ _ sz)] -> retV $ (lvl, SLV_Type $ ST_Bytes sz)
         _ -> illegal_args
-    SLPrim_BytesDynCast -> do
-      at <- withAt id
-      case args of
-        [] -> retV $ (lvl, SLV_Type $ ST_BytesDyn)
-        [x] -> do
-          (ty, dla) <- compileTypeOf x
-          case ty of
-            T_Bytes _ -> return ()
-            _ -> illegal_args
-          dv <- ctxt_lift_expr (DLVar at Nothing T_BytesDyn) $ DLE_Arg at dla
-          return $ (lvl, SLV_DLVar dv)
-        _ -> illegal_args
     SLPrim_Array ->
       case map snd sargs of
         [(SLV_Type ty), (SLV_Int _ _ sz)] ->
@@ -4128,6 +4115,18 @@ evalPrim p sargs =
           DLE_ContractNew at dcns dr
       ctcdv <- doInternalLog_ Nothing ctcdv_
       return $ public $ SLV_DLVar ctcdv
+    SLPrim_BytesDynCast -> do
+      case args of
+        [SLV_Bytes at bs] -> return $ (lvl, SLV_BytesDyn at bs)
+        [x] -> do
+          at <- withAt id
+          (ty, dla) <- compileTypeOf x
+          case ty of
+            T_Bytes _ -> return ()
+            _ -> illegal_args
+          dv <- ctxt_lift_expr (DLVar at Nothing T_BytesDyn) $ DLE_BytesDynCast at dla
+          return $ (lvl, SLV_DLVar dv)
+        _ -> illegal_args
     SLPrim_toStringDyn -> first_arg >>= \case
       SLV_Bytes at bs -> return $ (lvl, SLV_String at $ T.pack $ bunpack bs)
       v -> do
@@ -4437,6 +4436,8 @@ evalApplyValsAux assumePrecondition rator randvs =
       evalApplyValsAux assumePrecondition (SLV_Prim $ SLPrim_castOrTrunc to) randvs
     SLV_Type ST_StringDyn ->
       evalApplyValsAux assumePrecondition (SLV_Prim $ SLPrim_toStringDyn) randvs
+    SLV_Type ST_BytesDyn ->
+      evalApplyValsAux assumePrecondition (SLV_Prim $ SLPrim_BytesDynCast) randvs
     SLV_Prim p -> do
       sco <- e_sco <$> ask
       SLAppRes sco <$> evalPrim p randvs

--- a/hs/src/Reach/Eval/Types.hs
+++ b/hs/src/Reach/Eval/Types.hs
@@ -92,6 +92,7 @@ data DLValue
   | DLV_Data SrcLoc (M.Map SLVar DLType) String DLValue
   | DLV_Struct SrcLoc [(SLVar, DLValue)]
   | DLV_Bytes SrcLoc B.ByteString
+  | DLV_BytesDyn SrcLoc B.ByteString
   | DLV_StringDyn SrcLoc T.Text
 
 instance SrcLocOf DLValue where
@@ -104,6 +105,7 @@ instance SrcLocOf DLValue where
     DLV_Data at _ _ _ -> at
     DLV_Struct at _ -> at
     DLV_Bytes at _ -> at
+    DLV_BytesDyn at _ -> at
     DLV_StringDyn at _ -> at
 
 data TransferType

--- a/hs/src/Reach/Freshen.hs
+++ b/hs/src/Reach/Freshen.hs
@@ -110,6 +110,7 @@ instance Freshen DLLargeArg where
     DLLA_Data t v a -> DLLA_Data t v <$> fu a
     DLLA_Struct kvs -> DLLA_Struct <$> mapM go kvs
     DLLA_Bytes b -> return $ DLLA_Bytes b
+    DLLA_BytesDyn b -> return $ DLLA_BytesDyn b
     DLLA_StringDyn t -> return $ DLLA_StringDyn t
     where
       go (k, v) = (,) k <$> fu v

--- a/hs/src/Reach/Freshen.hs
+++ b/hs/src/Reach/Freshen.hs
@@ -172,6 +172,7 @@ instance Freshen DLExpr where
     DLE_ArrayRef at a b -> DLE_ArrayRef at <$> fu a <*> fu b
     DLE_ArraySet at a b c -> DLE_ArraySet at <$> fu a <*> fu b <*> fu c
     DLE_ArrayConcat at a b -> DLE_ArrayConcat at <$> fu a <*> fu b
+    DLE_BytesDynCast at a -> DLE_BytesDynCast at <$> fu a
     DLE_TupleRef at x y -> DLE_TupleRef at <$> fu x <*> pure y
     DLE_ObjectRef at x y -> DLE_ObjectRef at <$> fu x <*> pure y
     DLE_Interact a b c d e f -> DLE_Interact a b c d e <$> fu f

--- a/hs/src/Reach/Optimize.hs
+++ b/hs/src/Reach/Optimize.hs
@@ -547,6 +547,7 @@ instance Optimize DLExpr where
     DLE_ArrayRef at a i -> DLE_ArrayRef at <$> opt a <*> opt i
     DLE_ArraySet at a i v -> optSet DLE_ArraySet DLE_ArrayRef at a i v
     DLE_ArrayConcat at x0 y0 -> DLE_ArrayConcat at <$> opt x0 <*> opt y0
+    DLE_BytesDynCast at x -> DLE_BytesDynCast at <$> opt x
     DLE_TupleRef at t i -> do
       t' <- opt t
       let meh = return $ DLE_TupleRef at t' i

--- a/hs/src/Reach/Optimize.hs
+++ b/hs/src/Reach/Optimize.hs
@@ -405,6 +405,7 @@ instance Optimize DLLargeArg where
     DLLA_Data t vn vv -> DLLA_Data t vn <$> opt vv
     DLLA_Struct kvs -> DLLA_Struct <$> mapM go kvs
     DLLA_Bytes b -> return $ DLLA_Bytes b
+    DLLA_BytesDyn b -> return $ DLLA_BytesDyn b
     DLLA_StringDyn t -> return $ DLLA_StringDyn t
     where
       go (k, v) = (,) k <$> opt v

--- a/hs/src/Reach/Sanitize.hs
+++ b/hs/src/Reach/Sanitize.hs
@@ -95,6 +95,7 @@ instance Sanitize DLExpr where
     DLE_ArrayRef _ a i -> DLE_ArrayRef sb (sani a) (sani i)
     DLE_ArraySet _ a i v -> DLE_ArraySet sb (sani a) (sani i) (sani v)
     DLE_ArrayConcat _ x y -> DLE_ArrayConcat sb (sani x) (sani y)
+    DLE_BytesDynCast _ x -> DLE_BytesDynCast sb (sani x)
     DLE_TupleRef _ a i -> DLE_TupleRef sb (sani a) i
     DLE_ObjectRef _ a f -> DLE_ObjectRef sb (sani a) f
     DLE_Interact _ fs p m t as -> DLE_Interact sb fs p m t (sani as)

--- a/hs/src/Reach/Sanitize.hs
+++ b/hs/src/Reach/Sanitize.hs
@@ -51,6 +51,7 @@ instance Sanitize DLLargeArg where
     DLLA_Data t v va -> DLLA_Data t v (sani va)
     DLLA_Struct kvs -> DLLA_Struct $ map go kvs
     DLLA_Bytes b -> DLLA_Bytes b
+    DLLA_BytesDyn b -> DLLA_BytesDyn b
     DLLA_StringDyn t -> DLLA_StringDyn t
     where
       go (k, v) = (,) k (sani v)

--- a/hs/src/Reach/Simulator/Core.hs
+++ b/hs/src/Reach/Simulator/Core.hs
@@ -548,6 +548,7 @@ instance Interp DLExpr where
       arr1 <- vArray <$> interp dlarg1
       arr2 <- vArray <$> interp dlarg2
       return $ V_Array $ arr1 <> arr2
+    DLE_BytesDynCast _at v -> interp v
     DLE_TupleRef _at dlarg n -> do
       arr <- vTuple <$> interp dlarg
       return $ saferIndex (fromIntegral n) arr

--- a/hs/src/Reach/Simulator/Core.hs
+++ b/hs/src/Reach/Simulator/Core.hs
@@ -316,6 +316,7 @@ data DLVal
   | V_UInt Integer
   | V_Token Int
   | V_Bytes String -- XXX BS.ByteString
+  | V_BytesDyn String -- XXX BS.ByteString
   | V_StringDyn T.Text
   | V_Digest DLVal
   | V_Address Account
@@ -521,6 +522,7 @@ instance Interp DLLargeArg where
       evd_args <- mapM (\arg -> interp arg) $ M.fromList assoc_slvars_dlargs
       return $ V_Struct $ M.toAscList evd_args
     DLLA_Bytes bs -> return $ V_Bytes $ bunpack bs
+    DLLA_BytesDyn bs -> return $ V_Bytes $ bunpack bs
     DLLA_StringDyn t -> return $ V_StringDyn t
 
 instance Interp DLExpr where

--- a/hs/src/Reach/Subst.hs
+++ b/hs/src/Reach/Subst.hs
@@ -114,6 +114,7 @@ instance Subst DLExpr where
     DLE_ArrayRef at a b -> DLE_ArrayRef at <$> subst a <*> subst b
     DLE_ArraySet at a b c -> DLE_ArraySet at <$> subst a <*> subst b <*> subst c
     DLE_ArrayConcat at a b -> DLE_ArrayConcat at <$> subst a <*> subst b
+    DLE_BytesDynCast at a -> DLE_BytesDynCast at <$> subst a
     DLE_TupleRef at x y -> DLE_TupleRef at <$> subst x <*> pure y
     DLE_ObjectRef at x y -> DLE_ObjectRef at <$> subst x <*> pure y
     DLE_Interact a b c d e f -> DLE_Interact a b c d e <$> subst f

--- a/hs/src/Reach/Subst.hs
+++ b/hs/src/Reach/Subst.hs
@@ -56,6 +56,7 @@ instance Subst DLLargeArg where
     DLLA_Data t v a -> DLLA_Data t v <$> subst a
     DLLA_Struct kvs -> DLLA_Struct <$> mapM go kvs
     DLLA_Bytes b -> return $ DLLA_Bytes b
+    DLLA_BytesDyn b -> return $ DLLA_BytesDyn b
     DLLA_StringDyn t -> return $ DLLA_StringDyn t
     where
       go (k, v) = (,) k <$> subst v

--- a/hs/src/Reach/Verify/Knowledge.hs
+++ b/hs/src/Reach/Verify/Knowledge.hs
@@ -196,6 +196,7 @@ kgq_la ctxt mv = \case
   DLLA_Data _ _ a -> onea a
   DLLA_Struct kvs -> moreas $ map snd kvs
   DLLA_Bytes _ -> mempty
+  DLLA_BytesDyn _ -> mempty
   DLLA_StringDyn _ -> mempty
   where
     moreas = mconcatMap onea

--- a/hs/src/Reach/Verify/Knowledge.hs
+++ b/hs/src/Reach/Verify/Knowledge.hs
@@ -213,6 +213,7 @@ kgq_e ctxt mv = \case
   DLE_ArraySet _ a e n -> kgq_la ctxt mv (DLLA_Tuple [a, e, n])
   DLE_ArrayConcat _ x_da y_da ->
     kgq_a_onlym ctxt mv x_da >> kgq_a_onlym ctxt mv y_da
+  DLE_BytesDynCast _ a -> kgq_a_onlym ctxt mv a
   DLE_TupleRef _ a _ -> kgq_a_onlym ctxt mv a
   DLE_ObjectRef _ a _ -> kgq_a_onlym ctxt mv a
   DLE_Interact _ _ who what t as ->

--- a/hs/src/Reach/Verify/SMT.hs
+++ b/hs/src/Reach/Verify/SMT.hs
@@ -1084,6 +1084,8 @@ smt_la at_de dla = do
     DLLA_Struct kvs -> cons $ map snd kvs
     DLLA_Bytes bs -> do
       return $ smtApply "bytes" [Atom (show $ crc32 bs)]
+    DLLA_BytesDyn bs -> do
+      return $ smtApply "bytesDyn" [Atom (show $ crc32 bs)]
     DLLA_StringDyn st -> do
       return $ smtApply "stringDyn" [Atom (show $ crc32 $ bpack $ T.unpack st)]
 

--- a/hs/src/Reach/Verify/SMT.hs
+++ b/hs/src/Reach/Verify/SMT.hs
@@ -1125,6 +1125,9 @@ smt_e at_dv mdv de = do
     DLE_ArrayConcat {} ->
       --- FIXME: This might be possible to do by generating a function
       impossible "array_concat"
+    DLE_BytesDynCast at a -> do
+      a' <- smt_a at a
+      bound at $ smtApply "Bytes_toBytesDyn" [a']
     DLE_TupleRef at arr_da i -> do
       let t = argTypeOf arr_da
       s <- smtTypeSort t


### PR DESCRIPTION
I wanted to push this branch to get some comments.

(1) I think I can't call the casting function `BytesDyn` because in the default environment `BytesDyn` returns a type, not an `SLPrim`.  I could probably call it `BytesDyn.cast()` by adding the the type to `evalAsEnvM`.  I guess that's probably what I'll ultimately do, as there is precident with eg. `Token` type being there, although I decided for now to work on it as `BytesDynCast`.  Do I understand everything correctly here?

(2) I currently have an implementation of interpreting this primitive that I think should make sense, but when I use it on the ERC721 contract (replacing the `EmptyBytesDyn` variable with `BytesDynCast("")`) and compile it I get an error because it generates (in Solidity) two copies of the `ERC721TokenReceiver` interface, one with `bytes memory` and one with `bytes0`.  It seems like something is seeing through the layer where I'm setting the type as `BytesDyn` to see the type `Bytes(0)` instead.  My plan for implementation was to use `ctxt_lift_expr` with `DLE_Arg` to just make a new DLVar that references the old one but has the new type.  But it looks like that's probably not the right approach.  Do you have a recommendation?