### PR TITLE
Add Algorand Wallet Fallback support for AlgoSigner and Exodus Web Wallet

### DIFF
--- a/examples/algo-wallet-demo/index.js
+++ b/examples/algo-wallet-demo/index.js
@@ -7,6 +7,7 @@ import { loadStdlib } from '@reach-sh/stdlib';
 import { ALGO_MyAlgoConnect as MyAlgoConnect } from '@reach-sh/stdlib';
 import { ALGO_WalletConnect as WalletConnect } from '@reach-sh/stdlib';
 import { ALGO_MakePeraConnect as MakePeraConnect } from '@reach-sh/stdlib';
+import { ALGO_MakeAlgoSignerConnect as MakeAlgoSignerConnect } from '@reach-sh/stdlib';
 import { PeraWalletConnect } from "@perawallet/connect";
 
 // This program is intended to be used on the Algorand TestNet.
@@ -101,6 +102,15 @@ class App extends React.Component {
     this.appendMsg('Using PeraConnect');
   }
 
+  async useAlgoSignerConnect() {
+    delete window.algorand;
+    stdlib = loadStdlib(process.env);
+    stdlib.setWalletFallback(reach.walletFallback({
+      // ...we use a different fallback here:
+      providerEnv, MyAlgoConnect: MakeAlgoSignerConnect(AlgoSigner,'TestNet') }));
+    this.appendMsg('Using AlgoSignerConnect');
+  }
+
   // Here we save and restore WalletConnect sessions
   async saveWalletConnect() {
     walletConnect_session = window.algorand.wc.wc;
@@ -150,6 +160,8 @@ class App extends React.Component {
           >Use WalletConnect</button>
           <button onClick={() => parent.usePeraConnect()}
           >Use PeraConnect</button>
+          <button onClick={() => parent.useAlgoSignerConnect()}
+          >Use AlgoSignerConnect</button>
           <button onClick={() => parent.attachWallet()}
           >Attach Wallet</button>
           <button onClick={() => parent.queryAccount()}

--- a/js/stdlib/ts/ALGO_MakeAlgoSignerConnect.ts
+++ b/js/stdlib/ts/ALGO_MakeAlgoSignerConnect.ts
@@ -1,4 +1,4 @@
-export default function ALGO_MakeAlgoSignerConnect( AlgoSigner: any, provider: string ) {
+export default function MakeAlgoSignerConnect( AlgoSigner: any, provider: string ) {
     return class AlgoSignerConnect {
         constructor() {}
 

--- a/js/stdlib/ts/ALGO_MakeAlgoSignerConnect.ts
+++ b/js/stdlib/ts/ALGO_MakeAlgoSignerConnect.ts
@@ -1,4 +1,4 @@
-export default function MakeAlgoSignerConnect( AlgoSigner: any, provider: string ) {
+export default function ALGO_MakeAlgoSignerConnect( AlgoSigner: any, provider: string ) {
     return class AlgoSignerConnect {
         constructor() {}
 

--- a/js/stdlib/ts/ALGO_MakeAlgoSignerConnect.ts
+++ b/js/stdlib/ts/ALGO_MakeAlgoSignerConnect.ts
@@ -1,0 +1,30 @@
+export default function ALGO_MakeAlgoSignerConnect( AlgoSigner: any, provider: string ) {
+    return class AlgoSignerConnect {
+        constructor() {}
+
+        async connect() {
+            await AlgoSigner.connect();
+            console.log(provider);
+            console.log(await AlgoSigner.accounts({ledger:provider}));
+            return await AlgoSigner.accounts({ledger:provider});
+        }
+
+        async signTransaction(txns: any) {
+            let ntxns: any = [];
+            txns.forEach((x: any) => {
+                ntxns.push({txn: x});
+            });
+            let stxns = await AlgoSigner.signTxn(ntxns);
+
+            const result: any = [];
+            stxns.forEach((t: any) => {
+                result.push({
+                    blob: Buffer.from(t.blob, 'base64'),
+                    txID: t.txID
+                });
+            });
+
+            return result;
+        }
+    }
+}

--- a/js/stdlib/ts/index.ts
+++ b/js/stdlib/ts/index.ts
@@ -12,6 +12,9 @@ export { ALGO_WalletConnect };
 import ALGO_MakePeraConnect from './ALGO_MakePeraConnect';
 export { ALGO_MakePeraConnect };
 
+import ALGO_MakeAlgoSignerConnect from './ALGO_MakeAlgoSignerConnect';
+export { ALGO_MakeAlgoSignerConnect };
+
 export * as test from './test';
 
 export * as util from './util';


### PR DESCRIPTION
<!--
Hey! Thanks so much!
-->

## Summary

<!-- Explain what you're trying to do in this pull request -->
This is a wallet fallback wrapper function to be used with the AlgoSigner global exposed by the AlgoSigner browser extension. It works similarly to MakePeraConnect and allows AlgoSigner to be used as a wallet fallback.

This was also created to add support for the Exodus Web Wallet, a newer browser extension wallet for Chrome/Brave. Exodus Web Wallet exposes an AlgoSigner object for compatibility with existing dApps, and only supports MainNet.

Some of the specifications for this PR were:
1. Add compatibility for both AlgoSigner and Exodus Web Wallet browser extensions
2. Work with existing wallerFallback function without modifying the core standard library
3. Require implementer to specify AlgoSigner global to help avoid potential future compatibility issues

The same functionality could be implemented with slight modifications to ALGO.ts, however I went this route to maintain consistency with existing walletFallback routes.

<!-- DESIGN: Does this code have some deeper design concept that motivates it that is hard to understand just by reading the code? -->
It works the same way as the MakePeraConnect function by exporting a function that returns a class that can be used with `stdlib.walletFallback()`. The first argument to the function is the AlgoSigner global exposed by the AlgoSigner browser extension, and the second argument is the network (TestNet/MainNet) which is optional and defaults to TestNet.

The object returned from this function is used in place of MyAlgoConnect as follows:

```
import { ALGO_MakeAlgoSignerConnect as MakeAlgoSignerConnect } from '@reach-sh/stdlib';
const wf = stdlib.walletFallback({providerEnv: 'TestNet', MyAlgoConnect: MakeAlgoSignerConnect(AlgoSigner)});
```

or

```
import { ALGO_MakeAlgoSignerConnect as MakeAlgoSignerConnect } from '@reach-sh/stdlib';
const wf = stdlib.walletFallback({providerEnv: 'MainNet', MyAlgoConnect: MakeAlgoSignerConnect(AlgoSigner,'MainNet')});
```

<!-- TESTING: How did you test this? Is there a new example? Do you have some test scenario you're using? -->
This PR includes an update to [examples/algo-wallet-demo](/reach-sh/reach-lang/tree/master/examples/algo-wallet-demo) which demonstrates the walletFallback `connect()` function. Transaction signing was tested using API transactions with my own contracts deployed on TestNet and MainNet, but may require further testing for other potential scenarios (deploy contract, transfer, etc)

<!-- DOCS: Should there be a documentation or changelog update with this code? -->
Yes -- in the walletFallback section of the Frontend category [here](https://docs.reach.sh/frontend/#p_33), and I imagine a blurb in the changelog