### PR TITLE
Type mismatch location

### DIFF
--- a/docs/src/rsh/errors/index.md
+++ b/docs/src/rsh/errors/index.md
@@ -19,7 +19,7 @@ When you try to compile this program, you will get the following error:
 
 ```
 load: /hs/t/n/stack-example.txt
-md5: 46a1e92dc90971527a1fa8e813c9a5ad
+md5: 5d56c6a6b2a609bd949a3062eb9c2dd1
 ```
 
 The first block (lines 1-4) provides the category (`error` in this case, but could be `warning`), a code (`RE0088`), and an explanation (`These types are mismatched`).

--- a/docs/src/rsh/errors/index.md
+++ b/docs/src/rsh/errors/index.md
@@ -19,7 +19,7 @@ When you try to compile this program, you will get the following error:
 
 ```
 load: /hs/t/n/stack-example.txt
-md5: d41c28b3a520ffb3b3759055729c8583
+md5: 46a1e92dc90971527a1fa8e813c9a5ad
 ```
 
 The first block (lines 1-4) provides the category (`error` in this case, but could be `warning`), a code (`RE0088`), and an explanation (`These types are mismatched`).

--- a/hs/src/Reach/AST/Base.hs
+++ b/hs/src/Reach/AST/Base.hs
@@ -37,6 +37,8 @@ instance Show ReachSource where
 data SrcLoc = SrcLoc (Maybe String) (Maybe TokenPosn) (Maybe ReachSource)
   deriving (Eq, Generic, Ord)
 
+type MSrcLoc = Maybe SrcLoc
+
 instance FromJSON TokenPosn
 
 instance ToJSON TokenPosn

--- a/hs/src/Reach/EditorInfo.hs
+++ b/hs/src/Reach/EditorInfo.hs
@@ -99,7 +99,7 @@ completionKind v =
         SLPrim_Refine -> Just CK_TypeParameter
         SLPrim_Bytes -> Just CK_TypeParameter
         SLPrim_Data -> Just CK_TypeParameter
-        SLPrim_Data_variant _ _ _ -> Nothing
+        SLPrim_Data_variant _ _ _ _ -> Just CK_Function
         SLPrim_data_match -> Just CK_Method
         SLPrim_Array -> Just CK_TypeParameter
         SLPrim_Array_iota -> Just CK_Method

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -2227,7 +2227,8 @@ evalPrimOp sp sargs = do
           useStrict >>= \case
             True ->
               (,) <$> typeOfM x <*> typeOfM y >>= \case
-                (Just (x_ty, _), Just (y_ty, _)) -> typeEq x_ty y_ty Nothing Nothing >> chkEq
+                (Just (x_ty, _), Just (y_ty, _)) ->
+                  typeEq x_ty y_ty (Just $ srclocOf x) (Just $ srclocOf y) >> chkEq
                 _ -> return (lvl, SLV_Bool at $ x == y)
             False -> chkEq
           where
@@ -2983,15 +2984,15 @@ evalPrim p sargs =
     SLPrim_array_concat -> do
       at <- withAt id
       case map snd sargs of
-        [SLV_Array _ x_ty x_vs, SLV_Array _ y_ty y_vs] -> do
-          typeEq x_ty y_ty Nothing Nothing
+        [SLV_Array x_at x_ty x_vs, SLV_Array y_at y_ty y_vs] -> do
+          typeEq x_ty y_ty (Just x_at) (Just y_at)
           retV $ (lvl, SLV_Array at x_ty $ x_vs ++ y_vs)
         [x, y] -> do
           (xt, xa) <- compileTypeOf x
           (yt, ya) <- compileTypeOf y
           case (xt, yt) of
             (T_Array x_ty x_sz, T_Array y_ty y_sz) -> do
-              typeEq x_ty y_ty Nothing Nothing
+              typeEq x_ty y_ty (Just $ srclocOf x) (Just $ srclocOf y)
               let t = T_Array x_ty (x_sz + y_sz)
               let mkdv = DLVar at Nothing t
               dv <- ctxt_lift_expr mkdv $ DLE_ArrayConcat at xa ya
@@ -3070,7 +3071,7 @@ evalPrim p sargs =
               (f_lvl, f_v) <- f' b_dsv a_dsv i_dsv
               ensure_level lvl f_lvl
               (f_ty, f_da) <- compileTypeOf f_v
-              typeEq z_ty f_ty Nothing Nothing
+              typeEq z_ty f_ty (Just $ srclocOf z) (Just $ srclocOf f_v)
               return $ f_da
           let shouldUnroll = not (isLocal f_lifts) || all isSmallLiteralArray xs
           case shouldUnroll of
@@ -3346,7 +3347,8 @@ evalPrim p sargs =
       part <- one_arg
       who_a <-
         typeOfM part >>= \case
-          Just (ty, res) -> typeEq T_Address ty Nothing Nothing >> compileArgExpr_ res
+          Just (ty, res) -> typeEq T_Address ty (Just at) (Just $ srclocOf part)
+            >> compileArgExpr_ res
           Nothing ->
             case part of
               SLV_Participant _ who _ _ ->
@@ -3586,7 +3588,7 @@ evalPrim p sargs =
           (f_lvl, f_v) <- evalApplyVals' f [(lvl, b_dsv), (lvl, ma_dsv)]
           ensure_level lvl f_lvl
           (f_ty, f_da) <- compileTypeOf f_v
-          typeEq z_ty f_ty Nothing Nothing
+          typeEq z_ty f_ty (Just $ srclocOf z) (Just $ srclocOf f_v)
           return $ f_da
       (ans_dv, ans_dsv) <- make_dlvar at z_ty
       let f_bl = DLSBlock at [] f_lifts f_da
@@ -4756,7 +4758,7 @@ doTernary ce a te fa fe = locAtf (srcloc_jsa "?:" a) $ do
                 return $ (elifts', e_ty)
           (tlifts', t_ty) <- add_ret t_at' tlifts tv
           (flifts', f_ty) <- add_ret f_at' flifts fv
-          typeEq t_ty f_ty Nothing Nothing
+          typeEq t_ty f_ty (Just $ srclocOf tv) (Just $ srclocOf fv)
           at' <- withAt id
           let ans_dv = DLVar at' Nothing t_ty ret
           theIf <- checkCond om $ DLS_If at' (Just ans_dv) (DLA_Var cond_dv) sa tlifts' flifts'

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -5199,7 +5199,6 @@ doToConsensus ks (ToConsensusRec {..}) = locAt slptc_at $ do
                 evalChecks
                 let repeat_dv = M.lookup who pdvs
                 ds_isClass <- is_class who
-                --ds_msg <- mapM (\v -> snd <$> (compileTypeOf =<< ensure_public =<< evalId "publish msg" v)) msg
                 (ds_msg_at, ds_msg) <- unzip <$> mapM (\v -> do
                   sv <- evalId "publish msg" v
                   va <- snd <$> (compileTypeOf =<< ensure_public sv)

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -4295,7 +4295,7 @@ assertRefinedArgs :: ClaimType -> [SLSVal] -> SrcLoc -> SLTypeFun -> App (SLVal,
 assertRefinedArgs ct sargs iat (SLTypeFun {..}) = do
   let argvs = map snd sargs
   arges <-
-    mapM (uncurry $ typeCheck_s ct Nothing)
+    mapM (uncurry $ typeCheck_s ct (Just iat))
       =<< zipEq (Err_Apply_ArgCount iat) stf_dom argvs
   at <- withAt id
   let dom_tupv = SLV_Tuple at argvs

--- a/hs/src/Reach/Eval/Error.hs
+++ b/hs/src/Reach/Eval/Error.hs
@@ -117,7 +117,7 @@ data EvalError
   | Err_Type_None SLVal
   | Err_Type_NotDT SLType
   | Err_Type_NotApplicable SLType
-  | Err_Type_Mismatch DLType DLType
+  | Err_Type_Mismatch DLType DLType (Maybe SrcLoc) (Maybe SrcLoc)
   | Err_Eval_MustBeInWhileInvariant String
   | Err_Expected_Map SLValTy
   | Err_Prim_Foldable
@@ -683,8 +683,12 @@ instance Show EvalError where
       "Value of this type cannot exist at runtime: " <> show (pretty t)
     Err_Type_NotApplicable ty ->
       "Cannot apply this like a function: " <> show ty
-    Err_Type_Mismatch t1 t2 ->
-      "These types are mismatched:\n  expected: " <> show t1 <> "\n       got: " <> show t2
+    Err_Type_Mismatch t1 t2 ml1 ml2 ->
+      "These types are mismatched:\n  expected: " <> show t1 <> loc ml1 <> "\n       got: " <> show t2 <> loc ml2
+      where
+        loc ml = case ml of
+          Just at -> " from " <> show at
+          _ -> ""
     Err_Expected_Map v ->
       "Expected map, got: " <> show_sv v
     Err_Prim_Foldable ->

--- a/hs/t/n/Err_InspectAbstractToken.txt
+++ b/hs/t/n/Err_InspectAbstractToken.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt
-       got: Tuple(UInt, Token)
+  expected: UInt from reach standard library:35:14:return
+       got: Tuple(UInt, Token) from reach standard library:36:14:return
 
   reach standard library:33:49:block app
 

--- a/hs/t/n/asolpshinning-red.txt
+++ b/hs/t/n/asolpshinning-red.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: Tuple(UInt, Tuple(UInt, Token))
-       got: Tuple(UInt)
+  expected: Tuple(UInt, Tuple(UInt, Token)) from ./asolpshinning-red.rsh:11:27:return
+       got: Tuple(UInt) from ./asolpshinning-red.rsh:11:27:return
 
   ./asolpshinning-red.rsh:11:27:block app
 

--- a/hs/t/n/asolpshinning-redf.txt
+++ b/hs/t/n/asolpshinning-redf.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: Tuple(UInt, Tuple(UInt, Token))
-       got: Tuple(UInt)
+  expected: Tuple(UInt, Tuple(UInt, Token)) from ./asolpshinning-redf.rsh:12:7:return
+       got: Tuple(UInt) from ./asolpshinning-redf.rsh:12:7:return
 
   ./asolpshinning-redf.rsh:12:7:block app
 

--- a/hs/t/n/asolpshinning-redpb.txt
+++ b/hs/t/n/asolpshinning-redpb.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: Tuple(UInt, Tuple(UInt, Token))
-       got: Tuple(UInt)
+  expected: Tuple(UInt, Tuple(UInt, Token)) from ./asolpshinning-redpb.rsh:14:7:return
+       got: Tuple(UInt) from ./asolpshinning-redpb.rsh:16:7:return
 
   ./asolpshinning-redpb.rsh:12:32:block app
 

--- a/hs/t/n/asolpshinning-redpm.txt
+++ b/hs/t/n/asolpshinning-redpm.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: Tuple(UInt)
-       got: Tuple(UInt, Tuple(UInt, Token))
+  expected: Tuple(UInt) from ./asolpshinning-redpm.rsh:13:13:return
+       got: Tuple(UInt, Tuple(UInt, Token)) from ./asolpshinning-redpm.rsh:13:13:return
 
   ./asolpshinning-redpm.rsh:13:13:block app
 

--- a/hs/t/n/asolpshinning-redpm2.txt
+++ b/hs/t/n/asolpshinning-redpm2.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: Tuple(UInt)
-       got: Tuple(UInt, Tuple(UInt, UInt))
+  expected: Tuple(UInt) from ./asolpshinning-redpm2.rsh:6:18:return
+       got: Tuple(UInt, Tuple(UInt, UInt)) from ./asolpshinning-redpm2.rsh:5:18:return
 
   ./asolpshinning-redpm2.rsh:3:18:block app
 

--- a/hs/t/n/bool_add.txt
+++ b/hs/t/n/bool_add.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt
-       got: Bool
+  expected: UInt from definition
+       got: Bool from ./bool_add.rsh:3:7:literal
 
   ./bool_add.rsh:3:12:application
 

--- a/hs/t/n/default.txt
+++ b/hs/t/n/default.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt
-       got: Data({"None": Null, "Some": UInt})
+  expected: UInt from definition
+       got: Data({"None": Null, "Some": UInt}) from ./default.rsh:11:42:application
 
   ./default.rsh:15:27:application
 

--- a/hs/t/n/dynamicPaySpec.txt
+++ b/hs/t/n/dynamicPaySpec.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: Tuple(UInt, Tuple(UInt, Token), Tuple(UInt, Token))
-       got: Tuple(UInt, Tuple(UInt, Token))
+  expected: Tuple(UInt, Tuple(UInt, Token), Tuple(UInt, Token)) from ./dynamicPaySpec.rsh:28:19:return
+       got: Tuple(UInt, Tuple(UInt, Token)) from ./dynamicPaySpec.rsh:28:19:return
 
   ./dynamicPaySpec.rsh:28:19:block app
 

--- a/hs/t/n/export_ret_ty.txt
+++ b/hs/t/n/export_ret_ty.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt
-       got: Bool
+       got: Bool from 5:14:literal
 
   <top level>
 

--- a/hs/t/n/gh_1328.txt
+++ b/hs/t/n/gh_1328.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt
-       got: Object({"i": Object({"i": UInt, "scale": UInt}), "sign": Bool})
+  expected: UInt from definition
+       got: Object({"i": Object({"i": UInt, "scale": UInt}), "sign": Bool}) from reach standard library:270:4:obj
 
   ./gh_1328.rsh:6:13:application
 

--- a/hs/t/n/mismatch_return_type.txt
+++ b/hs/t/n/mismatch_return_type.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: Bool
-       got: UInt
+  expected: Bool from ./mismatch_return_type.rsh:14:11:id
+       got: UInt from ./mismatch_return_type.rsh:28:18:decimal
 
   ./mismatch_return_type.rsh:28:9:continue
 

--- a/hs/t/n/not_applicable_inside_only.txt
+++ b/hs/t/n/not_applicable_inside_only.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt256
+  expected: UInt256 from definition
        got: Bool from ./not_applicable_inside_only.rsh:4:24:application
 
   ./not_applicable_inside_only.rsh:8:19:application

--- a/hs/t/n/not_applicable_inside_only.txt
+++ b/hs/t/n/not_applicable_inside_only.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt256
-       got: Bool
+       got: Bool from ./not_applicable_inside_only.rsh:4:24:application
 
   ./not_applicable_inside_only.rsh:8:19:application
 

--- a/hs/t/n/pr325.txt
+++ b/hs/t/n/pr325.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: Data({"None": Null, "Some": Address})
-       got: Address
+  expected: Data({"None": Null, "Some": Address}) from reach standard library:106:32:application
+       got: Address from ./pr325.rsh:5:27:application
 
   ./pr325.rsh:13:23:application
 

--- a/hs/t/n/remote-ALGO-simStandins-1.txt
+++ b/hs/t/n/remote-ALGO-simStandins-1.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: Bool
-       got: Null
+  expected: Bool from ./remote-ALGO-simStandins-1.rsh:21:58:application
+       got: Null from ./remote-ALGO-simStandins-1.rsh:24:19:literal
 
   ./remote-ALGO-simStandins-1.rsh:24:19:literal
 

--- a/hs/t/n/remote-ALGO-simStandins-1.txt
+++ b/hs/t/n/remote-ALGO-simStandins-1.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: Bool from ./remote-ALGO-simStandins-1.rsh:21:58:application
+  expected: Bool from definition
        got: Null from ./remote-ALGO-simStandins-1.rsh:24:19:literal
 
   ./remote-ALGO-simStandins-1.rsh:24:19:literal

--- a/hs/t/n/remote-ALGO-simStandins-3.txt
+++ b/hs/t/n/remote-ALGO-simStandins-3.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt
-       got: Bool
+  expected: UInt from ./remote-ALGO-simStandins-3.rsh:21:58:application
+       got: Bool from ./remote-ALGO-simStandins-3.rsh:23:24:literal
 
   ./remote-ALGO-simStandins-3.rsh:23:20:tuple
 

--- a/hs/t/n/remote-ALGO-simStandins-3.txt
+++ b/hs/t/n/remote-ALGO-simStandins-3.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt from ./remote-ALGO-simStandins-3.rsh:21:58:application
+  expected: UInt from definition
        got: Bool from ./remote-ALGO-simStandins-3.rsh:23:24:literal
 
   ./remote-ALGO-simStandins-3.rsh:23:20:tuple

--- a/hs/t/n/stack-example.txt
+++ b/hs/t/n/stack-example.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt
+  expected: UInt from definition
        got: Bytes(4) from ./stack-example.rsh:8:25:string
 
   ./stack-example.rsh:7:25:application

--- a/hs/t/n/stack-example.txt
+++ b/hs/t/n/stack-example.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt
-       got: Bytes(4)
+       got: Bytes(4) from ./stack-example.rsh:8:25:string
 
   ./stack-example.rsh:7:25:application
 

--- a/hs/t/n/ui256_add_l.txt
+++ b/hs/t/n/ui256_add_l.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt256
+  expected: UInt256 from definition
        got: UInt from ./ui256_add_l.rsh:12:17:decimal
 
   ./ui256_add_l.rsh:12:15:application

--- a/hs/t/n/ui256_add_l.txt
+++ b/hs/t/n/ui256_add_l.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt256
-       got: UInt
+       got: UInt from ./ui256_add_l.rsh:12:17:decimal
 
   ./ui256_add_l.rsh:12:15:application
 

--- a/hs/t/n/ui256_add_r.txt
+++ b/hs/t/n/ui256_add_r.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt
-       got: UInt256
+       got: UInt256 from ./ui256_add_r.rsh:11:5:dot
 
   ./ui256_add_r.rsh:12:15:application
 

--- a/hs/t/n/ui256_add_r.txt
+++ b/hs/t/n/ui256_add_r.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt
+  expected: UInt from definition
        got: UInt256 from ./ui256_add_r.rsh:11:5:dot
 
   ./ui256_add_r.rsh:12:15:application

--- a/hs/t/n/ui256_cast_l.txt
+++ b/hs/t/n/ui256_cast_l.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt
-       got: UInt256
+       got: UInt256 from ./ui256_cast_l.rsh:11:5:dot
 
   ./ui256_cast_l.rsh:12:20:application
 

--- a/hs/t/n/ui256_cast_l.txt
+++ b/hs/t/n/ui256_cast_l.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt
+  expected: UInt from definition
        got: UInt256 from ./ui256_cast_l.rsh:11:5:dot
 
   ./ui256_cast_l.rsh:12:20:application

--- a/hs/t/n/ui256_cast_r.txt
+++ b/hs/t/n/ui256_cast_r.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt256
+  expected: UInt256 from definition
        got: UInt from ./ui256_cast_r.rsh:13:5:dot
 
   ./ui256_cast_r.rsh:14:17:application

--- a/hs/t/n/ui256_cast_r.txt
+++ b/hs/t/n/ui256_cast_r.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt256
-       got: UInt
+       got: UInt from ./ui256_cast_r.rsh:13:5:dot
 
   ./ui256_cast_r.rsh:14:17:application
 

--- a/hs/t/n/ui256_div_l.txt
+++ b/hs/t/n/ui256_div_l.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt256
+  expected: UInt256 from definition
        got: UInt from ./ui256_div_l.rsh:12:17:decimal
 
   ./ui256_div_l.rsh:12:15:application

--- a/hs/t/n/ui256_div_l.txt
+++ b/hs/t/n/ui256_div_l.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt256
-       got: UInt
+       got: UInt from ./ui256_div_l.rsh:12:17:decimal
 
   ./ui256_div_l.rsh:12:15:application
 

--- a/hs/t/n/ui256_div_r.txt
+++ b/hs/t/n/ui256_div_r.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt
-       got: UInt256
+       got: UInt256 from ./ui256_div_r.rsh:11:5:dot
 
   ./ui256_div_r.rsh:12:15:application
 

--- a/hs/t/n/ui256_div_r.txt
+++ b/hs/t/n/ui256_div_r.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt
+  expected: UInt from definition
        got: UInt256 from ./ui256_div_r.rsh:11:5:dot
 
   ./ui256_div_r.rsh:12:15:application

--- a/hs/t/n/ui256_mul_l.txt
+++ b/hs/t/n/ui256_mul_l.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt256
-       got: UInt
+       got: UInt from ./ui256_mul_l.rsh:12:17:decimal
 
   ./ui256_mul_l.rsh:12:15:application
 

--- a/hs/t/n/ui256_mul_l.txt
+++ b/hs/t/n/ui256_mul_l.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt256
+  expected: UInt256 from definition
        got: UInt from ./ui256_mul_l.rsh:12:17:decimal
 
   ./ui256_mul_l.rsh:12:15:application

--- a/hs/t/n/ui256_mul_r.txt
+++ b/hs/t/n/ui256_mul_r.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt
-       got: UInt256
+       got: UInt256 from ./ui256_mul_r.rsh:11:5:dot
 
   ./ui256_mul_r.rsh:12:15:application
 

--- a/hs/t/n/ui256_mul_r.txt
+++ b/hs/t/n/ui256_mul_r.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt
+  expected: UInt from definition
        got: UInt256 from ./ui256_mul_r.rsh:11:5:dot
 
   ./ui256_mul_r.rsh:12:15:application

--- a/hs/t/n/ui256_peq_l.txt
+++ b/hs/t/n/ui256_peq_l.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt256
-       got: UInt
+  expected: UInt256 from ./ui256_peq_l.rsh:11:5:dot
+       got: UInt from ./ui256_peq_l.rsh:12:18:decimal
 
   ./ui256_peq_l.rsh:12:15:application
 

--- a/hs/t/n/ui256_peq_r.txt
+++ b/hs/t/n/ui256_peq_r.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt
-       got: UInt256
+  expected: UInt from ./ui256_peq_r.rsh:12:13:decimal
+       got: UInt256 from ./ui256_peq_r.rsh:11:5:dot
 
   ./ui256_peq_r.rsh:12:15:application
 

--- a/hs/t/n/ui256_pge_l.txt
+++ b/hs/t/n/ui256_pge_l.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt256
-       got: UInt
+       got: UInt from ./ui256_pge_l.rsh:12:18:decimal
 
   ./ui256_pge_l.rsh:12:15:application
 

--- a/hs/t/n/ui256_pge_l.txt
+++ b/hs/t/n/ui256_pge_l.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt256
+  expected: UInt256 from definition
        got: UInt from ./ui256_pge_l.rsh:12:18:decimal
 
   ./ui256_pge_l.rsh:12:15:application

--- a/hs/t/n/ui256_pge_r.txt
+++ b/hs/t/n/ui256_pge_r.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt
-       got: UInt256
+       got: UInt256 from ./ui256_pge_r.rsh:11:5:dot
 
   ./ui256_pge_r.rsh:12:15:application
 

--- a/hs/t/n/ui256_pge_r.txt
+++ b/hs/t/n/ui256_pge_r.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt
+  expected: UInt from definition
        got: UInt256 from ./ui256_pge_r.rsh:11:5:dot
 
   ./ui256_pge_r.rsh:12:15:application

--- a/hs/t/n/ui256_pgt_l.txt
+++ b/hs/t/n/ui256_pgt_l.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt256
-       got: UInt
+       got: UInt from ./ui256_pgt_l.rsh:12:17:decimal
 
   ./ui256_pgt_l.rsh:12:15:application
 

--- a/hs/t/n/ui256_pgt_l.txt
+++ b/hs/t/n/ui256_pgt_l.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt256
+  expected: UInt256 from definition
        got: UInt from ./ui256_pgt_l.rsh:12:17:decimal
 
   ./ui256_pgt_l.rsh:12:15:application

--- a/hs/t/n/ui256_pgt_r.txt
+++ b/hs/t/n/ui256_pgt_r.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt
-       got: UInt256
+       got: UInt256 from ./ui256_pgt_r.rsh:11:5:dot
 
   ./ui256_pgt_r.rsh:12:15:application
 

--- a/hs/t/n/ui256_pgt_r.txt
+++ b/hs/t/n/ui256_pgt_r.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt
+  expected: UInt from definition
        got: UInt256 from ./ui256_pgt_r.rsh:11:5:dot
 
   ./ui256_pgt_r.rsh:12:15:application

--- a/hs/t/n/ui256_ple_l.txt
+++ b/hs/t/n/ui256_ple_l.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt256
+  expected: UInt256 from definition
        got: UInt from ./ui256_ple_l.rsh:12:18:decimal
 
   ./ui256_ple_l.rsh:12:15:application

--- a/hs/t/n/ui256_ple_l.txt
+++ b/hs/t/n/ui256_ple_l.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt256
-       got: UInt
+       got: UInt from ./ui256_ple_l.rsh:12:18:decimal
 
   ./ui256_ple_l.rsh:12:15:application
 

--- a/hs/t/n/ui256_ple_r.txt
+++ b/hs/t/n/ui256_ple_r.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt
+  expected: UInt from definition
        got: UInt256 from ./ui256_ple_r.rsh:11:5:dot
 
   ./ui256_ple_r.rsh:12:15:application

--- a/hs/t/n/ui256_ple_r.txt
+++ b/hs/t/n/ui256_ple_r.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt
-       got: UInt256
+       got: UInt256 from ./ui256_ple_r.rsh:11:5:dot
 
   ./ui256_ple_r.rsh:12:15:application
 

--- a/hs/t/n/ui256_plt_l.txt
+++ b/hs/t/n/ui256_plt_l.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt256
-       got: UInt
+       got: UInt from ./ui256_plt_l.rsh:12:17:decimal
 
   ./ui256_plt_l.rsh:12:15:application
 

--- a/hs/t/n/ui256_plt_l.txt
+++ b/hs/t/n/ui256_plt_l.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt256
+  expected: UInt256 from definition
        got: UInt from ./ui256_plt_l.rsh:12:17:decimal
 
   ./ui256_plt_l.rsh:12:15:application

--- a/hs/t/n/ui256_plt_r.txt
+++ b/hs/t/n/ui256_plt_r.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt
-       got: UInt256
+       got: UInt256 from ./ui256_plt_r.rsh:11:5:dot
 
   ./ui256_plt_r.rsh:12:15:application
 

--- a/hs/t/n/ui256_plt_r.txt
+++ b/hs/t/n/ui256_plt_r.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt
+  expected: UInt from definition
        got: UInt256 from ./ui256_plt_r.rsh:11:5:dot
 
   ./ui256_plt_r.rsh:12:15:application

--- a/hs/t/n/ui256_sub_l.txt
+++ b/hs/t/n/ui256_sub_l.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt256
-       got: UInt
+       got: UInt from ./ui256_sub_l.rsh:12:17:decimal
 
   ./ui256_sub_l.rsh:12:15:application
 

--- a/hs/t/n/ui256_sub_l.txt
+++ b/hs/t/n/ui256_sub_l.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt256
+  expected: UInt256 from definition
        got: UInt from ./ui256_sub_l.rsh:12:17:decimal
 
   ./ui256_sub_l.rsh:12:15:application

--- a/hs/t/n/ui256_sub_r.txt
+++ b/hs/t/n/ui256_sub_r.txt
@@ -1,5 +1,5 @@
 reachc: error[RE0088]: These types are mismatched:
-  expected: UInt
+  expected: UInt from definition
        got: UInt256 from ./ui256_sub_r.rsh:11:5:dot
 
   ./ui256_sub_r.rsh:12:15:application

--- a/hs/t/n/ui256_sub_r.txt
+++ b/hs/t/n/ui256_sub_r.txt
@@ -1,6 +1,6 @@
 reachc: error[RE0088]: These types are mismatched:
   expected: UInt
-       got: UInt256
+       got: UInt256 from ./ui256_sub_r.rsh:11:5:dot
 
   ./ui256_sub_r.rsh:12:15:application
 


### PR DESCRIPTION
For CORE-2482.  When there is a type mismatch error, this patch makes it display location information for the source of the expected and actual types, at least for some instances of type mismatches.