### PR TITLE
add nextUpToTime to event stream interface

### DIFF
--- a/docs/src/changelog/index.md
+++ b/docs/src/changelog/index.md
@@ -9,6 +9,8 @@ Versions and changes-within-versions are listed in reverse-chronological order: 
 
 @{rcNext("0.1.13-rc.2")}
 
++ 2023/02/17: Added `{!js} nextUpToTime` method for event stream objects.
+
 @{rcHead("0.1.13-rc.1")}
 
 + 2023/01/18: Added `{!rsh} Bytes.concat` to ALGO connector.

--- a/docs/src/frontend/index.md
+++ b/docs/src/frontend/index.md
@@ -1169,11 +1169,12 @@ An EventStream supports the following operations for a given `{!rsh} Event`:
 @{ref("js", "EventStream")}
 ```js
 EventStream<T> : {
-  next    : () => Promise<Event<T>>,
-  seek    : (t: Time) => void,
-  seekNow : () => Promise<void>,
-  lastTime: () => Promise<Time>,
-  monitor : ((Event<T>) => void) => Promise<void>,
+  next         : () => Promise<Event<T>>,
+  nextUpToTime : (t: Time) => Promise<undefined | Event<T>>,
+  seek         : (t: Time) => void,
+  seekNow      : () => Promise<void>,
+  lastTime     : () => Promise<Time>,
+  monitor      : ((Event<T>) => void) => Promise<void>,
 }
 ```
 
@@ -1188,6 +1189,9 @@ An `{!js} Event` is instantiated with it's corresponding type declared in Reach.
 
  `{!js} next` will wait for the next `{!rsh} Event` to occur, returning the time the event occurred
 and the arguments to the event.
+
+ `{!js} nextUpToTime` is the same as `{!js} next`, except it will only return events up to the given time `t` (inclusive).
+ If time `t` has passed and no more events within the time frame are available, it will stop waiting and return `undefined`.
 
  `{!js} seek` will set the internal time of the EventStream to the given argument.
 The EventStream will use this time as the minimum bound when searching for `{!rsh} Event`s.

--- a/examples/nextUpToTime/index.mjs
+++ b/examples/nextUpToTime/index.mjs
@@ -1,0 +1,62 @@
+import { loadStdlib } from '@reach-sh/stdlib';
+import * as backend from './build/index.main.mjs';
+const stdlib = loadStdlib(process.env);
+const assert = stdlib.assert;
+
+const assertEq = (a, b, context = 'assertEq') => {
+  if (a === b) return;
+  try {
+    const res1BN = bigNumberify(a);
+    const res2BN = bigNumberify(b);
+    if (res1BN.eq(res2BN)) return;
+  } catch {}
+  try {
+    const stripNulls = (s) => s.replace(/\0*$/g, "");
+    if (stripNulls(`${a}`) === stripNulls(`${b}`)) return;
+  } catch {}
+  try {
+    if (JSON.stringify(a) === JSON.stringify(b)) return;
+  } catch {}
+  try {
+    if (parseInt(a) == parseInt(b)) return;
+  } catch {}
+  assert(false, `${context}: ${a} == ${b}`);
+};
+
+
+const acc = await stdlib.newTestAccount(stdlib.parseCurrency(100));
+
+const ctc = acc.contract(backend);
+await stdlib.withDisconnect(() => ctc.participants.D({
+  ready: () => {stdlib.disconnect()}
+}));
+
+await ctc.a.poke();
+const t1 = await stdlib.getNetworkTime();
+await stdlib.wait(1);
+
+assertEq((await ctc.e.e.nextUpToTime(t1)).what, 0);
+assertEq((await ctc.e.e.nextUpToTime(t1)).what, 1);
+assertEq((await ctc.e.e.nextUpToTime(t1)), undefined);
+
+await ctc.a.poke();
+await stdlib.wait(1);
+const t2 = await stdlib.getNetworkTime();
+await ctc.a.poke();
+const t3 = await stdlib.getNetworkTime();
+await stdlib.wait(1);
+await ctc.a.poke();
+const t4 = await stdlib.getNetworkTime();
+await stdlib.wait(1);
+
+assertEq((await ctc.e.e.nextUpToTime(t3)).what, 2);
+assertEq((await ctc.e.e.nextUpToTime(t3)).what, 3);
+assertEq((await ctc.e.e.nextUpToTime(t3)).what, 4);
+assertEq((await ctc.e.e.nextUpToTime(t3)).what, 5);
+assertEq((await ctc.e.e.nextUpToTime(t3)), undefined);
+
+assertEq((await ctc.e.e.nextUpToTime(t4)).what, 6);
+assertEq((await ctc.e.e.nextUpToTime(t4)).what, 7);
+assertEq((await ctc.e.e.nextUpToTime(t4)), undefined);
+
+console.log("Done testing nextUpToTime.");

--- a/examples/nextUpToTime/index.rsh
+++ b/examples/nextUpToTime/index.rsh
@@ -1,0 +1,31 @@
+'reach 0.1';
+'use strict';
+
+export const main = Reach.App(() => {
+  const D = Participant('D', {
+    ready: Fun([], Null),
+  });
+  const E = Events({
+    e: [UInt],
+  });
+  const A = API({
+    poke: Fun([], Null),
+  })
+  init();
+
+  D.publish();
+  D.interact.ready();
+
+  const i = parallelReduce(0)
+        .invariant(balance() === 0)
+        .while(true)
+        .api_(A.poke, () => {
+          return [0, (k) => {
+            E.e(i);
+            E.e(i + 1);
+            k(null);
+            return i + 2;
+          },];
+        })
+  commit();
+});

--- a/examples/nextUpToTime/index.txt
+++ b/examples/nextUpToTime/index.txt
@@ -1,0 +1,6 @@
+Compiling `main`...
+Verifying knowledge assertions
+Verifying for generic connector
+  Verifying when ALL participants are honest
+  Verifying when NO participants are honest
+Checked 10 theorems; No failures!

--- a/js/stdlib/ts/shared_impl.ts
+++ b/js/stdlib/ts/shared_impl.ts
@@ -1145,7 +1145,7 @@ export const makeEventStream = <EQInitArgs, RawTxn, ProcTxn, Log>(args:IMESArgs<
     let parsedLog = undefined;
     while ( parsedLog === undefined ) {
       while ( logs.length === 0 ) {
-        const timeout = maxTime ? (async (t: BigNumber) => t > maxTime) : neverTrue;
+        const timeout = maxTime ? (async (t: BigNumber) => t.gt(maxTime)) : neverTrue;
         const r = await eq.peq(dhead, timeout);
         if ( r.timeout || await timeout(getTxnTime(r.txn))) {
           debug(dhead, "timeout", {maxTime, r})


### PR DESCRIPTION
As discussed previously, this allows for users to get all events up to a particular time and batch them for purposes like atomic database transactions that keep the database consistently in sync with a particular block time.  Because typical contracts with events may emit zero to many events per block, the `next` API does not give users a clean way to see if there are more events for a block time (including the latest) without waiting potentially indefinitely for a future event that may never come.