### PR TITLE
Add `acc.getDebugLabel`

### DIFF
--- a/docs/src/changelog/index.md
+++ b/docs/src/changelog/index.md
@@ -6,7 +6,8 @@ Versions and changes-within-versions are listed in reverse-chronological order: 
 ## 0.1.12: 2022/09 - present
 
 @{verRC("0.1.12")}
-+ 2022/09/19: Added `{!js} ctc.appOptIn` and `{!js} account.appOptedIn`
++ 2022/10/18: Added `${!js} acc.getDebugLabel`.
++ 2022/10/19: Added `{!js} ctc.appOptIn` and `{!js} account.appOptedIn`
 
 @{rcHead("0.1.12-rc.5")}
 

--- a/docs/src/changelog/index.md
+++ b/docs/src/changelog/index.md
@@ -6,7 +6,7 @@ Versions and changes-within-versions are listed in reverse-chronological order: 
 ## 0.1.12: 2022/09 - present
 
 @{verRC("0.1.12")}
-+ 2022/10/18: Added `${!js} acc.getDebugLabel`.
++ 2022/10/18: Added `{!js} acc.getDebugLabel`.
 + 2022/10/19: Added `{!js} ctc.appOptIn` and `{!js} account.appOptedIn`
 
 @{rcHead("0.1.12-rc.5")}

--- a/docs/src/frontend/index.md
+++ b/docs/src/frontend/index.md
@@ -640,6 +640,14 @@ Next, each address is logged so that participants can see both addresses.
 This can be useful to verify that the address receiving the payment is the correct address.
 
 ---
+@{ref("js", "getDebugLabel")}
+```js
+acc.getDebugLabel() => string
+```
+
+Returns the label used to distinguish an account in debug logs. If no label is provided, then the first four digits of the account address will be used.
+
+---
 @{ref("js", "setDebugLabel")}
 ```js
 acc.setDebugLabel(string) => acc

--- a/docs/src/frontend/index.md
+++ b/docs/src/frontend/index.md
@@ -645,7 +645,8 @@ This can be useful to verify that the address receiving the payment is the corre
 acc.getDebugLabel() => string
 ```
 
-Returns the label used to distinguish an account in debug logs. If no label is provided, then the first four digits of the account address will be used.
+Returns the label used to distinguish an account in debug logs.
+If no label was previously provided with `{!js} acc.setDebugLabel`, then the first four digits of the account address will be used.
 
 ---
 @{ref("js", "setDebugLabel")}

--- a/js/stdlib/ts/ALGO.ts
+++ b/js/stdlib/ts/ALGO.ts
@@ -2243,6 +2243,10 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
     return this;
   }
 
+  function getDebugLabel(): string {
+    return label;
+  }
+
   const me_na = { networkAccount };
   const tokenAccepted = async (token:Token): Promise<boolean> => {
     debug(`tokenAccepted`, token);
@@ -2294,7 +2298,7 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
   const unsupportedAcc = stdAccount_unsupported(connector);
 
   const accObj = { ...unsupportedAcc, networkAccount, getAddress: selfAddress,
-                   stdlib, setDebugLabel, tokenAccepted, tokensAccepted: tokensAccepted_,
+                   stdlib, getDebugLabel, setDebugLabel, tokenAccepted, tokensAccepted: tokensAccepted_,
                    tokenAccept, tokenMetadata, contract };
   const acc = accObj as unknown as Account;
   const balanceOf_ = (token?: Token): Promise<BigNumber> => balanceOf(acc, token);

--- a/js/stdlib/ts/ETH_like.ts
+++ b/js/stdlib/ts/ETH_like.ts
@@ -859,6 +859,10 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
     return this;
   };
 
+  function getDebugLabel(): string {
+    return label;
+  }
+
   const tokenAccepted = async (token:Token): Promise<boolean> => {
     debug(`tokenAccepted: Unnecessary on ETHlike`, token);
     return true;
@@ -905,7 +909,7 @@ const connectAccount = async (networkAccount: NetworkAccount): Promise<Account> 
     return true;
   };
 
-  const accObj = { networkAccount, getAddress: selfAddress, stdlib, setDebugLabel,
+  const accObj = { networkAccount, getAddress: selfAddress, stdlib, getDebugLabel, setDebugLabel,
                    tokenAccepted, tokensAccepted: tokensAccepted_, tokenAccept, tokenMetadata,
                    contract, setGasLimit, getGasLimit, setStorageLimit, getStorageLimit,
                    appOptedIn,

--- a/js/stdlib/ts/shared_impl.ts
+++ b/js/stdlib/ts/shared_impl.ts
@@ -551,6 +551,7 @@ export type IAccount<NetworkAccount, Backend, Contract, ContractInfo, Token> = {
   contract: (bin: Backend, ctcInfoP?: Promise<ContractInfo>) => Contract,
   stdlib: Object,
   getAddress: () => string,
+  getDebugLabel: () => string,
   setDebugLabel: (lab: string) => IAccount<NetworkAccount, Backend, Contract, ContractInfo, Token>,
   appOptedIn: (ctc: ContractInfo) => Promise<boolean>,
   tokenAccept: (token: Token) => Promise<void>,


### PR DESCRIPTION
Makes it easier for frontends to do custom logging when given just an `Account` value