### PR TITLE
DEVX-681: examples/pr-counter: api vs api_, simple pr

### DIFF
--- a/examples/parallelReduce-api-counter/index.mjs
+++ b/examples/parallelReduce-api-counter/index.mjs
@@ -1,0 +1,41 @@
+import {loadStdlib} from '@reach-sh/stdlib';
+import * as backend from './build/index.main.mjs';
+const stdlib = loadStdlib(process.env);
+
+const startingBalance = stdlib.parseCurrency(100);
+
+const accs = await stdlib.newTestAccounts(4, startingBalance);
+const [accA, acc1, acc2, acc3] = accs;
+const ctcA = accA.contract(backend);
+
+const startUp = async () => {
+  const flag = "startup incomplete";
+  try{
+    await ctcA.p.Admin({
+      max: 4,
+      launched: (c) => {
+        throw flag;
+      },
+    });
+  } catch (e) {
+    if(e !== flag) throw e;
+  };
+};
+
+const countMe = async (addr) => {
+  const num = await ctc(addr).a.countUp();
+  console.log(`Your number is ${num}`);
+};
+
+const ctcinfo = ctcA.getInfo();
+const ctc = (acc) => acc.contract(backend, ctcinfo);
+
+await startUp();
+console.log(`Startup successful`);
+
+await countMe(acc1);
+await countMe(acc2);
+await countMe(acc3);
+
+console.log(`Finished testing.`);
+

--- a/examples/parallelReduce-api-counter/index.mjs
+++ b/examples/parallelReduce-api-counter/index.mjs
@@ -10,7 +10,7 @@ const ctcA = accA.contract(backend);
 
 const startUp = async () => {
   const flag = "startup incomplete";
-  try{
+  try {
     await ctcA.p.Admin({
       max: 4,
       launched: (c) => {
@@ -18,7 +18,7 @@ const startUp = async () => {
       },
     });
   } catch (e) {
-    if(e !== flag) throw e;
+    if (e !== flag) throw e;
   };
 };
 

--- a/examples/parallelReduce-api-counter/index.rsh
+++ b/examples/parallelReduce-api-counter/index.rsh
@@ -1,0 +1,31 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const A = Participant('Admin', {
+    max: UInt,
+    launched: Fun([Contract], Null),
+  });
+  const B = API({
+    countUp: Fun([], UInt),
+  });
+  init();
+  A.only(() => {
+    const max = declassify(interact.max);
+  });
+  A.publish(max);
+  A.interact.launched(getContract());
+
+  const [count] = parallelReduce([0])
+    .invariant(balance() == 0, "network token balance wrong")
+    .while(count < max)
+    .api(B.countUp, 
+      () => {},
+      () => 0,
+      (ret) => {
+        ret(count)
+        return[count + 1];
+      })
+  commit();
+  exit();
+});
+

--- a/examples/parallelReduce-api-counter/index.rsh
+++ b/examples/parallelReduce-api-counter/index.rsh
@@ -15,7 +15,7 @@ export const main = Reach.App(() => {
   A.publish(max);
   A.interact.launched(getContract());
 
-  const [count] = parallelReduce([0])
+  const count = parallelReduce(0)
     .invariant(balance() == 0, "network token balance wrong")
     .while(count < max)
     .api(B.countUp, 
@@ -23,7 +23,7 @@ export const main = Reach.App(() => {
       () => 0,
       (ret) => {
         ret(count)
-        return[count + 1];
+        return count + 1;
       })
   commit();
   exit();

--- a/examples/parallelReduce-api-counter/index.txt
+++ b/examples/parallelReduce-api-counter/index.txt
@@ -1,0 +1,6 @@
+Compiling `main`...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 10 theorems; No failures!

--- a/examples/parallelReduce-api_-counter/index.mjs
+++ b/examples/parallelReduce-api_-counter/index.mjs
@@ -1,0 +1,41 @@
+import {loadStdlib} from '@reach-sh/stdlib';
+import * as backend from './build/index.main.mjs';
+const stdlib = loadStdlib(process.env);
+
+const startingBalance = stdlib.parseCurrency(100);
+
+const accs = await stdlib.newTestAccounts(4, startingBalance);
+const [accA, acc1, acc2, acc3] = accs;
+const ctcA = accA.contract(backend);
+
+const startUp = async () => {
+  const flag = "startup incomplete";
+  try{
+    await ctcA.p.Admin({
+      max: 4,
+      launched: (c) => {
+        throw flag;
+      },
+    });
+  } catch (e) {
+    if(e !== flag) throw e;
+  };
+};
+
+const countMe = async (addr) => {
+  const num = await ctc(addr).a.countUp();
+  console.log(`Your number is ${num}`);
+};
+
+const ctcinfo = ctcA.getInfo();
+const ctc = (acc) => acc.contract(backend, ctcinfo);
+
+await startUp();
+console.log(`Startup successful`);
+
+await countMe(acc1);
+await countMe(acc2);
+await countMe(acc3);
+
+console.log(`Finished testing.`);
+

--- a/examples/parallelReduce-api_-counter/index.mjs
+++ b/examples/parallelReduce-api_-counter/index.mjs
@@ -10,7 +10,7 @@ const ctcA = accA.contract(backend);
 
 const startUp = async () => {
   const flag = "startup incomplete";
-  try{
+  try {
     await ctcA.p.Admin({
       max: 4,
       launched: (c) => {
@@ -18,7 +18,7 @@ const startUp = async () => {
       },
     });
   } catch (e) {
-    if(e !== flag) throw e;
+    if (e !== flag) throw e;
   };
 };
 

--- a/examples/parallelReduce-api_-counter/index.rsh
+++ b/examples/parallelReduce-api_-counter/index.rsh
@@ -1,0 +1,30 @@
+'reach 0.1';
+
+export const main = Reach.App(() => {
+  const A = Participant('Admin', {
+    max: UInt,
+    launched: Fun([Contract], Null),
+  });
+  const B = API({
+    countUp: Fun([], UInt),
+  });
+  init();
+  A.only(() => {
+    const max = declassify(interact.max);
+  });
+  A.publish(max);
+  A.interact.launched(getContract());
+
+  const [count] = parallelReduce([0])
+    .invariant(balance() == 0, "network token balance wrong")
+    .while(count < max)
+    .api_(B.countUp, () => {
+      return[0, (ret) => {
+        ret(count);
+        return [count + 1];
+      }];
+    })
+  commit();
+  exit();
+});
+

--- a/examples/parallelReduce-api_-counter/index.rsh
+++ b/examples/parallelReduce-api_-counter/index.rsh
@@ -15,13 +15,13 @@ export const main = Reach.App(() => {
   A.publish(max);
   A.interact.launched(getContract());
 
-  const [count] = parallelReduce([0])
+  const count = parallelReduce(0)
     .invariant(balance() == 0, "network token balance wrong")
     .while(count < max)
     .api_(B.countUp, () => {
-      return[0, (ret) => {
+      return [0, (ret) => {
         ret(count);
-        return [count + 1];
+        return count + 1;
       }];
     })
   commit();

--- a/examples/parallelReduce-api_-counter/index.txt
+++ b/examples/parallelReduce-api_-counter/index.txt
@@ -1,0 +1,6 @@
+Compiling `main`...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 10 theorems; No failures!


### PR DESCRIPTION
These two programs are part of a guide I'm working on for the guides page. The purpose is to implement the most simple parallelReduce possible, while also highlighting the difference in syntax between `api` vs `api_` -- the guide will go into more detail on specifics

I originally had this all in one program with one of the api implementations commented out, but for the guide it seems better to point to code that is not commented out. Both frontend files are the same.

The long folder names were a commitment, but hopefully its the first place people look for a simple parallelReduce.

Let me know if you would like to see this structured differently
