### PR TITLE
Add `exports` field to package.json in stdlib

### DIFF
--- a/docs/src/frontend/index.md
+++ b/docs/src/frontend/index.md
@@ -32,6 +32,13 @@ $ npm install @reach-sh/stdlib
 
 You only need to install the package directly if you are running your frontend without `reach` or using a tool like [webpack](https://webpack.js.org/) for deployment.
 
+If you want to install the standard library for a browser application or library and you are using a bundler **without** _Node polyfills_ (e.g. [Webpack 5](https://webpack.js.org/), [Vite](https://vitejs.dev/)), you can import the library by writing:
+
+```js
+import { loadStdlib } from '@reach-sh/stdlib/browser';
+const stdlib = loadStdlib();
+```
+
 # {#ref-frontends-js-types} Types
 
 Whenever you are interacting with the Reach standard library, you need to remember the JavaScript representation of each of the Reach types:

--- a/js/stdlib/package.mo.json
+++ b/js/stdlib/package.mo.json
@@ -11,6 +11,17 @@
     "*.mjs",
     "*.d.ts"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./types/index.d.ts"
+    },
+    "./browser": {
+      "import": "./dist/browser/reachsdk.min.js",
+      "types": "./dist/browser/index.d.ts"
+    }
+  },
   "devDependencies": {
     "@types/await-timeout": "^0.3.1",
     "@types/express": "^4.17.1",


### PR DESCRIPTION
By adding a separate entrypoint `/browser` for the library, we make it much easier for the users to import the library in a browser, like so: `@reach-sh/stdlib/browser`.

<!--
Hey! Thanks so much!
-->

## Summary
This would address #152, #1316 and #1560, by using the library like so: `import { ... } from "@reach-sh/stdlib/browser`. In the current implementation there is the field "browser" that points to the right entrypoint, but that is not usually supported by default in most bundlers. Moreover, it does not work at all if used with Typescript, since the right types are not exposed.

Probably, documentation will need to be updated, I am also willing to do that if pointed in the right direction. Thank you  for taking the time to review this!