### PR TITLE
fix ALGO_MakePeraConnect

### DIFF
--- a/js/stdlib/ts/ALGO_MakePeraConnect.ts
+++ b/js/stdlib/ts/ALGO_MakePeraConnect.ts
@@ -1,3 +1,4 @@
+import { decodeUnsignedTransaction } from "algosdk";
 
 export default function ALGO_MakePeraConnect( PeraWalletConnect:any ) {
   return class PeraConnect {
@@ -36,8 +37,18 @@ export default function ALGO_MakePeraConnect( PeraWalletConnect:any ) {
 
     async signTxns(txns:string[]): Promise<string[]> {
       await this.ensureSession();
-      return this.pc.signTransaction(
-        txns.map((txn) => ({txn}))
+      const rawSignedTxns = await this.pc.signTransaction([
+        txns.map((value:string) => {
+          const decodedUnsignedTxn = decodeUnsignedTransaction(
+            Buffer.from(value, "base64")
+          );
+          return {
+            txn: decodedUnsignedTxn,
+          };
+        }),
+      ]);
+      return rawSignedTxns.map(
+        (value:string) => Buffer.from(value).toString("base64")
       );
     }
   }


### PR DESCRIPTION
<!--
Hey! Thanks so much!
-->

## Summary

Unable to sign transaction with Pera Wallet using ALGO_MakePeraWallet for Pera Wallet Web and Pera Wallet Mobile.

<!-- Explain what you're trying to do in this pull request -->

Fix `"TypeError: e.map is not a function"` error issue while trying to sign transaction with Pera Wallet. Until recently, I've just use ALGO_MakeWalletConnect instead of ALGO_MakePeraWallet. However, this does not work in the Pera Wallet Web. As of recent, Pera Wallet has to types Pera Wallet Mobile and Pera Wallet Web. 

After applying the fix in this PR, it is possible to sign transaction with Pera Wallet Web and Pera Wallet Mobile, utilizing the ALGO_MakePeraWallet function.

<!-- DESIGN: Does this code have some deeper design concept that motivates it that is hard to understand just by reading the code? -->

<!-- TESTING: How did you test this? Is there a new example? Do you have some test scenario you're using? -->

Tested in front end application as override to ALGO_MakePeraWallet 

https://github.com/temptemp3/arc-200/blob/main/app/app-sandbox/src/utils/reach.js#L12

<!-- DOCS: Should there be a documentation or changelog update with this code? -->

Linked issues and discussions

* https://github.com/temptemp3/arc-200/issues/29
* https://github.com/reach-sh/reach-lang/issues/1548
* https://github.com/temptemp3/arc-200/issues/29