### PR TITLE
Fix `IsDynamic` and Counter

### DIFF
--- a/hs/src/Reach/AST/SL.hs
+++ b/hs/src/Reach/AST/SL.hs
@@ -310,7 +310,7 @@ instance IsDynamic SLForm where
     SLForm_apiCall -> False
     SLForm_apiCall_partial {} -> True
     SLForm_wait -> False
-    SLForm_setApiDetails -> True
+    SLForm_setApiDetails -> False
 
 instance IsDynamic SLVal where
   isDynamic = \case

--- a/hs/t/y/child_reach_app.txt
+++ b/hs/t/y/child_reach_app.txt
@@ -4,13 +4,13 @@ Verifying for generic connector
   Verifying when ALL participants are honest
   Verifying when NO participants are honest
 Checked 3 theorems; No failures!
-Compiling internal contract #30 for `main`...
+Compiling internal contract #96 for `main`...
 Verifying knowledge assertions
 Verifying for generic connector
   Verifying when ALL participants are honest
   Verifying when NO participants are honest
 Checked 6 theorems; No failures!
-Compiling internal contract #32 for `main`...
+Compiling internal contract #151 for `main`...
 Verifying knowledge assertions
 Verifying for generic connector
   Verifying when ALL participants are honest


### PR DESCRIPTION
Found issues with spawning child ctc's because we use the same counter across apps for unique names