### PR TITLE
point-of-sale example

### DIFF
--- a/examples/point-of-sale/index.mjs
+++ b/examples/point-of-sale/index.mjs
@@ -12,20 +12,24 @@ const loyalTok = await stdlib.launchToken(accA, "Loyalty", "LYL", {supply: USERS
 
 console.log(`Welcome to the point-of-sale machine. This machine processes
 payments of varying amounts and rewards each purchase with a loyalty token.
-The pos will also process refunds, which return non-network tokens to the customer,
+The pos will also process refunds, which return network tokens to the customer,
 and loyalty tokens to the contract.\n`);
+
+const getPurchasePrice = (i) => {
+  const price = Math.floor(Math.random() * 100) + MIN_PRICE;
+  return (i == 0 ? 0 : price)
+};
 
 const startBuyers = async () => {
   const runBuyer = async (i) => {
     const acc = await stdlib.newTestAccount(stdlib.parseCurrency(100));
     const ctc = acc.contract(backend, ctcA.getInfo());
-    let cost = Math.floor(Math.random() * 100) + MIN_PRICE;
+    const cost = getPurchasePrice(i);
     await acc.tokenAccept(loyalTok.id);
-    cost = (i == 0 ? 0 : cost)// forcing a min cost error
     try{
       await ctc.apis.Buyer.purchase(cost);
       txns++;
-      console.log(`Purchase number: ${sold}`);
+      console.log(`Purchase number: ${txns}`);
     } catch (e) {
       console.log(`${e}`);
     }

--- a/examples/point-of-sale/index.mjs
+++ b/examples/point-of-sale/index.mjs
@@ -4,7 +4,6 @@ const stdlib = loadStdlib({REACH_NO_WARN: 'Y'});
 const MIN_PRICE = 10;
 const USERS = 10;
 const FAILS = 2;
-let txns = 0;
 
 const accA = await stdlib.newTestAccount(stdlib.parseCurrency(5000));
 const ctcA = accA.contract(backend);
@@ -27,8 +26,7 @@ const startBuyers = async () => {
     const cost = getPurchasePrice(i);
     await acc.tokenAccept(loyalTok.id);
     try{
-      await ctc.apis.Buyer.purchase(cost);
-      txns++;
+      const txns = await ctc.apis.Buyer.purchase(cost);
       console.log(`Purchase number: ${txns}`);
     } catch (e) {
       console.log(`${e}`);

--- a/examples/point-of-sale/index.mjs
+++ b/examples/point-of-sale/index.mjs
@@ -1,0 +1,55 @@
+import { loadStdlib } from "@reach-sh/stdlib";
+import * as backend from './build/index.main.mjs';
+const stdlib = loadStdlib({REACH_NO_WARN: 'Y'});
+const MIN_PRICE = 10;
+const USERS = 10;
+const FAILS = 2;
+let txns = 0;
+
+const accA = await stdlib.newTestAccount(stdlib.parseCurrency(5000));
+const ctcA = accA.contract(backend);
+const loyalTok = await stdlib.launchToken(accA, "Loyalty", "LYL", {supply: USERS});
+
+console.log(`Welcome to the point-of-sale machine. This machine processes
+payments of varying amounts and rewards each purchase with a loyalty token.
+The pos will also process refunds, which return non-network tokens to the customer,
+and loyalty tokens to the contract.\n`);
+
+const startBuyers = async () => {
+  const runBuyer = async (i) => {
+    const acc = await stdlib.newTestAccount(stdlib.parseCurrency(100));
+    const ctc = acc.contract(backend, ctcA.getInfo());
+    let cost = Math.floor(Math.random() * 100) + MIN_PRICE;
+    await acc.tokenAccept(loyalTok.id);
+    cost = (i == 0 ? 0 : cost)// forcing a min cost error
+    try{
+      await ctc.apis.Buyer.purchase(cost);
+      txns++;
+      console.log(`Purchase number: ${sold}`);
+    } catch (e) {
+      console.log(`${e}`);
+    }
+    if(i == 1){// 1 wants a refund
+      const amt = await ctc.apis.Buyer.refund();
+      console.log(`Customer ${i} is getting a refund of ${amt}`);
+    }
+  }// end of runBuyer
+  // 1 refund, 1 amount too low fail
+  for(let i = 0; i < USERS + FAILS; i++){
+    await runBuyer(i);
+  }
+}// end of startBuyers
+
+await ctcA.p.Admin({
+  params: {
+    tok: loyalTok.id,
+    min: MIN_PRICE,
+    supply: USERS,
+  },
+  launched: async (contract) => {
+    console.log(`Ready at contract: ${contract}\n`);
+    await startBuyers();
+  },
+});
+console.log('Exiting...');
+

--- a/examples/point-of-sale/index.rsh
+++ b/examples/point-of-sale/index.rsh
@@ -1,0 +1,58 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const A = Participant('Admin', {
+    params: Object({
+      min: UInt,
+      tok: Token,
+      supply: UInt,
+    }),
+    launched: Fun([Contract], Null),
+  });
+  const B = API('Buyer', {
+    purchase: Fun([UInt], Null),
+    refund: Fun([], UInt),
+  });
+  init();
+ 
+  A.only(() => {
+   const {min, tok, supply} = declassify(interact.params);
+  });
+  A.publish(min, tok, supply);
+  commit();
+  A.pay([[supply, tok]])
+  A.interact.launched(getContract());
+
+  const pMap = new Map(UInt);
+  const [tokensSold, total] = parallelReduce([0, 0])
+    .paySpec([tok])
+    .invariant(pMap.sum() == total, "tracking total wrong")
+    .invariant(balance() == total, "network token balance wrong")
+    .invariant(balance(tok) == supply - tokensSold, "non-network token balance wrong")
+    .while(tokensSold < supply)
+    .api_(B.purchase, (amount) => {
+      check(tokensSold != supply, "sorry, out of tickets");
+      check(isNone(pMap[this]), "sorry, you are already in this list");
+      check(amount >= min, "sorry, amount too low");
+      return[[amount, [0, tok]], (ret) => {
+        pMap[this] = amount;
+        transfer(1, tok).to(this);
+        ret(null);
+        return [tokensSold + 1, total + amount];
+      }];
+    })
+    .api_(B.refund, () => {
+      check(isSome(pMap[this]), "sorry, you are not in the list");
+      return[[0, [1, tok]], (ret) => {
+        const paid = fromSome(pMap[this], 0);
+        transfer(paid).to(this);
+        ret(paid);
+        delete pMap[this];
+        return[tokensSold - 1, total - paid]
+      }];
+    });
+  transfer(total).to(A);
+  commit();
+  exit();
+});
+

--- a/examples/point-of-sale/index.rsh
+++ b/examples/point-of-sale/index.rsh
@@ -30,15 +30,15 @@ export const main = Reach.App(() => {
     .invariant(balance() == total, "network token balance wrong")
     .invariant(balance(tok) == supply - tokensSold, "non-network token balance wrong")
     .while(tokensSold < supply)
-    .api_(B.purchase, (amount) => {
+    .api_(B.purchase, (purchasePrice) => {
       check(tokensSold != supply, "sorry, out of tickets");
       check(isNone(pMap[this]), "sorry, you are already in this list");
-      check(amount >= min, "sorry, amount too low");
-      return[[amount, [0, tok]], (ret) => {
-        pMap[this] = amount;
+      check(purchasePrice >= min, "sorry, amount too low");
+      return[[purchasePrice, [0, tok]], (ret) => {
+        pMap[this] = purchasePrice;
         transfer(1, tok).to(this);
         ret(null);
-        return [tokensSold + 1, total + amount];
+        return [tokensSold + 1, total + purchasePrice];
       }];
     })
     .api_(B.refund, () => {

--- a/examples/point-of-sale/index.rsh
+++ b/examples/point-of-sale/index.rsh
@@ -10,7 +10,7 @@ export const main = Reach.App(() => {
     launched: Fun([Contract], Null),
   });
   const B = API('Buyer', {
-    purchase: Fun([UInt], Null),
+    purchase: Fun([UInt], UInt),
     refund: Fun([], UInt),
   });
   init();
@@ -36,9 +36,10 @@ export const main = Reach.App(() => {
       check(purchasePrice >= min, "sorry, amount too low");
       return[[purchasePrice, [0, tok]], (ret) => {
         pMap[this] = purchasePrice;
+        const sold = tokensSold + 1;
         transfer(1, tok).to(this);
-        ret(null);
-        return [tokensSold + 1, total + purchasePrice];
+        ret(sold);
+        return [sold, total + purchasePrice];
       }];
     })
     .api_(B.refund, () => {

--- a/examples/point-of-sale/index.txt
+++ b/examples/point-of-sale/index.txt
@@ -1,0 +1,7 @@
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 78 theorems; No failures!
+WARNING: Compiler instructed to emit for Algorand, but the conservative analysis found these potential problems:
+ * This program was compiled with trustworthy maps, but maps are not trustworthy on Algorand, because they are represented with local state. A user can delete their local state at any time, by sending a ClearState transaction. The only way to use local state properly on Algorand is to ensure that a user doing this can only 'hurt' themselves and not the entire system.


### PR DESCRIPTION
This is a basic point-of-sale DApp with `purchase` and `refund` functions in a `parallelReduce`. This examples covers: tracking a supply of non-network tokens, taking in varying amount of network tokens, more advanced invariants/checks, refunding based on varied purchase amount, `paySpec`
