### PR TITLE
docs: fix

### DIFF
--- a/docs/src/quickstart/index.md
+++ b/docs/src/quickstart/index.md
@@ -252,7 +252,7 @@ $ curl https://docs.reach.sh/reach -o reach ; chmod +x reach
 
 Reach is successfully downloaded if the following command returns a version number:
 
-```
+``` cmd
 $ ./reach version
 ```
 


### PR DESCRIPTION
Small fix to command on docs: quickstart

copying the code before carried over the `$`
