### PR TITLE
Tuple.includes

### DIFF
--- a/docs/src/changelog/index.md
+++ b/docs/src/changelog/index.md
@@ -6,6 +6,8 @@ Versions and changes-within-versions are listed in reverse-chronological order: 
 ## 0.1.12: 2022/09 - present
 
 @{verRC("0.1.12")}
++ 2022/10/25: Added `{!rsh} Tuple.includes`.
++ 2022/10/25: Added `{!rsh} BytesDyn` casting from fixed-length bytes.
 
 @{rcHead("0.1.12-rc.7")}
 + 2022/10/25: Added `{!js} manager` optional field for `{!js} stdlib.launchToken`

--- a/docs/src/changelog/index.md
+++ b/docs/src/changelog/index.md
@@ -6,10 +6,9 @@ Versions and changes-within-versions are listed in reverse-chronological order: 
 ## 0.1.12: 2022/09 - present
 
 @{verRC("0.1.12")}
-+ 2022/10/25: Added `{!rsh} Tuple.includes`.
-+ 2022/10/25: Added `{!rsh} BytesDyn` casting from fixed-length bytes.
 
 @{rcHead("0.1.12-rc.7")}
++ 2022/10/25: Added `{!rsh} Tuple.includes`.
 + 2022/10/25: Added `{!js} manager` optional field for `{!js} stdlib.launchToken`
 + 2022/10/25: Added `{!rsh} BytesDyn` casting from fixed-length bytes.
 

--- a/docs/src/rsh/compute/index.md
+++ b/docs/src/rsh/compute/index.md
@@ -988,10 +988,11 @@ c.and()
 
 #### `Foldable.includes` && `.includes`
 
-@{ref("rsh", "Foldable.includes")}@{ref("rsh", "Map.includes")}@{ref("rsh", "Array.includes")}@{ref("rsh", "includes")}
+@{ref("rsh", "Foldable.includes")}@{ref("rsh", "Map.includes")}@{ref("rsh", "Array.includes")}@{ref("rsh", "Tuple.includes")}@{ref("rsh", "includes")}
 ```reach
 Foldable.includes(c, x)
 Array.includes(c, x)
+Tuple.includes(c, x)
 Map.includes(c, x)
 c.includes(x)
 ```
@@ -2976,13 +2977,13 @@ The `IDs` component is intended to hold byte strings that represent ERC-165 inte
 For example, we define all of the interfaces that are part of the [ERC-721](https://eips.ethereum.org/EIPS/eip-721) NFT specification using `{!rsh} mixin`:
 ```reach
 load: /examples/ERC721/index.rsh
-md5: fc2bac5972751cb3280a6e974d864096
+md5: 1101ece6c8b14e4fe7c64dbe941dd07d
 range: 8 - 59
 ```
 
 Then, we construct the final mixed contract, and overriding `ERC721EnumerablePartial`'s base with `ERC721Metadata` (because we want _both_ extensions to ERC-721):
 ```reach
 load: /examples/ERC721/index.rsh
-md5: fc2bac5972751cb3280a6e974d864096
+md5: 1101ece6c8b14e4fe7c64dbe941dd07d
 range: 79 - 80
 ```

--- a/examples/ERC721/index.rsh
+++ b/examples/ERC721/index.rsh
@@ -114,8 +114,7 @@ export const main = Reach.App(() => {
   V.name.set(name);
   V.symbol.set(symbol);
   V.totalSupply.set(totalSupply);
-  const IDsArray = array(Bytes(4), IDs);
-  V.supportsInterface.set(IDsArray.includes);
+  V.supportsInterface.set(IDs.includes);
 
   const owners = new Map(UInt, Address);
   const balances = new Map(UInt);

--- a/examples/tupleIncludes/index.mjs
+++ b/examples/tupleIncludes/index.mjs
@@ -1,0 +1,32 @@
+import * as backend from './build/index.main.mjs';
+import { loadStdlib, ask } from "@reach-sh/stdlib";
+const stdlib = loadStdlib(process.env);
+
+const startCtc = async (ctc, deployerName, startupInteractName, iface) => {
+  const flag = "startup success throw flag"
+  const fullIface = {...iface}
+  fullIface[startupInteractName] = (...args) => {throw flag;};
+  try {
+    await ctc.p[deployerName](fullIface);
+  } catch (e) {
+    if ( e !== flag) {throw e;}
+  }
+}
+
+const acc = await stdlib.newTestAccount(stdlib.parseCurrency(100));
+const ctc = acc.contract(backend);
+await startCtc(ctc, "Deployer", "deployed",
+               {getTuple: () => [3, 27, acc.getAddress(), 6]});
+
+stdlib.assert(await ctc.unsafeViews.vs1(27), "vs1-t")
+stdlib.assert(! await ctc.unsafeViews.vs1(97), "vs1-f")
+stdlib.assert(await ctc.unsafeViews.vs2(27), "vs2-t")
+stdlib.assert(! await ctc.unsafeViews.vs2(97), "vs2-f")
+stdlib.assert(await ctc.unsafeViews.vs3(27), "vs3-t")
+stdlib.assert(! await ctc.unsafeViews.vs3(97), "vs3-f")
+stdlib.assert(await ctc.unsafeViews.vd1(27), "vd1-t")
+stdlib.assert(! await ctc.unsafeViews.vd1(97), "vd1-f")
+stdlib.assert(await ctc.unsafeViews.vd2(27), "vd2-t")
+stdlib.assert(! await ctc.unsafeViews.vd2(97), "vd2-f")
+stdlib.assert(await ctc.unsafeViews.vd3(27), "vd3-t")
+stdlib.assert(! await ctc.unsafeViews.vd3(97), "vd3-f")

--- a/examples/tupleIncludes/index.rsh
+++ b/examples/tupleIncludes/index.rsh
@@ -1,0 +1,40 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const D = Participant('Deployer', {
+    getTuple: Fun([], Tuple(UInt, UInt, Address, UInt)),
+    deployed: Fun([Contract], Null),
+  });
+  const V = View({
+    vs1: Fun([UInt], Bool),
+    vs2: Fun([UInt], Bool),
+    vs3: Fun([UInt], Bool),
+    vd1: Fun([UInt], Bool),
+    vd2: Fun([UInt], Bool),
+    vd3: Fun([UInt], Bool),
+  })
+
+  const staticTup = [1, "hi", 27, 14];
+  init();
+
+  D.only(() => {
+    const dynamicTup = declassify(interact.getTuple());
+  })
+  D.publish(dynamicTup);
+
+  D.interact.deployed(getContract());
+
+  V.vs1.set(staticTup.includes);
+  V.vs2.set((x) => staticTup.includes(x))
+  V.vs3.set((x) => Tuple.includes(staticTup, x))
+  // TODO - these dynamic versions are failing with an SMT error.
+  V.vd1.set(dynamicTup.includes);
+  V.vd2.set((x) => dynamicTup.includes(x))
+  V.vd3.set((x) => Tuple.includes(dynamicTup, x))
+
+  commit();
+
+  D.publish();
+  commit();
+  exit();
+});

--- a/examples/tupleIncludes/index.txt
+++ b/examples/tupleIncludes/index.txt
@@ -1,0 +1,6 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 5 theorems; No failures!
+please upgrade and try again.

--- a/examples/tupleIncludes/index.txt
+++ b/examples/tupleIncludes/index.txt
@@ -3,4 +3,3 @@ Verifying for generic connector
   Verifying when ALL participants are honest
   Verifying when NO participants are honest
 Checked 5 theorems; No failures!
-please upgrade and try again.

--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -764,6 +764,7 @@ data SLPrimitive
   | SLPrim_Struct_toObject
   | SLPrim_Struct_fields
   | SLPrim_Tuple
+  | SLPrim_tuple_includes
   | SLPrim_tuple_length
   | SLPrim_tuple_set
   | SLPrim_Object

--- a/hs/src/Reach/EditorInfo.hs
+++ b/hs/src/Reach/EditorInfo.hs
@@ -120,6 +120,7 @@ completionKind v =
         SLPrim_Struct_toObject -> Just CK_Method
         SLPrim_Struct_fields -> Just CK_Method
         SLPrim_Tuple -> Just CK_TypeParameter
+        SLPrim_tuple_includes -> Just CK_Method
         SLPrim_tuple_length -> Just CK_Method
         SLPrim_tuple_set -> Just CK_Method
         SLPrim_Object -> Just CK_TypeParameter

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -2976,7 +2976,7 @@ evalPrim p sargs =
           let indices = map snd $ filter (\(t, _i) -> t == nt) (zip ts [0..])
           let mkdv = DLVar at Nothing nt
           let liftRef i = ctxt_lift_expr mkdv $
-               DLE_ArrayRef at (DLA_Var arrDlv) (DLA_Literal $ DLL_Int at UI_Word i)
+               DLE_TupleRef at (DLA_Var arrDlv) i
           dlvs <- mapM liftRef indices
           evalApplyVals' foldable_includes [(lvl, (SLV_Array at nt (map SLV_DLVar dlvs))), (lvl, needle)]
         _ -> illegal_args

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -1563,12 +1563,11 @@ evalAsEnvM sv@(lvl, obj) = case obj of
              -- if tested by `SLPrim_is` as a function, which means that something
              -- like `mytuple.includes` can't be set as a view function.
              -- Fixing the `SLPrim_is` implementation seems a lot harder than this.
-             foldable_includes <- lookStdlib "Foldable_includes"
              return $ (lvl, jsClo (srclocOf tupSlv) "tuple_includes"
                "(v) => f(tup, v)"
-               (M.fromList [("f", SLV_Prim SLPrim_tuple_includes),
-                            ("tup", tupSlv),
-                            ("Foldable_includes", foldable_includes)])))
+               (M.fromList [ ("f", SLV_Prim SLPrim_tuple_includes)
+                           , ("tup", tupSlv)
+                           ])))
         ]
     arrayValueEnv :: SLObjEnv
     arrayValueEnv =

--- a/hs/src/Reach/Eval/Core.hs
+++ b/hs/src/Reach/Eval/Core.hs
@@ -1559,15 +1559,18 @@ evalAsEnvM sv@(lvl, obj) = case obj of
         , ("length", doCall SLPrim_tuple_length)
         , ("includes",
            do
+             env <- (sco_cenv . e_sco) <$> ask
+             let env' = M.map sss_val env
              -- I would just do `delayCall SLPrim_tuple_includes`, but it fails
              -- if tested by `SLPrim_is` as a function, which means that something
              -- like `mytuple.includes` can't be set as a view function.
              -- Fixing the `SLPrim_is` implementation seems a lot harder than this.
              return $ (lvl, jsClo (srclocOf tupSlv) "tuple_includes"
                "(v) => f(tup, v)"
-               (M.fromList [ ("f", SLV_Prim SLPrim_tuple_includes)
+               (M.union (M.fromList [ ("f", SLV_Prim SLPrim_tuple_includes)
                            , ("tup", tupSlv)
-                           ])))
+                           ])
+                        env')))
         ]
     arrayValueEnv :: SLObjEnv
     arrayValueEnv =

--- a/hs/t/n/Err_Eval_RefNotInt.txt
+++ b/hs/t/n/Err_Eval_RefNotInt.txt
@@ -1,4 +1,4 @@
-reachc: error[RE0025]: hello is not a field of Tuple(UInt, UInt, UInt). Did you mean: ["set","length"]
+reachc: error[RE0025]: hello is not a field of Tuple(UInt, UInt, UInt). Did you mean: ["set","length","includes"]
 
   ./Err_Eval_RefNotInt.rsh:6:15:array ref
 

--- a/hs/t/y/tupleIncludes.rsh
+++ b/hs/t/y/tupleIncludes.rsh
@@ -1,0 +1,10 @@
+'reach 0.1'
+
+const tup = [1, 2, "hi", -3];
+const b1 = tup.includes("hi");
+const b2 = tup.includes(2);
+const b3 = tup.includes(0.1);
+const b4 = Tuple.includes(tup, 3);
+const b5 = Tuple.includes([1,2,3,"owl"], 3);
+const b6 = [1,2,3,"fourteen"].includes(7);
+

--- a/hs/t/y/tupleIncludes.txt
+++ b/hs/t/y/tupleIncludes.txt
@@ -1,0 +1,5 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 0 theorems; No failures!

--- a/vsce/data/print-keyword-info.json
+++ b/vsce/data/print-keyword-info.json
@@ -368,6 +368,9 @@
   "Tuple": {
     "CompletionItemKind": "TypeParameter"
   },
+  "Tuple.includes": {
+    "CompletionItemKind": "Method"
+  },
   "Tuple.length": {
     "CompletionItemKind": "Method"
   },


### PR DESCRIPTION
This almost works, but in the new `tupleIncludes` example, the dynamic case tests fail with an error about the generated SMT code:

```
reachc: The compiler has encountered an internal error:

  Unexpected result from the SMT solver:
  Expected: success
  Result: (error "line 162 column 31: select requires 1 arguments, but was provided with 2 arguments" )
```

Dealing with these SMT errors is difficult, because the reported location doesn't match the generated `index.main.smt` file, and I'm not sure exactly where it comes from.  The text of the error itself ends up in the `index.main.smt` file, and is clearly referencing a different file.  What file is it?  (I assume it's something transient during the compilation process, perhaps.)  I'm confused by this because from what I can tell, `select` DOES take 2 arguments, and we always give it two arguments.  I haven't modified any SMT generation code with this PR.  I don't see any obvious issues, so I thought I'd ask for a tip on where to look next.