### PR TITLE
Fix isqrt function

### DIFF
--- a/hs/src/Reach/Util.hs
+++ b/hs/src/Reach/Util.hs
@@ -165,11 +165,13 @@ maybeAt n (_:xs) = maybeAt (n-1) xs
 
 -- Source https://en.wikipedia.org/wiki/Integer_square_root#Using_only_integer_division
 isqrt :: Integral a => a -> a
+isqrt 0 = 0
+isqrt 1 = 1
 isqrt n = go n2 (iter n2)
   where
     n2 = n `div` 2
     iter x = (x + (n `div` x)) `div` 2
-    go x0 x1 = if x0 == x1 then x0 else go x1 (iter x1)
+    go x0 x1 = if x0 <= x1 then x0 else go x1 (iter x1)
 
 kmToM :: KM.KeyMap a -> M.Map T.Text a
 kmToM = M.fromList . map (\(k,v) -> (K.toText k, v)) . KM.toList


### PR DESCRIPTION
<!--
Hey!
Thanks so much!
-->

## Summary

The `isqrt` function seems to be broken. It throws an exception for n = 0 and n = 1 and just hangs for n = 3. I changed it according with the Wikipedia implementation
<!-- Explain what you're trying to do in this pull request -->

<!-- DESIGN: Does this code have some deeper design concept that motivates it that is hard to understand just by reading the code? -->

<!-- TESTING: How did you test this? Is there a new example? Do you have some test scenario you're using? -->

<!-- DOCS: Should there be a documentation or changelog update with this code? -->
