### PR TITLE
js: bytes(n) cbr based on n bytes

### DIFF
--- a/examples/unicode-bytelen/index.mjs
+++ b/examples/unicode-bytelen/index.mjs
@@ -1,0 +1,16 @@
+import {Reach} from '@reach-sh/stdlib';
+import * as backend from './build/index.main.mjs';
+const reach = new Reach();
+const accD = await reach.newTestAccount(reach.parseCurrency(100));
+const ctcD = await accD.contract(backend);
+const ctcO = await reach.contract(backend, ctcD.getInfo());
+const s = ['💩ABCD', '💩EFGH'];
+await reach.withDisconnect(() => backend.D(ctcD, {
+  s, ready: reach.disconnect
+}));
+const vs = await ctcO.v.s();
+await ctcD.a.halt();
+console.log({s, vs});
+reach.assert(vs[0] === 'Some')
+reach.assert(vs[1][0] === s[0]);
+reach.assert(vs[1][1] === s[1]);

--- a/examples/unicode-bytelen/index.rsh
+++ b/examples/unicode-bytelen/index.rsh
@@ -1,0 +1,20 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const I = { s: Tuple(Bytes(8), Bytes(8)) };
+  const D = Participant('D', { ...I, ready: Fun([], Null) });
+  const V = View({ ...I });
+  const A = API({halt: Fun([], Null)});
+  init();
+  D.only(() => {
+    const s = declassify(interact.s);
+  });
+  D.publish(s);
+  V.s.set(s);
+  commit();
+  D.interact.ready();
+  const [[], k] = call(A.halt)
+    .check(() => { check(this == D); });
+  k(null);
+  commit();
+});

--- a/examples/unicode-bytelen/index.txt
+++ b/examples/unicode-bytelen/index.txt
@@ -1,0 +1,5 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 6 theorems; No failures!

--- a/js/stdlib/ts/CBR.ts
+++ b/js/stdlib/ts/CBR.ts
@@ -1,6 +1,8 @@
 import { ethers } from 'ethers';
 import { checkedBigNumberify } from './shared_backend';
 import { j2s, labelMaps, hasProp, isUint8Array } from './shared_impl';
+import buffer from 'buffer';
+const Buffer = buffer.Buffer;
 // "CBR", canonical backend representation
 
 type BigNumber = ethers.BigNumber;
@@ -101,28 +103,45 @@ export const BV_UInt = (val: BigNumber, max: BigNumber): CBR_UInt => {
   return BT_UInt(max).canonicalize(val);
 };
 
-export const BT_Bytes = (len: number): BackendTy<CBR_Bytes> => ({
+const zpad = (len: number, b: Buffer): Buffer => {
+  const res = Buffer.alloc(len, 0);
+  b.copy(res);
+  return res;
+};
+type BLabel = 'string' | 'hex string' | 'Uint8Array' | 'unknown';
+const arr_to_buf = (s: Uint8Array): Buffer => Buffer.from(s);
+const str_to_buf = (s: string): Buffer => Buffer.from(s);
+const hex_to_buf = (s: string): Buffer => Buffer.from(s.slice(2), 'hex');
+const buf_to_arr = (b: Buffer): Uint8Array => new Uint8Array(b);
+const buf_to_str = (b: Buffer): string => b.toString();
+const buf_to_hex = (b: Buffer): string => '0x' + b.toString('hex');
+const to_buf = (val: unknown): [BLabel, Buffer] => {
+  if (typeof val === 'string') {
+    return val.slice(0, 2) === '0x'
+      ? ['hex string', hex_to_buf(val)]
+      : ['string', str_to_buf(val)];
+  } else if (isUint8Array(val)) {
+    return ['Uint8Array', arr_to_buf(val as Uint8Array)];
+  } else {
+    return ['unknown', str_to_buf('')];
+  }
+};
+export const BT_Bytes = (len: number|BigNumber): BackendTy<CBR_Bytes> => ({
   name: `Bytes(${len})`,
-  defaultValue: ''.padEnd(len, '\0'),
+  defaultValue: buf_to_str(zpad(bigNumberToNumber(len), str_to_buf(''))),
   canonicalize: (val: unknown): CBR_Bytes => {
-    if (typeof(val) == 'string') {
-      const lenn = bigNumberToNumber(len);
-      const checkLen = (label:string, alen:number, fill:string): string => {
-        const v = val as string;
-        if ( v.length > alen ) {
-          throw Error(`Bytes(${len}) must be a ${label}string less than or equal to ${alen}, but given ${label}string of length ${v.length}`);
-        }
-        return v.padEnd(alen, fill);
-      };
-      if ( val.slice(0,2) === '0x' ) {
-        return checkLen('hex ', lenn*2+2, '0');
-      } else {
-        return checkLen('', lenn, '\0');
-      }
-    } else if (isUint8Array(val)) {
-      return val as Uint8Array;
-    } else {
-      throw Error(`Bytes expected string or Uint8Array, but got ${j2s(val)}`);
+    const [label, b] = to_buf(val);
+    const alen = b.length;
+    const lenn = bigNumberToNumber(len);
+    if (alen > lenn) {
+      throw Error(`Bytes(${lenn}) must be less than or equal to ${lenn} bytes, but given ${label} of ${alen} bytes`);
+    }
+    const zb = zpad(lenn, b);
+    if      (label === 'hex string') { return buf_to_hex(zb); }
+    else if (label === 'string')      { return buf_to_str(zb); }
+    else if (label === 'Uint8Array') { return buf_to_arr(zb); }
+    else {
+      throw Error(`Bytes expected string or Uint8Array, but got ${j2s(val)}: ${typeof val}`);
     }
   },
 });


### PR DESCRIPTION
before:

```
$ REACH_CONNECTOR_MODE=ALGO reach run
...
{
  s: [ '💩ABCD', '💩EFGH' ],
  vs: [ 'Some', [ '💩ABCD', '\x00\x00💩EF' ] ]
}
/stdlib/dist/cjs/shared_backend.js:161
        throw Error("Assertion failed".concat((0, exports.formatAssertInfo)(ai)));
              ^

Error: Assertion failed
    at Reach.assert (/stdlib/dist/cjs/shared_backend.js:161:15)
    at file:///app/index.mjs:16:7
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
ERROR: 1
```

```
$ REACH_CONNECTOR_MODE=ETH reach run

/stdlib/node_modules/@ethersproject/logger/lib/index.js:238
        var error = new Error(message);
                    ^

Error: incorrect data length (argument="elem0", value=[240,159,146,169,65,66,67,68,0,0], code=INVALID_ARGUMENT, version=abi/5.7.0)
    at Logger.makeError (/stdlib/node_modules/@ethersproject/logger/lib/index.js:238:21)
    at Logger.throwError (/stdlib/node_modules/@ethersproject/logger/lib/index.js:247:20)
    at Logger.throwArgumentError (/stdlib/node_modules/@ethersproject/logger/lib/index.js:250:21)
    at FixedBytesCoder.Coder._throwError (/stdlib/node_modules/@ethersproject/abi/lib/coders/abstract-coder.js:41:16)
    at FixedBytesCoder.encode (/stdlib/node_modules/@ethersproject/abi/lib/coders/fixed-bytes.js:37:18)
    at /stdlib/node_modules/@ethersproject/abi/lib/coders/array.js:74:19
    at Array.forEach (<anonymous>)
    at pack (/stdlib/node_modules/@ethersproject/abi/lib/coders/array.js:60:12)
    at TupleCoder.encode (/stdlib/node_modules/@ethersproject/abi/lib/coders/tuple.js:71:33)
    at /stdlib/node_modules/@ethersproject/abi/lib/coders/array.js:74:19 {
  reason: 'incorrect data length',
  code: 'INVALID_ARGUMENT',
  argument: 'elem0',
  value: [
    240, 159, 146, 169, 65,
     66,  67,  68,   0,  0
  ]
}
ERROR: 1
```

after: it works as expected.