### PR TITLE
Metadata hash

### DIFF
--- a/examples/launchToken/index.mjs
+++ b/examples/launchToken/index.mjs
@@ -37,7 +37,8 @@ if (isAlgo) {
   for (const k in accOpts) {
     stdlib.assert(stdlib.addressEq(m[k], accOpts[k]));
   };
-  stdlib.assert(m.metadataHash === metadataHash, "metadataHash match");
+  // In the result the `metadataHash` field is renamed to just `metadata`...
+  stdlib.assert(m.metadata === metadataHash, "metadataHash match");
   stdlib.assert(m.defaultFrozen === true);
   console.log(`All assertions passed. =]`);
 }

--- a/examples/launchToken/index.mjs
+++ b/examples/launchToken/index.mjs
@@ -10,8 +10,9 @@ const accOpts = {
   freeze: accC,
   reserve: accD,
 };
+const metadataHash = "12345678901234567890123456789012";
 const gil = await stdlib.launchToken(accA, 'Gil', 'GIL', {
-  ...(isAlgo ? {...accOpts, defaultFrozen: true} : {}),
+  ...(isAlgo ? {...accOpts, defaultFrozen: true, metadataHash,} : {}),
 });
 
 if (isAlgo) {
@@ -36,6 +37,7 @@ if (isAlgo) {
   for (const k in accOpts) {
     stdlib.assert(stdlib.addressEq(m[k], accOpts[k]));
   };
+  stdlib.assert(m.metadataHash === metadataHash, "metadataHash match");
   stdlib.assert(m.defaultFrozen === true);
   console.log(`All assertions passed. =]`);
 }


### PR DESCRIPTION
Adjusts tests to check for issue #1439.  

As far as I can tell, the problem is that the input key for AlgoSDK is called `assetMetadataHash`, which is similar but not quite the same as our key `metadataHash`, neither of which is the same as the key for this data on the result, which is `metadata`.

This PR so far adds a check that the resulting `metadata` field matches the given value for `metadataHash`.  Do we want to do anything more than that?